### PR TITLE
feat: [v1.23 P1] error classification & query-only fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+- query-only 模式不再對 `SHOW`/`DESCRIBE`/`EXPLAIN`/`ANALYZE SELECT` 注入 `LIMIT`,避免 server 拒絕(v1.23 P1, issue #1)
+- MariaDB `ANALYZE SELECT` 與 PostgreSQL `EXPLAIN (ANALYZE, BUFFERS) SELECT` 視為 read-only,query-only 模式可執行(v1.23 P1, issue #2)
+- driver 在 execute 階段丟出的 SQL 錯誤(語法錯、table 不存在、column 不存在)不再被誤包成 `Connection failed`;訊息附 actionable hints 與 fuzzy table 候選(v1.23 P1, issue #3)
+- `dbcli schema --refresh` 首次 bootstrap 不再要求 `--force`(v1.23 P1, issue #7)
+- query-only 模式拒絕未知 SQL 時的訊息明確化:加入當前 permission level 與 issue 連結
+
+### Changed
+
+- `ConnectionError.code` union 新增 `SQL_SYNTAX_ERROR` / `TABLE_NOT_FOUND` / `COLUMN_NOT_FOUND`(向後相容;既有 consumer 只匹配 `UNKNOWN` 仍 fallback)
+
+
 ## [1.22.0] - 2026-05-21 - Elasticsearch Shell/Export + Redis Masking
 
 ### Added

--- a/docs/superpowers/plans/2026-05-28-v1.23-p1-error-classification.md
+++ b/docs/superpowers/plans/2026-05-28-v1.23-p1-error-classification.md
@@ -1,0 +1,1216 @@
+# v1.23 P1 — Error Classification & Query-Only 修正 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修正 query-only mode 對 `SHOW`/`DESCRIBE`/`EXPLAIN`/`ANALYZE SELECT` 的過嚴行為，並把 driver 在 execute 階段丟出的 SQL 錯誤（語法錯、table 不存在、column 不存在）從 generic `Connection failed` 分流成正確分類，附 actionable hints（含 fuzzy match 候選）。同時讓 `schema --refresh` 首次 bootstrap 不再強制 `--force`。
+
+**Architecture:** 改動聚焦在三個檔案：(1) `src/core/permission-guard.ts` — `classifyStatement` 入口加 MariaDB `ANALYZE SELECT` 偵測；UNKNOWN 訊息改善。(2) `src/core/query-executor.ts` — auto-LIMIT 條件加 statement type 白名單，只對 `SELECT` 注入。(3) `src/adapters/error-mapper.ts` — 在既有 AUTH_FAILED 分支之前插入新分類器（依 mysql2 `code`/`errno` 與 pg SQLSTATE），同時擴展 `ConnectionError` code union。Schema 命令在捕捉到 `TABLE_NOT_FOUND` 時呼叫既有 `suggestTableName()` 補 fuzzy 候選。`schema --refresh` 加 first-time bootstrap 分流。
+
+**Tech Stack:** TypeScript、Bun、`bun:test`、mysql2、pg。
+
+**Spec:** `docs/superpowers/specs/2026-05-28-dbcli-feedback-fixes-design.md`（P1 section）。
+
+**Branch:** `feature/v1.23-p1-error-classification`
+
+---
+
+### Task 1: 擴展 `ConnectionError` code union 與新分類常數
+
+新增 3 個錯誤分類碼，後續 task 會用到。先做型別變更，避免後面實作時 type-check 卡住。
+
+**Files:**
+- Modify: `src/adapters/types.ts`（`ConnectionError` 類別 code 欄位的 union）
+- Test: `tests/unit/adapters/error-mapper.test.ts`（加 type-only smoke test）
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `tests/unit/adapters/error-mapper.test.ts` 末尾追加：
+
+```typescript
+import { test, expect } from 'bun:test'
+import { ConnectionError } from 'src/adapters/error-mapper'
+
+test('ConnectionError accepts SQL_SYNTAX_ERROR code', () => {
+  const err = new ConnectionError('SQL_SYNTAX_ERROR', 'msg', ['hint'])
+  expect(err.code).toBe('SQL_SYNTAX_ERROR')
+})
+
+test('ConnectionError accepts TABLE_NOT_FOUND code', () => {
+  const err = new ConnectionError('TABLE_NOT_FOUND', 'msg', ['hint'])
+  expect(err.code).toBe('TABLE_NOT_FOUND')
+})
+
+test('ConnectionError accepts COLUMN_NOT_FOUND code', () => {
+  const err = new ConnectionError('COLUMN_NOT_FOUND', 'msg', ['hint'])
+  expect(err.code).toBe('COLUMN_NOT_FOUND')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts`
+Expected: type error — 三個新 code 不在 union 內。
+
+- [ ] **Step 3: 擴展 union**
+
+在 `src/adapters/types.ts` 中找到 `ConnectionError` 類別，把 `code` 欄位 union 改為：
+
+```typescript
+public code:
+  | 'ECONNREFUSED'
+  | 'ETIMEDOUT'
+  | 'AUTH_FAILED'
+  | 'ENOTFOUND'
+  | 'SQL_SYNTAX_ERROR'
+  | 'TABLE_NOT_FOUND'
+  | 'COLUMN_NOT_FOUND'
+  | 'UNKNOWN',
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts`
+Expected: PASS（含既有測試）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adapters/types.ts tests/unit/adapters/error-mapper.test.ts
+git commit -m "feat: [adapters] extend ConnectionError union for SQL error categories"
+```
+
+---
+
+### Task 2: Issue #2 — `classifyStatement` 把 MariaDB `ANALYZE SELECT` 視為 EXPLAIN
+
+**Files:**
+- Modify: `src/core/permission-guard.ts:342`（`classifyStatement` 函式入口）
+- Test: `tests/unit/core/permission-guard.test.ts`
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `tests/unit/core/permission-guard.test.ts` 中與 `EXPLAIN SELECT` 測試同區段加入：
+
+```typescript
+test('classifyStatement: MariaDB ANALYZE SELECT is treated as EXPLAIN', () => {
+  const result = classifyStatement(
+    "ANALYZE SELECT COUNT(*) FROM betting_logs WHERE settled_at >= '2026-03-01'"
+  )
+  expect(result.type).toBe('EXPLAIN')
+  expect(result.isDangerous).toBe(false)
+  expect(result.confidence).toBe('HIGH')
+})
+
+test('classifyStatement: PostgreSQL EXPLAIN (ANALYZE, BUFFERS) SELECT', () => {
+  const result = classifyStatement(
+    'EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM users WHERE id = 1'
+  )
+  expect(result.type).toBe('EXPLAIN')
+  expect(result.isDangerous).toBe(false)
+})
+
+test('checkPermission: ANALYZE SELECT allowed in query-only', () => {
+  const result = checkPermission(
+    'ANALYZE SELECT * FROM users',
+    'query-only'
+  )
+  expect(result.allowed).toBe(true)
+  expect(result.classification.type).toBe('EXPLAIN')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/core/permission-guard.test.ts`
+Expected: `ANALYZE SELECT` 測試失敗（type 是 UNKNOWN 而非 EXPLAIN）。
+
+- [ ] **Step 3: 加入 ANALYZE SELECT 偵測**
+
+在 `src/core/permission-guard.ts` 找到 `export function classifyStatement(sql: string): StatementClassification {` 之後，在 `const composite = detectCompositePatterns(upper)` 行之前，插入：
+
+```typescript
+// MariaDB/MySQL: 'ANALYZE SELECT ...' is a read-only EXPLAIN variant.
+// PostgreSQL uses 'EXPLAIN (ANALYZE ...) SELECT ...' which is handled by
+// the regular EXPLAIN keyword classifier; this branch only handles the
+// MariaDB form where ANALYZE is the leading keyword.
+if (/^\s*ANALYZE\s+SELECT\b/i.test(stripped)) {
+  return {
+    type: 'EXPLAIN',
+    isDangerous: false,
+    keywords: extractAllKeywords(stripped),
+    isComposite: false,
+    confidence: 'HIGH',
+  }
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/core/permission-guard.test.ts`
+Expected: PASS（含既有與新測試）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/permission-guard.ts tests/unit/core/permission-guard.test.ts
+git commit -m "fix: [permission-guard] classify ANALYZE SELECT as EXPLAIN (MariaDB)"
+```
+
+---
+
+### Task 3: Issue #2 — UNKNOWN 拒絕訊息明確化
+
+**Files:**
+- Modify: `src/core/permission-guard.ts`（`checkPermission` query-only 分支的 reason）
+- Test: `tests/unit/core/permission-guard.test.ts`
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 permission-guard.test.ts 加入：
+
+```typescript
+test('checkPermission: UNKNOWN denial mentions current level and asks for issue report', () => {
+  const result = checkPermission('FOO BAR BAZ', 'query-only')
+  expect(result.allowed).toBe(false)
+  expect(result.classification.type).toBe('UNKNOWN')
+  expect(result.reason).toContain('current level: query-only')
+  expect(result.reason.toLowerCase()).toContain('unknown')
+  expect(result.reason).toContain('issue')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/core/permission-guard.test.ts -t "UNKNOWN denial"`
+Expected: FAIL — reason 是「UNKNOWN operation requires read-write or admin permission」，沒含 `current level` / `issue`。
+
+- [ ] **Step 3: 改寫 query-only 拒絕訊息**
+
+在 `src/core/permission-guard.ts` 中 `if (permission === 'query-only')` 分支的 `return { allowed: false, ... }`，把 reason 改為：
+
+```typescript
+const isUnknown = classification.type === 'UNKNOWN'
+return {
+  allowed: false,
+  reason: isUnknown
+    ? `Unrecognised SQL statement (current level: query-only). Security policy requires read-write+ for unknown statements. If this is a legitimate read-only statement, please open an issue at https://github.com/CarlLee1983/dbcli/issues.`
+    : `${classification.type} operation requires read-write or admin permission`,
+  classification,
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/core/permission-guard.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/permission-guard.ts tests/unit/core/permission-guard.test.ts
+git commit -m "fix: [permission-guard] clarify UNKNOWN denial message in query-only mode"
+```
+
+---
+
+### Task 4: Issue #1 — Auto-LIMIT 只套用在 SELECT
+
+**Files:**
+- Modify: `src/core/query-executor.ts:60-70`
+- Test: `tests/unit/commands/query-executor-autolimit.test.ts`（新檔）
+
+- [ ] **Step 1: 寫失敗測試**
+
+新建 `tests/unit/commands/query-executor-autolimit.test.ts`：
+
+```typescript
+/**
+ * QueryExecutor auto-LIMIT scope tests
+ * Verifies LIMIT injection only happens for SELECT, not for SHOW/DESCRIBE/EXPLAIN.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { QueryExecutor } from '@/core/query-executor'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function makeSpyAdapter(): { adapter: DatabaseAdapter; lastSql: () => string } {
+  let captured = ''
+  const adapter: DatabaseAdapter = {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>(sql: string) => {
+      captured = sql
+      return { rows: [] as T[], affectedRows: 0 }
+    },
+    listTables: async () => [],
+    getTableSchema: async () => ({
+      name: '',
+      columns: [],
+      rowCount: 0,
+      primaryKey: undefined,
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+  return { adapter, lastSql: () => captured }
+}
+
+describe('QueryExecutor auto-LIMIT scope', () => {
+  it('injects LIMIT for plain SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SELECT * FROM users')
+    expect(lastSql()).toMatch(/LIMIT\s+1000/i)
+  })
+
+  it('does NOT inject LIMIT for SHOW INDEX in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SHOW INDEX FROM betting_logs')
+    expect(lastSql()).toBe('SHOW INDEX FROM betting_logs')
+  })
+
+  it('does NOT inject LIMIT for DESCRIBE in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('DESCRIBE users')
+    expect(lastSql()).toBe('DESCRIBE users')
+  })
+
+  it('does NOT inject LIMIT for EXPLAIN SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('EXPLAIN SELECT * FROM users')
+    expect(lastSql()).toBe('EXPLAIN SELECT * FROM users')
+  })
+
+  it('does NOT inject LIMIT for ANALYZE SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('ANALYZE SELECT * FROM users')
+    expect(lastSql()).toBe('ANALYZE SELECT * FROM users')
+  })
+
+  it('preserves existing LIMIT and does not add another', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SELECT * FROM users LIMIT 50')
+    expect(lastSql()).toBe('SELECT * FROM users LIMIT 50')
+  })
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/commands/query-executor-autolimit.test.ts`
+Expected: FAIL — SHOW/DESCRIBE/EXPLAIN/ANALYZE 4 個測試失敗（被加 LIMIT 1000）。
+
+- [ ] **Step 3: 改寫 auto-LIMIT 條件**
+
+在 `src/core/query-executor.ts` 找到既有 auto-LIMIT 區塊（約 line 60-70），把：
+
+```typescript
+// 2. Auto-limit in query-only mode (safety default)
+let executeSql = sql
+if (
+  this.permission === 'query-only' &&
+  !executeSql.match(/LIMIT\s+\d+/i) &&
+  options?.autoLimit !== false
+) {
+  const limitValue = options?.limitValue || DEFAULT_QUERY_ONLY_LIMIT
+  executeSql = `${executeSql} LIMIT ${limitValue}`
+  console.error(`Query-only mode: auto-limiting to ${limitValue} rows`)
+}
+```
+
+改為：
+
+```typescript
+// 2. Auto-limit in query-only mode (safety default).
+// Only applies to SELECT — SHOW/DESCRIBE/EXPLAIN do not accept LIMIT and
+// server rejects with a syntax error. Classification was already computed
+// by enforcePermission() above.
+const AUTO_LIMIT_TYPES = new Set(['SELECT'])
+let executeSql = sql
+if (
+  this.permission === 'query-only' &&
+  AUTO_LIMIT_TYPES.has(classification.type) &&
+  !executeSql.match(/LIMIT\s+\d+/i) &&
+  options?.autoLimit !== false
+) {
+  const limitValue = options?.limitValue || DEFAULT_QUERY_ONLY_LIMIT
+  executeSql = `${executeSql} LIMIT ${limitValue}`
+  console.error(`Query-only mode: auto-limiting to ${limitValue} rows`)
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/commands/query-executor-autolimit.test.ts tests/unit/commands/query-executor-blacklist.test.ts`
+Expected: PASS（含既有 blacklist 測試）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/query-executor.ts tests/unit/commands/query-executor-autolimit.test.ts
+git commit -m "fix: [query-executor] only auto-LIMIT SELECT in query-only mode"
+```
+
+---
+
+### Task 5: Issue #3 — `mapError` SQL_SYNTAX_ERROR 分類
+
+**Files:**
+- Modify: `src/adapters/error-mapper.ts`
+- Test: `tests/unit/adapters/error-mapper.test.ts`
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 error-mapper.test.ts 加入：
+
+```typescript
+test('mapError: MySQL ER_PARSE_ERROR (1064) → SQL_SYNTAX_ERROR', () => {
+  const error = {
+    code: 'ER_PARSE_ERROR',
+    errno: 1064,
+    message:
+      "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'LIMIT 1000' at line 1",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.code).toBe('SQL_SYNTAX_ERROR')
+  expect(result.message.toLowerCase()).toContain('sql syntax')
+  expect(result.hints.join(' ')).toContain('--no-limit')
+})
+
+test('mapError: PostgreSQL syntax_error (42601) → SQL_SYNTAX_ERROR', () => {
+  const error = {
+    code: '42601',
+    message: 'syntax error at or near "FROOM"',
+  }
+  const result = mapError(error, 'postgresql', mockOptions)
+  expect(result.code).toBe('SQL_SYNTAX_ERROR')
+  expect(result.message.toLowerCase()).toContain('sql syntax')
+})
+
+test('mapError: SQL_SYNTAX_ERROR does NOT include connection-troubleshooting hints', () => {
+  const error = { code: 'ER_PARSE_ERROR', errno: 1064, message: 'bad syntax' }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  const hints = result.hints.join(' ')
+  expect(hints).not.toContain('mysql.log')
+  expect(hints).not.toContain('host=')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts -t "SQL_SYNTAX"`
+Expected: FAIL — 落入 UNKNOWN（既有 fallback），印 connection hints。
+
+- [ ] **Step 3: 加入 SQL_SYNTAX_ERROR 分類器**
+
+在 `src/adapters/error-mapper.ts` 中，在現有 `// ENOTFOUND` 區塊之後、`// UNKNOWN: Fallback` 區塊之前，新增：
+
+```typescript
+  // SQL_SYNTAX_ERROR: driver returned a parse error from execute() (not connect()).
+  // MySQL/MariaDB: code='ER_PARSE_ERROR' / errno=1064
+  // PostgreSQL: code='42601' (SQLSTATE syntax_error)
+  if (
+    errCode === 'ER_PARSE_ERROR' ||
+    err?.errno === 1064 ||
+    errCode === '42601'
+  ) {
+    return new ConnectionError(
+      'SQL_SYNTAX_ERROR',
+      `SQL syntax error: ${errMsg}`,
+      [
+        'Check your SQL syntax near the position reported above',
+        'In query-only mode, dbcli auto-appends LIMIT 1000; use --no-limit to disable',
+        'For SHOW/DESCRIBE/EXPLAIN statements, LIMIT is not allowed — these are not auto-limited',
+      ]
+    )
+  }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts`
+Expected: PASS（含既有測試）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adapters/error-mapper.ts tests/unit/adapters/error-mapper.test.ts
+git commit -m "feat: [error-mapper] classify SQL syntax errors separately from connection errors"
+```
+
+---
+
+### Task 6: Issue #3 — `mapError` TABLE_NOT_FOUND 分類
+
+**Files:**
+- Modify: `src/adapters/error-mapper.ts`
+- Test: `tests/unit/adapters/error-mapper.test.ts`
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 error-mapper.test.ts 加入：
+
+```typescript
+test("mapError: MySQL ER_NO_SUCH_TABLE (1146) → TABLE_NOT_FOUND", () => {
+  const error = {
+    code: 'ER_NO_SUCH_TABLE',
+    errno: 1146,
+    message: "Table 'station_local.bets' doesn't exist",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb', database: 'station_local' })
+  expect(result.code).toBe('TABLE_NOT_FOUND')
+  expect(result.message).toContain("bets")
+  expect(result.message).toContain('station_local')
+  expect(result.hints.join(' ')).toContain('dbcli list')
+})
+
+test("mapError: PostgreSQL undefined_table (42P01) → TABLE_NOT_FOUND", () => {
+  const error = {
+    code: '42P01',
+    message: 'relation "bets" does not exist',
+  }
+  const result = mapError(error, 'postgresql', { ...mockOptions, database: 'testdb' })
+  expect(result.code).toBe('TABLE_NOT_FOUND')
+  expect(result.message).toContain("bets")
+  expect(result.hints.join(' ')).toContain('dbcli list')
+})
+
+test('mapError: TABLE_NOT_FOUND does NOT include connection-troubleshooting hints', () => {
+  const error = { code: 'ER_NO_SUCH_TABLE', errno: 1146, message: "Table 'x.y' doesn't exist" }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.hints.join(' ')).not.toContain('mysql.log')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts -t "TABLE_NOT_FOUND"`
+Expected: FAIL — 既有 logic 把「does not exist」抓進 AUTH_FAILED 或 fallback。
+
+- [ ] **Step 3: 加入 TABLE_NOT_FOUND 分類器**
+
+**重要插入位置**：必須在 `// AUTH_FAILED:` 區塊**之前**，否則 PG 訊息中的 "does not exist" 會被 AUTH_FAILED 攔截。
+
+在 `src/adapters/error-mapper.ts` 的 `// AUTH_FAILED: Authentication (credentials) error` 註解區塊之前，新增：
+
+```typescript
+  // TABLE_NOT_FOUND: server rejected query because referenced table doesn't exist.
+  // MySQL/MariaDB: code='ER_NO_SUCH_TABLE' / errno=1146
+  // PostgreSQL: code='42P01' (SQLSTATE undefined_table)
+  if (
+    errCode === 'ER_NO_SUCH_TABLE' ||
+    err?.errno === 1146 ||
+    errCode === '42P01'
+  ) {
+    // Extract table name from message:
+    //  - MySQL: Table 'db.tablename' doesn't exist
+    //  - PG:    relation "tablename" does not exist
+    const mysqlMatch = errMsg.match(/Table\s+'(?:[^.']+\.)?([^']+)'/i)
+    const pgMatch = errMsg.match(/relation\s+"([^"]+)"/i)
+    const tableName = mysqlMatch?.[1] || pgMatch?.[1] || 'unknown'
+    return new ConnectionError(
+      'TABLE_NOT_FOUND',
+      `Table '${tableName}' not found in database '${options.database || 'unknown'}'`,
+      [
+        'Run `dbcli list` to see available tables',
+        'Run `dbcli schema <table>` to confirm the exact name (ORM export names may differ from DB table names)',
+      ]
+    )
+  }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adapters/error-mapper.ts tests/unit/adapters/error-mapper.test.ts
+git commit -m "feat: [error-mapper] classify TABLE_NOT_FOUND with actionable hints"
+```
+
+---
+
+### Task 7: Issue #3 — `mapError` COLUMN_NOT_FOUND 分類
+
+**Files:**
+- Modify: `src/adapters/error-mapper.ts`
+- Test: `tests/unit/adapters/error-mapper.test.ts`
+
+- [ ] **Step 1: 寫失敗測試**
+
+```typescript
+test("mapError: MySQL ER_BAD_FIELD_ERROR (1054) → COLUMN_NOT_FOUND", () => {
+  const error = {
+    code: 'ER_BAD_FIELD_ERROR',
+    errno: 1054,
+    message: "Unknown column 'usr_id' in 'where clause'",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.code).toBe('COLUMN_NOT_FOUND')
+  expect(result.message).toContain('usr_id')
+  expect(result.hints.join(' ')).toContain('dbcli schema')
+})
+
+test("mapError: PostgreSQL undefined_column (42703) → COLUMN_NOT_FOUND", () => {
+  const error = {
+    code: '42703',
+    message: 'column "usr_id" does not exist',
+  }
+  const result = mapError(error, 'postgresql', mockOptions)
+  expect(result.code).toBe('COLUMN_NOT_FOUND')
+  expect(result.message).toContain('usr_id')
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts -t "COLUMN_NOT_FOUND"`
+Expected: FAIL。
+
+- [ ] **Step 3: 加入 COLUMN_NOT_FOUND 分類器**
+
+在 TABLE_NOT_FOUND 區塊之後、`// AUTH_FAILED:` 之前，新增：
+
+```typescript
+  // COLUMN_NOT_FOUND: referenced column doesn't exist on the table.
+  // MySQL/MariaDB: code='ER_BAD_FIELD_ERROR' / errno=1054
+  // PostgreSQL: code='42703' (SQLSTATE undefined_column)
+  if (
+    errCode === 'ER_BAD_FIELD_ERROR' ||
+    err?.errno === 1054 ||
+    errCode === '42703'
+  ) {
+    const mysqlMatch = errMsg.match(/Unknown column\s+'([^']+)'/i)
+    const pgMatch = errMsg.match(/column\s+"([^"]+)"\s+does not exist/i)
+    const columnName = mysqlMatch?.[1] || pgMatch?.[1] || 'unknown'
+    return new ConnectionError(
+      'COLUMN_NOT_FOUND',
+      `Column '${columnName}' not found`,
+      [
+        'Run `dbcli schema <table>` to see the actual column names',
+        'Column names are case-sensitive on some databases (PostgreSQL with quoted identifiers)',
+      ]
+    )
+  }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `bun test tests/unit/adapters/error-mapper.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adapters/error-mapper.ts tests/unit/adapters/error-mapper.test.ts
+git commit -m "feat: [error-mapper] classify COLUMN_NOT_FOUND with schema-lookup hint"
+```
+
+---
+
+### Task 8: Issue #3 — `schema` 命令在 TABLE_NOT_FOUND 時加 fuzzy 候選
+
+`suggestTableName()` 已存在於 `src/utils/error-suggester.ts`，但 schema 命令目前沒接。把它接上。
+
+**Files:**
+- Modify: `src/commands/schema.ts`
+- Test: `tests/unit/commands/schema-suggest.test.ts`（新檔）
+
+- [ ] **Step 1: 找到 schema 命令的 error path**
+
+Run: `grep -n "getTableSchema\|catch" src/commands/schema.ts | head -15`
+記下 single-table schema 查詢的 try/catch 行號。
+
+- [ ] **Step 2: 寫失敗測試**
+
+新建 `tests/unit/commands/schema-suggest.test.ts`：
+
+```typescript
+/**
+ * `dbcli schema <table>` should attach fuzzy-match suggestions when the
+ * underlying TABLE_NOT_FOUND error fires.
+ */
+import { test, expect } from 'bun:test'
+import { ConnectionError } from '@/adapters/error-mapper'
+import { attachTableSuggestions } from '@/commands/schema'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function mockAdapterWithTables(tables: string[]): DatabaseAdapter {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>() => ({ rows: [] as T[], affectedRows: 0 }),
+    listTables: async () =>
+      tables.map((name) => ({
+        name,
+        columns: [],
+        rowCount: 0,
+        primaryKey: undefined,
+        foreignKeys: [],
+      })),
+    getTableSchema: async () => {
+      throw new ConnectionError('TABLE_NOT_FOUND', "Table 'bets' not found", [
+        'Run `dbcli list` to see available tables',
+      ])
+    },
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+}
+
+test('attachTableSuggestions appends top-3 fuzzy candidates to hints', async () => {
+  const adapter = mockAdapterWithTables(['betting_logs', 'bet_history', 'orders', 'users'])
+  const baseErr = new ConnectionError('TABLE_NOT_FOUND', "Table 'bets' not found", [
+    'Run `dbcli list` to see available tables',
+  ])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'bets')
+  expect(enriched.hints.some((h) => h.includes('Did you mean'))).toBe(true)
+  const suggestionLine = enriched.hints.find((h) => h.includes('Did you mean')) || ''
+  expect(suggestionLine).toMatch(/bet/i)
+})
+
+test('attachTableSuggestions returns original error when no close matches', async () => {
+  const adapter = mockAdapterWithTables(['users', 'orders', 'payments'])
+  const baseErr = new ConnectionError('TABLE_NOT_FOUND', "Table 'xyz123' not found", [
+    'Run `dbcli list` to see available tables',
+  ])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'xyz123')
+  expect(enriched.hints.some((h) => h.includes('Did you mean'))).toBe(false)
+})
+
+test('attachTableSuggestions is a no-op for non-TABLE_NOT_FOUND errors', async () => {
+  const adapter = mockAdapterWithTables(['users'])
+  const baseErr = new ConnectionError('UNKNOWN', 'something else', ['hint'])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'anything')
+  expect(enriched).toBe(baseErr)
+})
+```
+
+- [ ] **Step 3: 跑測試確認失敗**
+
+Run: `bun test tests/unit/commands/schema-suggest.test.ts`
+Expected: FAIL — `attachTableSuggestions` 不存在。
+
+- [ ] **Step 4: 實作 attachTableSuggestions**
+
+在 `src/commands/schema.ts` 檔案頂部 import 區塊加入：
+
+```typescript
+import { suggestTableName } from '@/utils/error-suggester'
+import { ConnectionError } from '@/adapters/error-mapper'
+```
+
+在 `export const schemaCommand = new Command()` 之前（與其他 helper 同層）新增 export：
+
+```typescript
+/**
+ * Enrich a TABLE_NOT_FOUND ConnectionError with fuzzy-match suggestions.
+ * Pure pass-through for any other error code. Safe to call on every catch path.
+ */
+export async function attachTableSuggestions(
+  err: ConnectionError,
+  adapter: DatabaseAdapter,
+  attemptedName: string
+): Promise<ConnectionError> {
+  if (err.code !== 'TABLE_NOT_FOUND') return err
+  try {
+    const { suggestions } = await suggestTableName(
+      `Table '${attemptedName}' doesn't exist`,
+      adapter
+    )
+    if (suggestions.length === 0) return err
+    const suggestionLine = `Did you mean: ${suggestions.join(', ')}?`
+    return new ConnectionError(err.code, err.message, [...err.hints, suggestionLine])
+  } catch {
+    // If listing tables itself fails (e.g. permission), don't mask the original error.
+    return err
+  }
+}
+```
+
+- [ ] **Step 5: 跑測試確認通過**
+
+Run: `bun test tests/unit/commands/schema-suggest.test.ts`
+Expected: PASS。
+
+- [ ] **Step 6: 在 schema 命令的 catch 路徑接上**
+
+在 `src/commands/schema.ts` 中找到 single-table 查詢分支對 `adapter.getTableSchema(...)` 的呼叫。把該呼叫包進 try/catch（若尚未）並接上 suggester：
+
+```typescript
+try {
+  // 既有 getTableSchema 呼叫保持不變
+} catch (error) {
+  if (error instanceof ConnectionError) {
+    throw await attachTableSuggestions(error, adapter, tableName)
+  }
+  throw error
+}
+```
+
+- [ ] **Step 7: 跑既有 schema 測試確認沒 regression**
+
+Run: `bun test tests/unit/commands/schema-*.test.ts tests/integration/commands/schema.test.ts`
+Expected: PASS。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/commands/schema.ts tests/unit/commands/schema-suggest.test.ts
+git commit -m "feat: [schema] attach fuzzy table-name suggestions on TABLE_NOT_FOUND"
+```
+
+---
+
+### Task 9: Issue #7 — `schema --refresh` 首次 bootstrap 免 `--force`
+
+**Files:**
+- Modify: `src/commands/schema.ts`（`handleSchemaRefresh` 函式 line 438-442）
+- Test: `tests/unit/commands/schema-refresh-bootstrap.test.ts`（新檔）
+
+- [ ] **Step 1: 寫失敗測試**
+
+新建 `tests/unit/commands/schema-refresh-bootstrap.test.ts`：
+
+```typescript
+/**
+ * schema --refresh first-time bootstrap behaviour.
+ * When config.schema is empty, --force should not be required.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { handleSchemaRefresh } from '@/commands/schema'
+import type { DatabaseAdapter } from '@/adapters/types'
+import type { DbcliConfig } from '@/utils/validation'
+
+function mockAdapter(): DatabaseAdapter {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>() => ({ rows: [] as T[], affectedRows: 0 }),
+    listTables: async () => [
+      { name: 'users', columns: [], rowCount: 0, primaryKey: undefined, foreignKeys: [] },
+      { name: 'orders', columns: [], rowCount: 0, primaryKey: undefined, foreignKeys: [] },
+    ],
+    getTableSchema: async (name: string) => ({
+      name,
+      columns: [{ name: 'id', type: 'int', nullable: false, isPrimaryKey: true }],
+      rowCount: 0,
+      primaryKey: ['id'],
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+}
+
+describe('handleSchemaRefresh first-time bootstrap', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'dbcli-schema-bootstrap-'))
+  })
+
+  it('persists schema without --force when cache is empty', async () => {
+    const config: DbcliConfig = {
+      connection: {
+        system: 'mariadb',
+        host: 'localhost',
+        port: 3306,
+        user: 'u',
+        password: 'p',
+        database: 'db',
+      },
+      permission: 'admin',
+      schema: {},
+    } as unknown as DbcliConfig
+
+    await handleSchemaRefresh(
+      mockAdapter(),
+      config,
+      { config: 'dummy', refresh: true, force: false },
+      undefined,
+      tmpDir
+    )
+
+    expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(true)
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('still requires --force when cache is non-empty', async () => {
+    const config: DbcliConfig = {
+      connection: {
+        system: 'mariadb',
+        host: 'localhost',
+        port: 3306,
+        user: 'u',
+        password: 'p',
+        database: 'db',
+      },
+      permission: 'admin',
+      schema: {
+        users: {
+          name: 'users',
+          columns: [{ name: 'id', type: 'int', nullable: false, isPrimaryKey: true }],
+          rowCount: 0,
+          primaryKey: ['id'],
+          foreignKeys: [],
+        },
+      },
+    } as unknown as DbcliConfig
+
+    await handleSchemaRefresh(
+      mockAdapter(),
+      config,
+      { config: 'dummy', refresh: true, force: false },
+      undefined,
+      tmpDir
+    )
+
+    expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(false)
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun test tests/unit/commands/schema-refresh-bootstrap.test.ts`
+Expected: FAIL — `handleSchemaRefresh` 不是 export（module-level 私有）。
+
+- [ ] **Step 3: Export `handleSchemaRefresh`**
+
+在 `src/commands/schema.ts` 中把 `async function handleSchemaRefresh(...)` 改為 `export async function handleSchemaRefresh(...)`。
+
+- [ ] **Step 4: 跑測試確認**
+
+Run: `bun test tests/unit/commands/schema-refresh-bootstrap.test.ts`
+Expected: 第一個測試仍 FAIL（bootstrap 沒寫入），第二個 PASS。
+
+- [ ] **Step 5: 加入 first-time bootstrap 分流**
+
+在 `src/commands/schema.ts` 的 `handleSchemaRefresh` 找到（約 line 438）：
+
+```typescript
+// Require --force to apply
+if (!options.force) {
+  console.log('   Use --force to apply changes')
+  return
+}
+```
+
+改為：
+
+```typescript
+// First-time bootstrap: no existing cache to protect, skip --force gate.
+const isFirstTime = Object.keys(config.schema || {}).length === 0
+if (!options.force && !isFirstTime) {
+  console.log('   Use --force to apply changes')
+  return
+}
+if (isFirstTime) {
+  console.log('   First-time bootstrap (no existing cache to protect)')
+}
+```
+
+接著找到 refresh 完成後的 console log（約 line 470）：
+
+```typescript
+console.log(`✅ Schema persisted to layered storage (.dbcli/schemas/${connectionName || ''})`)
+```
+
+代之以 bootstrap-vs-update 分流訊息：
+
+```typescript
+if (isFirstTime) {
+  console.log(`✅ Schema cache initialised (${Object.keys(newSchema).length} tables)`)
+} else {
+  console.log(
+    `✅ Schema updated (${report.tablesAdded.length} added / ${report.tablesRemoved.length} removed / ${Object.keys(report.tablesModified).length} modified)`
+  )
+}
+```
+
+- [ ] **Step 6: 跑測試確認通過**
+
+Run: `bun test tests/unit/commands/schema-refresh-bootstrap.test.ts`
+Expected: PASS。
+
+- [ ] **Step 7: 跑既有 schema 測試確認沒 regression**
+
+Run: `bun test tests/unit/commands/schema-*.test.ts`
+Expected: PASS。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/commands/schema.ts tests/unit/commands/schema-refresh-bootstrap.test.ts
+git commit -m "fix: [schema] skip --force for first-time refresh bootstrap"
+```
+
+---
+
+### Task 10: 跨 DB 整合測試 smoke pass
+
+**Files:**
+- Test: `tests/integration/p1-error-classification.test.ts`（新檔）
+
+對真實 MariaDB / PostgreSQL container 各跑代表性錯誤情境，確保 P1 端到端體驗一致。
+
+- [ ] **Step 1: 確認 integration 測試環境**
+
+Run: `head -50 tests/integration/commands/schema.test.ts`
+觀察既有 integration 測試怎麼起 DB / 載 connection options。沿用同一 pattern。
+
+- [ ] **Step 2: 寫整合測試（依現有 pattern 調整）**
+
+新建 `tests/integration/p1-error-classification.test.ts`。骨架（若既有 test 已有 connection helper，import 之取代手刻 options）：
+
+```typescript
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { AdapterFactory } from '@/adapters'
+import { QueryExecutor } from '@/core/query-executor'
+import { ConnectionError } from '@/adapters/error-mapper'
+
+const MARIADB_AVAILABLE =
+  !!process.env.TEST_MARIADB_HOST || !!process.env.TEST_MARIADB_DSN
+
+const MARIADB_OPTS = {
+  system: 'mariadb' as const,
+  host: process.env.TEST_MARIADB_HOST || 'localhost',
+  port: Number(process.env.TEST_MARIADB_PORT || 3306),
+  user: process.env.TEST_MARIADB_USER || 'root',
+  password: process.env.TEST_MARIADB_PASSWORD || '',
+  database: process.env.TEST_MARIADB_DB || 'test',
+}
+
+describe.skipIf(!MARIADB_AVAILABLE)('P1: error classification (MariaDB)', () => {
+  let adapter: ReturnType<typeof AdapterFactory.create>
+
+  beforeAll(async () => {
+    adapter = AdapterFactory.create(MARIADB_OPTS)
+    await adapter.connect()
+  })
+
+  afterAll(async () => {
+    await adapter.disconnect()
+  })
+
+  test('SHOW TABLES is NOT rejected in query-only mode', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await expect(exec.execute('SHOW TABLES')).resolves.toBeDefined()
+  })
+
+  test('SELECT against unknown table → TABLE_NOT_FOUND', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    try {
+      await exec.execute('SELECT * FROM definitely_does_not_exist_xyz')
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectionError)
+      expect((err as ConnectionError).code).toBe('TABLE_NOT_FOUND')
+    }
+  })
+
+  test('ANALYZE SELECT is allowed in query-only mode', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await expect(exec.execute('ANALYZE SELECT 1')).resolves.toBeDefined()
+  })
+})
+
+// PG section — same shape, gate on TEST_POSTGRESQL_HOST
+```
+
+- [ ] **Step 3: 跑整合測試（若 DB 可用）**
+
+Run: `bun test tests/integration/p1-error-classification.test.ts`
+Expected: PASS 或 skipped（依環境）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/p1-error-classification.test.ts
+git commit -m "test: [p1] cross-DB integration smoke for error classification"
+```
+
+---
+
+### Task 11: 文件 + CHANGELOG 更新
+
+依專案 mandate（AGENTS.md "Documentation Mandate"），P1 行為改動須同步更新 `docs/user/{en,zh-TW}/{index.md,index.html}` 與 `CHANGELOG.md`。
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/user/en/index.md` `docs/user/en/index.html`
+- Modify: `docs/user/zh-TW/index.md` `docs/user/zh-TW/index.html`
+
+- [ ] **Step 1: CHANGELOG entry**
+
+在 `CHANGELOG.md` 頂部加：
+
+```markdown
+## [Unreleased]
+
+### Fixed
+- query-only mode 不再對 `SHOW`/`DESCRIBE`/`EXPLAIN`/`ANALYZE SELECT` 注入 `LIMIT`，避免 server 拒絕（v1.23 P1, issue #1）
+- MariaDB `ANALYZE SELECT` 與 PostgreSQL `EXPLAIN (ANALYZE, BUFFERS) SELECT` 視為 read-only，query-only 模式可執行（v1.23 P1, issue #2）
+- driver 在 execute 階段丟出的 SQL 錯誤（語法錯、table 不存在、column 不存在）不再被誤包成 `Connection failed`；訊息附 actionable hints 與 fuzzy table 候選（v1.23 P1, issue #3）
+- `dbcli schema --refresh` 首次 bootstrap 不再要求 `--force`（v1.23 P1, issue #7）
+
+### Changed
+- `ConnectionError.code` union 新增 `SQL_SYNTAX_ERROR` / `TABLE_NOT_FOUND` / `COLUMN_NOT_FOUND`（向後相容；既有 consumer 只匹配 `UNKNOWN` 仍 fallback）
+```
+
+- [ ] **Step 2: User docs 更新（en）**
+
+在 `docs/user/en/index.md` 找到 troubleshooting / error-handling 區塊（若無則加在 Permissions 區塊之後），加入：
+
+```markdown
+### Error categories
+
+`dbcli` distinguishes between **connection errors** (server down, auth failed) and
+**SQL errors** (syntax, missing table, missing column). SQL errors now print:
+
+- The specific problem (not "Connection failed")
+- A hint pointing to the right next command (`dbcli list`, `dbcli schema <table>`, `--no-limit`)
+- For missing tables, top-3 fuzzy-match candidates
+
+### Query-only mode auto-LIMIT
+
+`dbcli` auto-appends `LIMIT 1000` to `SELECT` queries in `query-only` mode. This
+**does not** apply to:
+
+- `SHOW` / `DESCRIBE` statements (LIMIT is not valid syntax here)
+- `EXPLAIN` / `EXPLAIN ANALYZE` / MariaDB `ANALYZE SELECT`
+
+Use `--no-limit` on `SELECT` to disable when querying `information_schema`.
+
+### Schema cache bootstrap
+
+The first `dbcli schema --refresh` after init writes the cache without `--force`.
+Subsequent refreshes that detect changes against an existing cache still require
+`--force` to overwrite.
+```
+
+對 `docs/user/en/index.html` 加入對應 section（依現有 HTML 結構 sidebar + content）。
+
+- [ ] **Step 3: User docs 更新（zh-TW）**
+
+在 `docs/user/zh-TW/index.md` 對應位置加：
+
+```markdown
+### 錯誤分類
+
+`dbcli` 區分**連線錯誤**（server 沒起、認證失敗）與 **SQL 錯誤**（語法錯、table/column 不存在）。SQL 錯誤現在會印：
+
+- 具體問題（不再印 "Connection failed"）
+- 指向正確下一步的 hint（`dbcli list`、`dbcli schema <table>`、`--no-limit`）
+- 對 table 不存在，附上 top-3 fuzzy 候選
+
+### Query-only auto-LIMIT 範圍
+
+`dbcli` 會在 `query-only` 模式對 `SELECT` 自動加 `LIMIT 1000`。**不** 套用於：
+
+- `SHOW` / `DESCRIBE` 語句（LIMIT 在此非合法語法）
+- `EXPLAIN` / `EXPLAIN ANALYZE` / MariaDB `ANALYZE SELECT`
+
+查 `information_schema` 時用 `--no-limit` 關閉。
+
+### Schema cache bootstrap
+
+第一次 `dbcli schema --refresh` 不需 `--force` 即會寫入 cache。後續 refresh 偵測到既有 cache 有 diff 才會要求 `--force`。
+```
+
+對 `docs/user/zh-TW/index.html` 加對應 section。
+
+- [ ] **Step 4: 視覺確認 docs render**
+
+若專案有 docs build 指令（`bun run docs:build` 之類），執行之。否則用 browser 開啟靜態 HTML 確認 sidebar nav 有新 anchor。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md docs/user/en/index.md docs/user/en/index.html docs/user/zh-TW/index.md docs/user/zh-TW/index.html
+git commit -m "docs: [p1] document error classification + auto-LIMIT scope + bootstrap"
+```
+
+---
+
+### Task 12: PR & alpha tag
+
+- [ ] **Step 1: 跑完整測試**
+
+Run: `bun test`
+Expected: 全綠。
+
+- [ ] **Step 2: 推 branch**
+
+```bash
+git push -u origin feature/v1.23-p1-error-classification
+```
+
+- [ ] **Step 3: 開 PR**
+
+```bash
+gh pr create --title "feat: [v1.23 P1] error classification & query-only fixes" --body "$(cat <<'EOF'
+## Summary
+
+實作 v1.23 P1，回應 arcade-report 使用者回饋（2026-05-28）：
+
+- #1 SHOW/DESCRIBE/EXPLAIN 不再被 auto-LIMIT 注入
+- #2 MariaDB ANALYZE SELECT / PG EXPLAIN ANALYZE 視為 read-only
+- #3 SQL execute 錯誤分流為 SQL_SYNTAX_ERROR / TABLE_NOT_FOUND / COLUMN_NOT_FOUND；schema 命令附 fuzzy 候選
+- #7 schema --refresh 首次 bootstrap 免 --force
+
+Spec: docs/superpowers/specs/2026-05-28-dbcli-feedback-fixes-design.md
+
+## Test plan
+
+- [ ] `bun test` 全綠
+- [ ] 對真實 MariaDB：`SHOW INDEX FROM <table>` 在 query-only 不被拒
+- [ ] 對真實 MariaDB：`SELECT * FROM nonexistent` 報 TABLE_NOT_FOUND，hints 含 `dbcli list`
+- [ ] 對真實 PostgreSQL：`EXPLAIN (ANALYZE, BUFFERS) SELECT ...` 在 query-only 可執行
+- [ ] `dbcli schema --refresh` 首次（空 cache）直接寫入
+- [ ] CHANGELOG + en/zh-TW docs 同步
+EOF
+)"
+```
+
+- [ ] **Step 4: Merge 後打 alpha tag**
+
+待 PR review + merge 後：
+
+```bash
+git checkout main && git pull
+git tag -a v1.23.0-alpha.1 -m "v1.23.0 P1: error classification & query-only fixes"
+git push origin v1.23.0-alpha.1
+```
+
+---
+
+## Self-Review 檢查
+
+**Spec coverage**：
+- Issue #1 SHOW auto-LIMIT → Task 4
+- Issue #2 ANALYZE SELECT → Task 2 + Task 3 (UNKNOWN message)
+- Issue #3 SQL_SYNTAX_ERROR / TABLE_NOT_FOUND / COLUMN_NOT_FOUND → Task 5 / 6 / 7
+- Issue #3 schema fuzzy suggestions → Task 8
+- Issue #7 schema bootstrap → Task 9
+- 跨 DB 整合測試 → Task 10
+- Docs/CHANGELOG → Task 11
+- Release flow → Task 12
+
+**Placeholder scan**：無 TBD/TODO；docs build step 是 informed-conditional（依專案是否有 build 指令）。
+
+**Type 一致性**：`ConnectionError` 在 Task 1 擴展 union；Task 5-8 統一使用 `SQL_SYNTAX_ERROR` / `TABLE_NOT_FOUND` / `COLUMN_NOT_FOUND` 成員；Task 8 與 P1 範圍內所有檔案都從 `@/adapters/error-mapper` import `ConnectionError`。

--- a/docs/superpowers/specs/2026-05-28-dbcli-feedback-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-28-dbcli-feedback-fixes-design.md
@@ -1,0 +1,553 @@
+# v1.23.0 — Source-Driven Performance Review Tooling
+
+**Spec date**: 2026-05-28
+**Driver feedback**: `/Users/carl/Dev/CMG/arcade-report/docs/dbcli-feedback-2026-05-28.md`
+**Milestone**: v1.23.0
+**Status**: Design (awaiting implementation plan)
+
+## Background
+
+外部使用者在 `arcade-report` 專案執行 source-driven 效能審查時（拿 PR 動到的 service 檔 → 列重型 SQL → 跑 EXPLAIN → 整理表格），回饋 8 個 issue 涵蓋兩大主題：
+
+1. **Bug fixes**：query-only mode 過嚴、錯誤訊息分類錯誤誤導排錯方向、schema bootstrap 多一個來回。
+2. **新指令需求**：`dbcli explain` 一級指令（含 `--bulk`）、`dbcli guide missing-index-for`、`dbcli inspect` task pack 提示。
+
+本 spec 把 8 個 issue 整合為 v1.23.0 一個 milestone，切分為 P1–P4 共 4 個 phase，每個 phase 各自 feature branch 與 PR。
+
+## Goals
+
+- **不再誤導**：使用者再也不會把 SQL 語法錯或 table 不存在誤認為連線錯。
+- **EXPLAIN 提升為一級工具**：直接輸出可貼進 PR 的 markdown，支援批次、自動標籤化問題點。
+- **索引建議聚焦到單一 query**：補上 `guide index-usage` 缺的 per-query 視角。
+- **Agent step-1 可發現 task packs**：`inspect` 主動提示，不靠 agent 記憶。
+
+## Non-Goals
+
+- 不重寫整體權限模型（P1 只局部放寬 classifier）。
+- `dbcli explain --from-diff`：留 v1.24+，本 milestone 不做。
+- Mongo / ES / Redis 的 EXPLAIN 對應：本 milestone 不做（無概念對應）。
+- Functional / partial index 建議：P3 只警示，不主動推薦。
+- 跨方言完整 SQL parser：採用既有 `node-sql-parser`，方言邊界 fallback 為 EXPLAIN 啟發式。
+
+## Phase Overview
+
+| Phase | 主題 | 涵蓋 feedback issue | 預估規模 |
+|---|---|---|---|
+| **P1** | Error classification & query-only 修正 | #1 SHOW auto-LIMIT、#2 ANALYZE SELECT、#3 Table not found 訊息、#7 schema refresh first-time | 中（~600–800 LOC + tests） |
+| **P2** | `dbcli explain` 一級指令 + `--bulk` | #4、#5 | 中-大（~1000–1500 LOC + tests） |
+| **P3** | `dbcli guide missing-index-for` 含 SQL parser | #6 | 大（~1500–2000 LOC + tests） |
+| **P4** | `dbcli inspect` suggestedCommands 強化 | #8 | 小（~200–300 LOC + tests） |
+
+**Branch 策略**：4 個獨立 feature branch（`feature/v1.23-p1-error-classification`、`feature/v1.23-p2-explain`、`feature/v1.23-p3-missing-index`、`feature/v1.23-p4-inspect-hints`），各自 PR 各自 merge 到 main。Release tag 在 P4 merge 後打 `v1.23.0`，中間每個 phase 完成打 `v1.23.0-alpha.N`/`-beta.N`。
+
+**DB 支援矩陣**：P1/P2/P3 全部支援 MySQL/MariaDB/PostgreSQL。Mongo/ES/Redis 不適用。
+
+**Phase 依賴**：P3 → P2（P3 重用 P2 的 explain runner 拿真實 plan）；其他 phase 互相獨立。
+
+---
+
+## P1 — Error Classification & Query-Only 修正
+
+### P1.1 Issue #1 — SHOW/DESCRIBE 不再被 auto-LIMIT 注入
+
+**現況**：`src/core/query-executor.ts:60-70` 對所有 query-only 語句注入 `LIMIT 1000`，造成 `SHOW INDEX FROM ...` 等語句被 server 拒絕。錯誤又被誤包成 connection error。
+
+**改動**：
+
+```typescript
+// src/core/query-executor.ts
+const AUTO_LIMIT_TYPES = new Set(['SELECT'])  // 只對 SELECT 套用
+
+if (this.permission === 'query-only' &&
+    AUTO_LIMIT_TYPES.has(classification.type) &&
+    !executeSql.match(/LIMIT\s+\d+/i) &&
+    options?.autoLimit !== false) {
+  // 既有邏輯
+}
+```
+
+`classification` 在前一行 `enforcePermission(sql, this.permission)` 已取得，無需重複 classify。
+
+### P1.2 Issue #2 — `ANALYZE SELECT` / `EXPLAIN ANALYZE` 視為 read-only
+
+**現況**：`src/core/permission-guard.ts` 把 `ANALYZE` 開頭歸為 UNKNOWN，query-only 拒絕執行。錯誤訊息「required: query-only」與當前等級矛盾。
+
+**改動**：`src/core/permission-guard.ts:classifyStatement` 入口新增 MariaDB 變體偵測：
+
+```typescript
+export function classifyStatement(sql: string): StatementClassification {
+  const normalized = normalizeSQL(sql)
+  const stripped = stripCommentsAndStrings(normalized)
+
+  // MariaDB 'ANALYZE SELECT' is a read-only EXPLAIN variant
+  if (/^\s*ANALYZE\s+SELECT\b/i.test(stripped)) {
+    return {
+      type: 'EXPLAIN',
+      isDangerous: false,
+      keywords: extractAllKeywords(stripped),
+      isComposite: false,
+      confidence: 'HIGH',
+    }
+  }
+
+  // 既有邏輯
+}
+```
+
+PG 的 `EXPLAIN (ANALYZE, BUFFERS) SELECT ...` 既有 `extractFirstKeyword` 已正確歸為 `EXPLAIN`；補測試驗證。
+
+**UNKNOWN 錯誤訊息**：當 classify 為 UNKNOWN 且權限不允許時，訊息改為：
+
+> 「未識別的 SQL 語句（current level: query-only）。安全策略要求 read-write+ 才能執行未知語句。若這是合法的 read-only 語法，請在 GitHub 開 issue 回報。」
+
+### P1.3 Issue #3 — Table-not-found / SQL syntax error 訊息分流
+
+**現況**：`src/adapters/error-mapper.ts` 把所有 driver 錯誤都 fallback 成 `Connection failed`，並印連線排錯 hint。
+
+**改動**：`mapError` 在現有 fallback 之前加新分類器：
+
+| 分類 | MySQL/MariaDB code | PostgreSQL code | 訊息 |
+|---|---|---|---|
+| `SQL_SYNTAX_ERROR` | `1064` (ER_PARSE_ERROR) | `42601` | "SQL syntax error: ..." + hint「檢查語法；query-only 可用 `--no-limit`」 |
+| `TABLE_NOT_FOUND` | `1146` (ER_NO_SUCH_TABLE) | `42P01` | "Table 'X' not found in database 'Y'" + hint「`dbcli list`」+ fuzzy match 候選 |
+| `COLUMN_NOT_FOUND` | `1054` | `42703` | "Column 'X' not found in table 'Y'" + hint「`dbcli schema <table>`」 |
+
+**分流原則**：driver 在連線階段（pool.connect）丟錯 → 既有 ECONNREFUSED/AUTH_FAILED 邏輯。driver 在 execute 階段丟錯 → 新分類器。
+
+**Schema 命令整合**：`src/commands/schema.ts` 捕捉到 `TABLE_NOT_FOUND` 時呼叫既有 `suggestTableName()`（`src/utils/error-suggester.ts`），把 top-3 候選印在 hint 區。
+
+### P1.4 Issue #7 — Schema refresh first-time bootstrap
+
+**現況**：`src/commands/schema.ts:438-442` 對任何 schema diff 都要求 `--force`，第一次（無 cache）也得跑兩次。
+
+**改動**：
+
+```typescript
+// src/commands/schema.ts handleSchemaRefresh
+const isFirstTime = Object.keys(config.schema || {}).length === 0
+if (!options.force && !isFirstTime) {
+  console.log('   Use --force to apply changes')
+  return
+}
+if (isFirstTime) {
+  console.log('   First-time bootstrap (no existing cache to protect)')
+}
+// 繼續寫入
+```
+
+訊息分流：
+- bootstrap：「✅ Schema cache initialised (N tables)」
+- update：「✅ Schema updated (N added / M removed / K modified)」
+
+### P1 測試
+
+- `tests/unit/core/query-executor.test.ts`：SHOW/DESCRIBE/EXPLAIN 不被注入 LIMIT
+- `tests/unit/core/permission-guard.test.ts`：`ANALYZE SELECT`、`EXPLAIN (ANALYZE, BUFFERS) SELECT` 正確分類為 EXPLAIN
+- `tests/unit/adapters/error-mapper.test.ts`：1064 / 42601 / 1146 / 42P01 / 1054 / 42703 各 code 對應正確訊息
+- `tests/unit/commands/schema-refresh-bootstrap.test.ts`：first-time 不需 `--force`
+- 整合測試（既有 docker compose）：跨 MySQL/MariaDB/PostgreSQL 驗證 P1 端到端
+
+---
+
+## P2 — `dbcli explain` 一級指令 + `--bulk`
+
+### P2.1 指令介面
+
+```bash
+# 基本
+dbcli explain "SELECT ... FROM betting_logs WHERE ..."
+
+# 對 saved query
+dbcli explain @analytics/live-summary --param hosterSpaceId=1
+
+# ANALYZE 變體
+dbcli explain --analyze "SELECT ..."
+
+# 輸出格式（預設 markdown）
+dbcli explain "..." --format json
+dbcli explain "..." --format markdown
+dbcli explain "..." --format table
+
+# 批次
+dbcli explain --bulk @queries-to-review.sql --format markdown
+dbcli explain --bulk @analytics/* --format markdown
+```
+
+`--from-diff` 留 v1.24+。
+
+### P2.2 架構
+
+```
+src/commands/explain.ts             # CLI handler、flag、bulk 迴圈
+src/core/explain/
+  ├─ types.ts                       # ExplainRow、ExplainPlan、ExplainAnnotation
+  ├─ runner.ts                      # 單條 query → ExplainPlan
+  ├─ bulk-runner.ts                 # @file / glob / saved query 展開 + 多筆
+  └─ annotate.ts                    # 語意標籤
+src/adapters/explain/
+  ├─ index.ts                       # adapter-aware dispatcher
+  ├─ mysql-mariadb.ts               # EXPLAIN / ANALYZE SELECT → 統一 schema
+  └─ postgresql.ts                  # EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) → 統一 schema
+src/formatters/explain/
+  ├─ markdown.ts                    # | Query | driving | type | key | rows | Extra |
+  ├─ json.ts
+  └─ table.ts                       # 重用既有 TableFormatter
+```
+
+### P2.3 統一 Plan Schema
+
+```typescript
+interface ExplainRow {
+  queryLabel?: string          // bulk mode 才有
+  driving: string              // MySQL table / PG plan node alias
+  accessType: string           // MySQL type / PG node-type
+  key: string | null           // MySQL key / PG index name
+  rows: number                 // 估算列數
+  filtered?: number            // MySQL filtered %
+  extra: string[]              // Using temporary、Sort Method 等
+  cost?: { startup: number, total: number }  // PG only
+  annotations: ExplainAnnotation[]
+}
+
+interface ExplainAnnotation {
+  severity: 'red' | 'yellow' | 'gray'
+  rule: 'full-scan' | 'temp-table' | 'filesort' | 'cost-estimate-skew' | 'nested-loop-large'
+  message: string
+}
+```
+
+### P2.4 Annotation 規則
+
+| 規則 | MySQL/MariaDB 觸發 | PostgreSQL 觸發 | 嚴重度 |
+|---|---|---|---|
+| `full-scan` | `type=ALL` 或 `key=NULL` | `Seq Scan` | red |
+| `temp-table` | `Extra` 含 `Using temporary` | `HashAggregate`/`Sort` over derived | yellow |
+| `filesort` | `Extra` 含 `Using filesort` | `Sort Method: external merge` | yellow |
+| `cost-estimate-skew` | rows vs actual rows 比例 > 10x（需 ANALYZE） | 同樣比例 | gray |
+| `nested-loop-large` | `rows > 10000` 且 access type 為 nested-loop 一側 | `Nested Loop` cost > threshold | yellow |
+
+閾值寫成常數集中於 `src/core/explain/annotate.ts` 開頭，方便日後調整或開放 `--annotation-config` flag。
+
+預設 `--format markdown` 用 `**bold**` / `_italic_` / 灰底；`--format table`（ANSI）才上顏色。
+
+### P2.5 PostgreSQL 細節
+
+`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` 回傳 JSON tree。`src/adapters/explain/postgresql.ts`：
+
+1. 遞迴展開 `Plans[*]` 為 row-per-node
+2. Pick leaf-most relations 當 `driving`
+3. Convert `Node Type` → `accessType`（`Seq Scan` → `ALL`、`Index Scan` → `ref`，建對照表）
+4. `Index Name` → `key`
+
+### P2.6 `--bulk` 來源解析
+
+| 輸入形式 | 處理 |
+|---|---|
+| `@queries.sql` | 讀檔、依 `;` 拆分（忽略 comments） |
+| `@analytics/*` | Saved-queries glob expansion（重用 `src/core/saved-queries`） |
+| `@analytics/live-summary` | 單一 saved query |
+| 多個位置參數 | 多條原始 SQL |
+
+含 `*` 視為 glob；否則先查 saved-queries store；找不到才 fallback 當路徑。每條 query 加 `queryLabel`，markdown 輸出時放表格第一欄。
+
+### P2.7 與 P1 的耦合
+
+P1 已把 `ANALYZE SELECT` / `EXPLAIN ANALYZE` 歸為 read-only。`dbcli explain --analyze` 在 query-only mode 可直接執行，不偷偷升級權限。
+
+### P2 測試
+
+- `tests/unit/core/explain/runner.test.ts`：mock adapter、fake EXPLAIN → 驗證 normalize + annotation
+- `tests/unit/core/explain/bulk-runner.test.ts`：`@file`、glob、多參數展開
+- `tests/unit/adapters/explain/mysql-mariadb.test.ts`：raw EXPLAIN → ExplainRow
+- `tests/unit/adapters/explain/postgresql.test.ts`：PG JSON tree → ExplainRow（含遞迴 fixture 集）
+- `tests/unit/formatters/explain/markdown.test.ts`：標籤色彩、對齊
+- `tests/unit/commands/explain.test.ts`：CLI flag、error path（`--analyze` 對非 SELECT 拒絕）
+- 整合測試:真實 MariaDB/PG 各 3 條代表性 query
+
+### P2 風險
+
+- PG plan tree 遞迴展開：先建多種 fixture（subquery、CTE、partition scan、parallel）再開發
+- Annotation 閾值需 tune：P2 ship 後若必要快速 patch
+- `--bulk` glob 與 saved query 衝突：明確優先序（含 `*` → glob → store → 路徑）
+
+---
+
+## P3 — `dbcli guide missing-index-for` 含 SQL parser
+
+### P3.1 指令介面
+
+```bash
+dbcli guide missing-index-for "SELECT ... FROM betting_logs b JOIN hoster_machines hm ..."
+dbcli guide missing-index-for @analytics/live-summary
+dbcli guide missing-index-for "..." --format yaml      # 預設
+dbcli guide missing-index-for "..." --format json
+dbcli guide missing-index-for "..." --format markdown
+dbcli guide missing-index-for "..." --min-confidence medium
+```
+
+### P3.2 SQL Parser
+
+**選用 `node-sql-parser`**：純 TS、支援 MySQL/PostgreSQL/MariaDB 方言、維護活躍、無 native 相依、Bun 相容。
+
+新增 production 相依：`bun add node-sql-parser`。
+
+替代方案皆不採用：
+- `pgsql-parser`：PG-only
+- 自寫 mini-parser：成本高、風險大（feedback 原文已警示）
+- `sql-parser-cst`：AST 過於低階
+
+### P3.3 架構
+
+```
+src/core/guide/missing-index/
+  ├─ types.ts                    # IndexCandidate、QueryAnalysis、AnalysisWarning
+  ├─ analyzer.ts                 # 主控:parse → enrich → score → output
+  ├─ sql-extractor.ts            # AST → 結構化 column refs
+  ├─ explain-enricher.ts         # 跑 P2 explain 拿真實 plan
+  ├─ index-introspector.ts       # information_schema / pg_indexes
+  ├─ candidate-builder.ts        # 推複合索引
+  ├─ scorer.ts                   # confidence + reason
+  └─ warnings.ts                 # 函式索引、type cast 警告
+
+src/formatters/guide/
+  ├─ missing-index-yaml.ts
+  ├─ missing-index-json.ts
+  └─ missing-index-markdown.ts
+```
+
+### P3.4 分析流程
+
+```
+[1] node-sql-parser → AST
+      失敗 → fallback：僅做 EXPLAIN 啟發式 + warning
+[2] sql-extractor 抽出每個 table 的：
+      - filter columns（WHERE / HAVING）
+      - join columns（ON 兩側）
+      - order columns（ORDER BY / GROUP BY）
+      - functional columns（DATE(x)、UPPER(x) → warning）
+[3] explain-enricher：呼叫 P2 explain runner 拿 access type / key / rows / Extra
+[4] index-introspector 抓現有索引：
+      MySQL/MariaDB: information_schema.STATISTICS
+      PostgreSQL: pg_indexes + pg_index
+[5] candidate-builder 對每個 table 產候選複合索引
+      排序:equality > range > order/group
+      覆蓋:JOIN column 後接 WHERE column
+[6] scorer：
+      high   = type=ALL + 候選完整覆蓋 WHERE+JOIN
+      medium = 部分覆蓋 或 既有單列索引可改成複合
+      low    = 啟發式推測
+[7] warnings 收集（含 parser-limit 提示）
+```
+
+### P3.5 輸出範例
+
+```yaml
+query: "SELECT ... FROM betting_logs b JOIN hoster_machines hm ..."
+candidates:
+  - table: betting_logs
+    columns: [user_id, settled_at]
+    reason: |
+      WHERE b.settled_at >= ? 與 JOIN b.user_id = hm.user_id；
+      目前 access_type=ref (key=user_id_index)，settled_at 仍需 filter pass。
+      複合索引可把 filtered % 從 ~20% 推到接近 100%。
+    confidence: high
+    existing_index_collision: null
+    estimated_rows_reduction: "546 → ~50 (per user × time window)"
+  - table: hoster_machines
+    columns: [hoster_space_id, user_id]
+    reason: |
+      hm 走 type=ALL（rows=20），hoster_space_id 過濾後仍需 user_id 給 nested loop join。
+    confidence: medium
+warnings:
+  - rule: functional-expression
+    column: settled_at
+    detail: |
+      GROUP BY DATE(settled_at) 使用函式 → 索引無法避免 filesort。
+      考慮 (1) MariaDB generated column + 索引 (2) 改用範圍 WHERE。
+  - rule: parser-limit
+    detail: window function 在 SELECT clause；分析範圍限於 WHERE/JOIN/ORDER。
+```
+
+### P3.6 邊界與限制（明確 docs 揭露）
+
+- 支援單一 SELECT；不分析 INSERT/UPDATE/DELETE 子查詢
+- 不分析 stored procedure、view 內 SQL
+- functional / partial index 只標 warning，不主動建議（留 v1.24+）
+- 跨方言以 node-sql-parser 支援為準；不支援方言走 fallback
+
+### P3 測試
+
+- `tests/unit/core/guide/missing-index/sql-extractor.test.ts`：各種 WHERE/JOIN/ORDER BY pattern
+- `tests/unit/core/guide/missing-index/candidate-builder.test.ts`：fixture 進、候選出
+- `tests/unit/core/guide/missing-index/scorer.test.ts`：信心度判定
+- `tests/unit/core/guide/missing-index/warnings.test.ts`：函式索引 / type cast
+- `tests/unit/core/guide/missing-index/analyzer.test.ts`：end-to-end with mocked adapter
+- 整合測試:對真實 MariaDB/PG 跑 feedback 文件提到的 live-report query，驗證輸出與人工分析接近
+
+### P3 風險
+
+- node-sql-parser 方言邊界（如 MariaDB `ANALYZE SELECT`、JSON path） → fallback 模式
+- 建議「正確性」評估：輸出永遠帶 `confidence` 與 `reason`，不寫「應該建立」斷言
+- 效能:對長 query parse + explain + introspect 可能 > 1 秒；加 timeout protection
+- PG vs MySQL 索引語意差異（partial / expression）：輸出語法用兩段註記避免混淆
+
+---
+
+## P4 — `dbcli inspect` suggestedCommands 強化
+
+### P4.1 改動範圍
+
+| 檔案 | 改動 |
+|---|---|
+| `src/core/inspect/suggest-commands.ts` | 主要邏輯：擴展候選命令 |
+| `src/core/inspect/types.ts` | `InspectSnapshot` 新增 `hints: string[]` |
+| `src/core/inspect/collector.ts` | 收集 `auditRecent`、task pack 數量 |
+| `src/core/inspect/render-json.ts` | 序列化 `hints` |
+| `src/core/inspect/render-markdown.ts` | human-readable footer |
+
+### P4.2 三層加權邏輯
+
+```typescript
+function suggestCommands(snap, opts): string[] {
+  const out: string[] = []
+
+  // Tier 1 — bootstrap（既有）
+  if (isSql && (!snap.schemaCache.available || snap.schemaCache.stale)) {
+    out.push('dbcli schema --refresh')
+  }
+  out.push('dbcli list --format json')
+
+  // Tier 2 — context-aware（NEW）
+  const topTable = snap.auditRecent?.topTables?.[0]
+  if (topTable && taskPacksAvailable(snap)) {
+    out.push(`dbcli skill tasks plan analyze-table-perf --param table=${topTable}`)
+  }
+
+  const topIntent = snap.snippets.intents[0]
+  if (topIntent) {
+    const prefix = topIntent.intent.split('.')[0]
+    out.push(`dbcli queries suggest ${prefix} --format json`)
+  }
+
+  // Tier 3 — discovery（NEW）
+  if (taskPacksAvailable(snap) && !alreadySeenTaskPacks(snap)) {
+    out.push('dbcli skill tasks list')
+  }
+
+  out.push('dbcli doctor --format json')
+
+  const cap = opts.brief ? 1 : 5
+  return out.slice(0, cap)
+}
+```
+
+### P4.3 新 `hints` 欄位
+
+`InspectSnapshot` 加 `hints: string[]`，與 `suggestedCommands` 平行。`hints` 是「文字提示」，`suggestedCommands` 是「可執行命令」。
+
+JSON 範例：
+
+```json
+{
+  "suggestedCommands": [
+    "dbcli schema --refresh",
+    "dbcli skill tasks plan analyze-table-perf --param table=betting_logs",
+    "dbcli skill tasks list"
+  ],
+  "hints": [
+    "Most queried table in last 5 runs: betting_logs",
+    "21 task packs available — run `dbcli skill tasks list` to browse",
+    "Schema cache: 115 tables, last refreshed 2 hours ago"
+  ]
+}
+```
+
+### P4.4 Human-readable footer
+
+`render-markdown.ts` 在最後加 footer（只在 task pack 存在時）：
+
+```
+─────────────────────────────────────
+Tip: 21 task packs available.
+Run `dbcli skill tasks list` to browse.
+─────────────────────────────────────
+```
+
+### P4.5 Top-table 抽取
+
+**來源**：既有 audit log（`.dbcli/audit/`）
+
+**演算法**：
+1. 讀近 10 條 entries（既有 reader）
+2. 對每條抽 `tableName`（重用 `extractTableName` from `engine-hints.ts`）
+3. 計數，回傳 top-1
+
+audit 為空 / 全部抽不出表 → 跳過 Tier 2 第一條建議，不報錯。
+
+### P4.6 Task pack 偵測
+
+- `taskPacksAvailable(snap)`：呼叫 `src/core/agent-tasks/` 既有 registry 拿數量
+- `alreadySeenTaskPacks(snap)`：偵測最近 audit 是否已有 `dbcli skill tasks` invocation；若有則不再推薦（避免重複）
+
+### P4.7 相容性
+
+- `--brief` 行為不變（仍只回 1 條）
+- `--for-agent` JSON shape 向後相容（既有 consumer 只讀 `suggestedCommands`，新增 `hints` 不 break）
+- 5 條 cap 維持
+
+### P4 測試
+
+- `tests/unit/core/inspect/suggest-commands.test.ts`：
+  - 有 audit + task pack → 推 `analyze-table-perf`
+  - 沒 audit → 跳過 Tier 2
+  - 已 seen task packs → 不推 `tasks list`
+  - `--brief` 仍只回 1 條
+- `tests/unit/core/inspect/collector.test.ts`：`auditRecent.topTables` 抽取
+- `tests/unit/core/inspect/render-markdown.test.ts`：footer 時機
+- 整合測試:JSON shape
+
+### P4 風險
+
+- Audit log 讀取效能：每次 inspect 都讀近 10 條；既有 cache 應已夠用，但需 benchmark gate（> 200ms 不准 merge）
+- Task pack registry 載入：若延遲載入，inspect 觸發冷啟動成本 → 加 lightweight count API（只回數字不載入 metadata）
+
+---
+
+## 全體測試與 Release 策略
+
+### 測試門檻
+
+- 各 phase 完成時 unit + integration 全綠
+- Coverage 維持專案既定門檻
+- P2/P3 額外跑 real-DB 整合測試（docker compose 起 MariaDB + PostgreSQL）
+
+### Backward Compatibility
+
+- P1 全部是放寬或訊息改善，無 breaking
+- P2 新增指令，不動現有 `dbcli query "EXPLAIN ..."`
+- P3 新增 sub-command，不動 `dbcli guide index-usage`
+- P4 既有 `suggestedCommands` shape 不變，只擴內容；新增 `hints` 是 additive
+
+### Release Flow
+
+1. P1 PR → review → merge → tag `v1.23.0-alpha.1`
+2. P2 PR → review → merge → tag `v1.23.0-alpha.2`
+3. P3 PR → review → merge → tag `v1.23.0-beta.1`
+4. P4 PR → review → merge → tag `v1.23.0`
+5. Final：`docs/user/{en,zh-TW}/{index.md,index.html}` 同步更新（依專案 mandate）
+
+### 整體風險摘要
+
+| 風險 | 影響 | 緩解 |
+|---|---|---|
+| `node-sql-parser` 方言邊界 | P3 部分 query 走 fallback | docs 明確揭露；fallback 仍給 EXPLAIN 啟發式 |
+| PG plan tree 遞迴複雜度 | P2 開發時程拉長 | 先建 fixture 集再開發 |
+| Annotation 閾值需 tune | P2 早期使用者抱怨「黃太多/少」 | 閾值集中常數管理；ship 後快速 patch |
+| Audit log 效能 | P4 inspect 變慢 | benchmark gate > 200ms 不准 merge |
+| node-sql-parser 套件依賴新增 | 攻擊面、bundle size | 已是廣泛使用套件；P3 PR 含 npm-audit gate |
+
+## Open Questions
+
+- **Annotation 閾值是否做 config**：v1.23 先固定常數；若 ship 後反饋需要再加 `--annotation-config`。
+- **`--from-diff` 是否提前到 v1.23 P2.5**：暫不；等 P2 ship 後看實際使用頻率。
+- **P3 fallback mode 的輸出格式**：目前設計為「同樣的 schema 但 `candidates=[]`、`warnings` 含 parser-limit」；待 P3 實作時驗證可讀性。

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -97,6 +97,7 @@
                     <li class="nav-item"><a href="#engines" class="nav-link">Engine Support</a></li>
                     <li class="nav-item"><a href="#ai" class="nav-link">AI Integration</a></li>
                     <li class="nav-item"><a href="#agent-recovery" class="nav-link">Agent Recovery</a></li>
+                    <li class="nav-item"><a href="#error-classification" class="nav-link">Errors & Auto-LIMIT</a></li>
                     <li class="nav-item"><a href="#documentation-maintenance" class="nav-link">Doc Maintenance</a></li>
                 </ul>
             </section>
@@ -481,6 +482,30 @@ dbcli recover --next --after-step 2 --result @/tmp/r2.json
                     <tr><td><code>3</code></td><td>Every step was skipped by the gate — widen <code>--allow-write</code> or fill placeholders, then retry</td></tr>
                 </tbody>
             </table>
+        </section>
+
+        <!-- doc-key: error-classification -->
+        <section id="error-classification" class="mt-20">
+            <h2>Troubleshooting & Error Reference</h2>
+
+            <h3>Error categories</h3>
+            <p><code>dbcli</code> distinguishes between <strong>connection errors</strong> (server down, auth failed) and <strong>SQL errors</strong> (syntax, missing table, missing column). SQL errors now print:</p>
+            <ul>
+                <li>The specific problem (not "Connection failed")</li>
+                <li>A hint pointing to the right next command (<code>dbcli list</code>, <code>dbcli schema &lt;table&gt;</code>, <code>--no-limit</code>)</li>
+                <li>For missing tables, top-3 fuzzy-match candidates</li>
+            </ul>
+
+            <h3>Query-only mode auto-LIMIT</h3>
+            <p><code>dbcli</code> auto-appends <code>LIMIT 1000</code> to <code>SELECT</code> queries in <code>query-only</code> mode. This <strong>does not</strong> apply to:</p>
+            <ul>
+                <li><code>SHOW</code> / <code>DESCRIBE</code> statements (LIMIT is not valid syntax here)</li>
+                <li><code>EXPLAIN</code> / <code>EXPLAIN ANALYZE</code> / MariaDB <code>ANALYZE SELECT</code></li>
+            </ul>
+            <p>Use <code>--no-limit</code> on <code>SELECT</code> to disable when querying <code>information_schema</code>.</p>
+
+            <h3>Schema cache bootstrap</h3>
+            <p>The first <code>dbcli schema --refresh</code> after init writes the cache without <code>--force</code>. Subsequent refreshes that detect changes against an existing cache still require <code>--force</code> to overwrite.</p>
         </section>
 
         <!-- doc-key: documentation-maintenance -->

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -442,6 +442,36 @@ dbcli recover --from /path/to/archived.json   # cross-machine / archived replay
 
 ---
 
+<!-- doc-key: error-classification -->
+## Troubleshooting & Error Reference
+
+### Error categories
+
+`dbcli` distinguishes between **connection errors** (server down, auth failed) and
+**SQL errors** (syntax, missing table, missing column). SQL errors now print:
+
+- The specific problem (not "Connection failed")
+- A hint pointing to the right next command (`dbcli list`, `dbcli schema <table>`, `--no-limit`)
+- For missing tables, top-3 fuzzy-match candidates
+
+### Query-only mode auto-LIMIT
+
+`dbcli` auto-appends `LIMIT 1000` to `SELECT` queries in `query-only` mode. This
+**does not** apply to:
+
+- `SHOW` / `DESCRIBE` statements (LIMIT is not valid syntax here)
+- `EXPLAIN` / `EXPLAIN ANALYZE` / MariaDB `ANALYZE SELECT`
+
+Use `--no-limit` on `SELECT` to disable when querying `information_schema`.
+
+### Schema cache bootstrap
+
+The first `dbcli schema --refresh` after init writes the cache without `--force`.
+Subsequent refreshes that detect changes against an existing cache still require
+`--force` to overwrite.
+
+---
+
 <!-- doc-key: documentation-maintenance -->
 ## Documentation Maintenance & Coverage
 

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -97,6 +97,7 @@
                     <li class="nav-item"><a href="#engines" class="nav-link">引擎支援</a></li>
                     <li class="nav-item"><a href="#ai" class="nav-link">AI 代理整合</a></li>
                     <li class="nav-item"><a href="#agent-recovery" class="nav-link">Agent 修復工作流</a></li>
+                    <li class="nav-item"><a href="#error-classification" class="nav-link">錯誤與 Auto-LIMIT</a></li>
                     <li class="nav-item"><a href="#documentation-maintenance" class="nav-link">文件維護</a></li>
                 </ul>
             </section>
@@ -481,6 +482,30 @@ dbcli recover --next --after-step 2 --result @/tmp/r2.json
                     <tr><td><code>3</code></td><td>所有步驟都被 gate 跳過（widen <code>--allow-write</code> 或填上 placeholder 再試）</td></tr>
                 </tbody>
             </table>
+        </section>
+
+        <!-- doc-key: error-classification -->
+        <section id="error-classification" class="mt-20">
+            <h2>疑難排解與錯誤參考</h2>
+
+            <h3>錯誤分類</h3>
+            <p><code>dbcli</code> 區分<strong>連線錯誤</strong>（server 沒起、認證失敗）與 <strong>SQL 錯誤</strong>（語法錯、table/column 不存在）。SQL 錯誤現在會印：</p>
+            <ul>
+                <li>具體問題（不再印 "Connection failed"）</li>
+                <li>指向正確下一步的 hint（<code>dbcli list</code>、<code>dbcli schema &lt;table&gt;</code>、<code>--no-limit</code>）</li>
+                <li>對 table 不存在，附上 top-3 fuzzy 候選</li>
+            </ul>
+
+            <h3>Query-only auto-LIMIT 範圍</h3>
+            <p><code>dbcli</code> 會在 <code>query-only</code> 模式對 <code>SELECT</code> 自動加 <code>LIMIT 1000</code>。<strong>不</strong>套用於：</p>
+            <ul>
+                <li><code>SHOW</code> / <code>DESCRIBE</code> 語句（LIMIT 在此非合法語法）</li>
+                <li><code>EXPLAIN</code> / <code>EXPLAIN ANALYZE</code> / MariaDB <code>ANALYZE SELECT</code></li>
+            </ul>
+            <p>查 <code>information_schema</code> 時用 <code>--no-limit</code> 關閉。</p>
+
+            <h3>Schema cache bootstrap</h3>
+            <p>第一次 <code>dbcli schema --refresh</code> 不需 <code>--force</code> 即會寫入 cache。後續 refresh 偵測到既有 cache 有 diff 才會要求 <code>--force</code>。</p>
         </section>
 
         <!-- doc-key: documentation-maintenance -->

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -440,6 +440,32 @@ dbcli recover --from /path/to/archived.json   # 跨機器/歸檔重播
 
 ---
 
+<!-- doc-key: error-classification -->
+## 疑難排解與錯誤參考
+
+### 錯誤分類
+
+`dbcli` 區分**連線錯誤**(server 沒起、認證失敗)與 **SQL 錯誤**(語法錯、table/column 不存在)。SQL 錯誤現在會印:
+
+- 具體問題(不再印 "Connection failed")
+- 指向正確下一步的 hint(`dbcli list`、`dbcli schema <table>`、`--no-limit`)
+- 對 table 不存在,附上 top-3 fuzzy 候選
+
+### Query-only auto-LIMIT 範圍
+
+`dbcli` 會在 `query-only` 模式對 `SELECT` 自動加 `LIMIT 1000`。**不**套用於:
+
+- `SHOW` / `DESCRIBE` 語句(LIMIT 在此非合法語法)
+- `EXPLAIN` / `EXPLAIN ANALYZE` / MariaDB `ANALYZE SELECT`
+
+查 `information_schema` 時用 `--no-limit` 關閉。
+
+### Schema cache bootstrap
+
+第一次 `dbcli schema --refresh` 不需 `--force` 即會寫入 cache。後續 refresh 偵測到既有 cache 有 diff 才會要求 `--force`。
+
+---
+
 <!-- doc-key: documentation-maintenance -->
 ## 文件維護與覆蓋範圍
 

--- a/src/adapters/error-mapper.ts
+++ b/src/adapters/error-mapper.ts
@@ -95,6 +95,25 @@ export function mapError(
     ])
   }
 
+  // SQL_SYNTAX_ERROR: driver returned a parse error from execute() (not connect()).
+  // MySQL/MariaDB: code='ER_PARSE_ERROR' / errno=1064
+  // PostgreSQL: code='42601' (SQLSTATE syntax_error)
+  if (
+    errCode === 'ER_PARSE_ERROR' ||
+    err?.errno === 1064 ||
+    errCode === '42601'
+  ) {
+    return new ConnectionError(
+      'SQL_SYNTAX_ERROR',
+      `SQL syntax error: ${errMsg}`,
+      [
+        'Check your SQL syntax near the position reported above',
+        'In query-only mode, dbcli auto-appends LIMIT 1000; use --no-limit to disable',
+        'For SHOW/DESCRIBE/EXPLAIN statements, LIMIT is not allowed — these are not auto-limited',
+      ]
+    )
+  }
+
   // UNKNOWN: Fallback for unrecognized errors
   return new ConnectionError('UNKNOWN', `Connection failed: ${errMsg}`, [
     `Check connection parameters: host=${options.host}, port=${options.port}, user=${options.user}`,

--- a/src/adapters/error-mapper.ts
+++ b/src/adapters/error-mapper.ts
@@ -60,6 +60,30 @@ export function mapError(
     )
   }
 
+  // TABLE_NOT_FOUND: server rejected query because referenced table doesn't exist.
+  // MySQL/MariaDB: code='ER_NO_SUCH_TABLE' / errno=1146
+  // PostgreSQL: code='42P01' (SQLSTATE undefined_table)
+  if (
+    errCode === 'ER_NO_SUCH_TABLE' ||
+    err?.errno === 1146 ||
+    errCode === '42P01'
+  ) {
+    // Extract table name from message:
+    //  - MySQL: Table 'db.tablename' doesn't exist
+    //  - PG:    relation "tablename" does not exist
+    const mysqlMatch = errMsg.match(/Table\s+'(?:[^.']+\.)?([^']+)'/i)
+    const pgMatch = errMsg.match(/relation\s+"([^"]+)"/i)
+    const tableName = mysqlMatch?.[1] || pgMatch?.[1] || 'unknown'
+    return new ConnectionError(
+      'TABLE_NOT_FOUND',
+      `Table '${tableName}' not found in database '${options.database || 'unknown'}'`,
+      [
+        'Run `dbcli list` to see available tables',
+        'Run `dbcli schema <table>` to confirm the exact name (ORM export names may differ from DB table names)',
+      ]
+    )
+  }
+
   // AUTH_FAILED: Authentication (credentials) error
   if (
     errMsg.includes('authentication') ||

--- a/src/adapters/error-mapper.ts
+++ b/src/adapters/error-mapper.ts
@@ -84,6 +84,27 @@ export function mapError(
     )
   }
 
+  // COLUMN_NOT_FOUND: referenced column doesn't exist on the table.
+  // MySQL/MariaDB: code='ER_BAD_FIELD_ERROR' / errno=1054
+  // PostgreSQL: code='42703' (SQLSTATE undefined_column)
+  if (
+    errCode === 'ER_BAD_FIELD_ERROR' ||
+    err?.errno === 1054 ||
+    errCode === '42703'
+  ) {
+    const mysqlMatch = errMsg.match(/Unknown column\s+'([^']+)'/i)
+    const pgMatch = errMsg.match(/column\s+"([^"]+)"\s+does not exist/i)
+    const columnName = mysqlMatch?.[1] || pgMatch?.[1] || 'unknown'
+    return new ConnectionError(
+      'COLUMN_NOT_FOUND',
+      `Column '${columnName}' not found`,
+      [
+        'Run `dbcli schema <table>` to see the actual column names',
+        'Column names are case-sensitive on some databases (PostgreSQL with quoted identifiers)',
+      ]
+    )
+  }
+
   // AUTH_FAILED: Authentication (credentials) error
   if (
     errMsg.includes('authentication') ||

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -127,7 +127,15 @@ export interface TableSchema {
 export class ConnectionError extends Error {
   constructor(
     /** Error category code */
-    public code: 'ECONNREFUSED' | 'ETIMEDOUT' | 'AUTH_FAILED' | 'ENOTFOUND' | 'UNKNOWN',
+    public code:
+      | 'ECONNREFUSED'
+      | 'ETIMEDOUT'
+      | 'AUTH_FAILED'
+      | 'ENOTFOUND'
+      | 'SQL_SYNTAX_ERROR'
+      | 'TABLE_NOT_FOUND'
+      | 'COLUMN_NOT_FOUND'
+      | 'UNKNOWN',
     /** User-friendly error message */
     message: string,
     /** Array of actionable troubleshooting hints */

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -18,6 +18,7 @@ import { writeAuditEntry } from '@/core/audit/integration-helper'
 import type { TableSchema, DatabaseAdapter, ColumnSchema } from '@/adapters/types'
 import type { DbcliConfig } from '@/utils/validation'
 import { validateFormat } from '@/utils/validation'
+import { suggestTableName } from '@/utils/error-suggester'
 import { compilePatterns, matchAny } from '@/core/mongo/path-matcher'
 import type { BlacklistConfig } from '@/types/blacklist'
 
@@ -52,6 +53,30 @@ function decorateMongoSchema(schema: TableSchema, meta: MongoDecorateMeta): Tabl
 }
 
 import { resolveConfigPath } from '@/utils/config-path'
+
+/**
+ * Enrich a TABLE_NOT_FOUND ConnectionError with fuzzy-match suggestions.
+ * Pure pass-through for any other error code. Safe to call on every catch path.
+ */
+export async function attachTableSuggestions(
+  err: ConnectionError,
+  adapter: DatabaseAdapter,
+  attemptedName: string
+): Promise<ConnectionError> {
+  if (err.code !== 'TABLE_NOT_FOUND') return err
+  try {
+    const { suggestions } = await suggestTableName(
+      `Table '${attemptedName}' doesn't exist`,
+      adapter
+    )
+    if (suggestions.length === 0) return err
+    const suggestionLine = `Did you mean: ${suggestions.join(', ')}?`
+    return new ConnectionError(err.code, err.message, [...err.hints, suggestionLine])
+  } catch {
+    // If listing tables itself fails (e.g. permission), don't mask the original error.
+    return err
+  }
+}
 
 const ALLOWED_FORMATS = ['table', 'json'] as const
 
@@ -347,7 +372,15 @@ async function handleSingleTableSchema(
   inferenceOptions?: { sampleSize?: number; sampleMethod?: 'random' | 'natural' },
   mongoMeta?: MongoDecorateMeta
 ): Promise<void> {
-  let schema = await adapter.getTableSchema(tableName, inferenceOptions)
+  let schema: TableSchema
+  try {
+    schema = await adapter.getTableSchema(tableName, inferenceOptions)
+  } catch (error) {
+    if (error instanceof ConnectionError) {
+      throw await attachTableSuggestions(error, adapter, tableName)
+    }
+    throw error
+  }
   if (mongoMeta) schema = decorateMongoSchema(schema, mongoMeta)
 
   if (format === 'json') {

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -433,7 +433,7 @@ async function handleSingleTableSchema(
 /**
  * Handles schema refresh - detects incremental changes and applies them
  */
-async function handleSchemaRefresh(
+export async function handleSchemaRefresh(
   adapter: DatabaseAdapter,
   config: DbcliConfig,
   options: { config: string; refresh: boolean; force: boolean },
@@ -468,10 +468,14 @@ async function handleSchemaRefresh(
   console.log('🔍 Schema changes detected:')
   console.log(`   ${report.summary}`)
 
-  // Require --force to apply
-  if (!options.force) {
+  // First-time bootstrap: no existing cache to protect, skip --force gate.
+  const isFirstTime = Object.keys(config.schema || {}).length === 0
+  if (!options.force && !isFirstTime) {
     console.log('   Use --force to apply changes')
     return
+  }
+  if (isFirstTime) {
+    console.log('   First-time bootstrap (no existing cache to protect)')
   }
 
   // Build new schema object with all table entries
@@ -500,7 +504,13 @@ async function handleSchemaRefresh(
   // Wave 1 Integration: Persist to layered storage
   const writer = new SchemaWriter(storagePath)
   await writer.save(newSchema, connectionName)
-  console.log(`✅ Schema persisted to layered storage (.dbcli/schemas/${connectionName || ''})`)
+  if (isFirstTime) {
+    console.log(`✅ Schema cache initialised (${Object.keys(newSchema).length} tables)`)
+  } else {
+    console.log(
+      `✅ Schema updated (${report.tablesAdded.length} added / ${report.tablesRemoved.length} removed / ${Object.keys(report.tablesModified).length} modified)`
+    )
+  }
 
   await writeSchema(storagePath, updatedConfig, connectionName)
   console.log(`✅ Schema updated in .dbcli`)

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -344,6 +344,20 @@ export function classifyStatement(sql: string): StatementClassification {
   const stripped = stripCommentsAndStrings(normalized)
   const upper = stripped.toUpperCase()
 
+  // MariaDB/MySQL: 'ANALYZE SELECT ...' is a read-only EXPLAIN variant.
+  // PostgreSQL uses 'EXPLAIN (ANALYZE ...) SELECT ...' which is handled by
+  // the regular EXPLAIN keyword classifier; this branch only handles the
+  // MariaDB form where ANALYZE is the leading keyword.
+  if (/^\s*ANALYZE\s+SELECT\b/i.test(stripped)) {
+    return {
+      type: 'EXPLAIN',
+      isDangerous: false,
+      keywords: extractAllKeywords(stripped),
+      isComposite: false,
+      confidence: 'HIGH',
+    }
+  }
+
   const composite = detectCompositePatterns(upper)
   const firstKeyword = extractFirstKeyword(stripped)
 

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -432,9 +432,12 @@ export function checkPermission(sql: string, permission: Permission): Permission
         classification,
       }
     }
+    const isUnknown = classification.type === 'UNKNOWN'
     return {
       allowed: false,
-      reason: `${classification.type} operation requires read-write or admin permission`,
+      reason: isUnknown
+        ? `Unrecognised SQL statement (current level: query-only). Security policy requires read-write+ for unknown statements. If this is a legitimate read-only statement, please open an issue at https://github.com/CarlLee1983/dbcli/issues.`
+        : `${classification.type} operation requires read-write or admin permission`,
       classification,
     }
   }

--- a/src/core/query-executor.ts
+++ b/src/core/query-executor.ts
@@ -55,10 +55,15 @@ export class QueryExecutor {
         console.error(`⚠ Warning: executing ${classification.type} operation (admin mode)`)
       }
 
-      // 2. Auto-limit in query-only mode (safety default)
+      // 2. Auto-limit in query-only mode (safety default).
+      // Only applies to SELECT — SHOW/DESCRIBE/EXPLAIN do not accept LIMIT and
+      // server rejects with a syntax error. Classification was already computed
+      // by enforcePermission() above.
+      const AUTO_LIMIT_TYPES = new Set(['SELECT'])
       let executeSql = sql
       if (
         this.permission === 'query-only' &&
+        AUTO_LIMIT_TYPES.has(classification.type) &&
         !executeSql.match(/LIMIT\s+\d+/i) &&
         options?.autoLimit !== false
       ) {

--- a/tests/integration/p1-error-classification.test.ts
+++ b/tests/integration/p1-error-classification.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { AdapterFactory } from '@/adapters'
+import type { DatabaseAdapter, SqlConnectionOptions } from '@/adapters/types'
+import { QueryExecutor } from '@/core/query-executor'
+import { ConnectionError } from '@/adapters/types'
+
+const MARIADB_AVAILABLE =
+  !!process.env.TEST_MARIADB_HOST || !!process.env.TEST_MARIADB_DSN
+
+const MARIADB_OPTS: SqlConnectionOptions = {
+  system: 'mariadb',
+  host: process.env.TEST_MARIADB_HOST || 'localhost',
+  port: Number(process.env.TEST_MARIADB_PORT || 3306),
+  user: process.env.TEST_MARIADB_USER || 'root',
+  password: process.env.TEST_MARIADB_PASSWORD || '',
+  database: process.env.TEST_MARIADB_DB || 'test',
+}
+
+const PG_AVAILABLE = !!process.env.TEST_POSTGRESQL_HOST
+
+const PG_OPTS: SqlConnectionOptions = {
+  system: 'postgresql',
+  host: process.env.TEST_POSTGRESQL_HOST || 'localhost',
+  port: Number(process.env.TEST_POSTGRESQL_PORT || 5432),
+  user: process.env.TEST_POSTGRESQL_USER || 'postgres',
+  password: process.env.TEST_POSTGRESQL_PASSWORD || '',
+  database: process.env.TEST_POSTGRESQL_DB || 'postgres',
+}
+
+describe.skipIf(!MARIADB_AVAILABLE)('P1: error classification (MariaDB)', () => {
+  let adapter: DatabaseAdapter
+
+  beforeAll(async () => {
+    adapter = AdapterFactory.createSqlAdapter(MARIADB_OPTS)
+    await adapter.connect()
+  })
+
+  afterAll(async () => {
+    if (adapter) await adapter.disconnect()
+  })
+
+  test('SHOW TABLES is NOT rejected in query-only mode', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await expect(exec.execute('SHOW TABLES')).resolves.toBeDefined()
+  })
+
+  test('SELECT against unknown table → TABLE_NOT_FOUND', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    try {
+      await exec.execute('SELECT * FROM definitely_does_not_exist_xyz')
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectionError)
+      expect((err as ConnectionError).code).toBe('TABLE_NOT_FOUND')
+    }
+  })
+
+  test('ANALYZE SELECT is allowed in query-only mode', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await expect(exec.execute('ANALYZE SELECT 1')).resolves.toBeDefined()
+  })
+})
+
+describe.skipIf(!PG_AVAILABLE)('P1: error classification (PostgreSQL)', () => {
+  let adapter: DatabaseAdapter
+
+  beforeAll(async () => {
+    adapter = AdapterFactory.createSqlAdapter(PG_OPTS)
+    await adapter.connect()
+  })
+
+  afterAll(async () => {
+    if (adapter) await adapter.disconnect()
+  })
+
+  test('SELECT against unknown relation → TABLE_NOT_FOUND', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    try {
+      await exec.execute('SELECT * FROM definitely_does_not_exist_xyz')
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectionError)
+      expect((err as ConnectionError).code).toBe('TABLE_NOT_FOUND')
+    }
+  })
+
+  test('EXPLAIN (ANALYZE, BUFFERS) SELECT is allowed in query-only mode', async () => {
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await expect(exec.execute('EXPLAIN (ANALYZE, BUFFERS) SELECT 1')).resolves.toBeDefined()
+  })
+})

--- a/tests/unit/adapters/error-mapper.test.ts
+++ b/tests/unit/adapters/error-mapper.test.ts
@@ -134,3 +134,33 @@ test('mapError: SQL_SYNTAX_ERROR does NOT include connection-troubleshooting hin
   expect(hints).not.toContain('mysql.log')
   expect(hints).not.toContain('host=')
 })
+
+test('mapError: MySQL ER_NO_SUCH_TABLE (1146) → TABLE_NOT_FOUND', () => {
+  const error = {
+    code: 'ER_NO_SUCH_TABLE',
+    errno: 1146,
+    message: "Table 'station_local.bets' doesn't exist",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb', database: 'station_local' })
+  expect(result.code).toBe('TABLE_NOT_FOUND')
+  expect(result.message).toContain('bets')
+  expect(result.message).toContain('station_local')
+  expect(result.hints.join(' ')).toContain('dbcli list')
+})
+
+test('mapError: PostgreSQL undefined_table (42P01) → TABLE_NOT_FOUND', () => {
+  const error = {
+    code: '42P01',
+    message: 'relation "bets" does not exist',
+  }
+  const result = mapError(error, 'postgresql', { ...mockOptions, database: 'testdb' })
+  expect(result.code).toBe('TABLE_NOT_FOUND')
+  expect(result.message).toContain('bets')
+  expect(result.hints.join(' ')).toContain('dbcli list')
+})
+
+test('mapError: TABLE_NOT_FOUND does NOT include connection-troubleshooting hints', () => {
+  const error = { code: 'ER_NO_SUCH_TABLE', errno: 1146, message: "Table 'x.y' doesn't exist" }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.hints.join(' ')).not.toContain('mysql.log')
+})

--- a/tests/unit/adapters/error-mapper.test.ts
+++ b/tests/unit/adapters/error-mapper.test.ts
@@ -88,3 +88,18 @@ test('mapError works for all database systems', () => {
   expect(mysqlResult.code).toBe('ECONNREFUSED')
   expect(mariadbResult.code).toBe('ECONNREFUSED')
 })
+
+test('ConnectionError accepts SQL_SYNTAX_ERROR code', () => {
+  const err = new ConnectionError('SQL_SYNTAX_ERROR', 'msg', ['hint'])
+  expect(err.code).toBe('SQL_SYNTAX_ERROR')
+})
+
+test('ConnectionError accepts TABLE_NOT_FOUND code', () => {
+  const err = new ConnectionError('TABLE_NOT_FOUND', 'msg', ['hint'])
+  expect(err.code).toBe('TABLE_NOT_FOUND')
+})
+
+test('ConnectionError accepts COLUMN_NOT_FOUND code', () => {
+  const err = new ConnectionError('COLUMN_NOT_FOUND', 'msg', ['hint'])
+  expect(err.code).toBe('COLUMN_NOT_FOUND')
+})

--- a/tests/unit/adapters/error-mapper.test.ts
+++ b/tests/unit/adapters/error-mapper.test.ts
@@ -103,3 +103,34 @@ test('ConnectionError accepts COLUMN_NOT_FOUND code', () => {
   const err = new ConnectionError('COLUMN_NOT_FOUND', 'msg', ['hint'])
   expect(err.code).toBe('COLUMN_NOT_FOUND')
 })
+
+test('mapError: MySQL ER_PARSE_ERROR (1064) → SQL_SYNTAX_ERROR', () => {
+  const error = {
+    code: 'ER_PARSE_ERROR',
+    errno: 1064,
+    message:
+      "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'LIMIT 1000' at line 1",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.code).toBe('SQL_SYNTAX_ERROR')
+  expect(result.message.toLowerCase()).toContain('sql syntax')
+  expect(result.hints.join(' ')).toContain('--no-limit')
+})
+
+test('mapError: PostgreSQL syntax_error (42601) → SQL_SYNTAX_ERROR', () => {
+  const error = {
+    code: '42601',
+    message: 'syntax error at or near "FROOM"',
+  }
+  const result = mapError(error, 'postgresql', mockOptions)
+  expect(result.code).toBe('SQL_SYNTAX_ERROR')
+  expect(result.message.toLowerCase()).toContain('sql syntax')
+})
+
+test('mapError: SQL_SYNTAX_ERROR does NOT include connection-troubleshooting hints', () => {
+  const error = { code: 'ER_PARSE_ERROR', errno: 1064, message: 'bad syntax' }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  const hints = result.hints.join(' ')
+  expect(hints).not.toContain('mysql.log')
+  expect(hints).not.toContain('host=')
+})

--- a/tests/unit/adapters/error-mapper.test.ts
+++ b/tests/unit/adapters/error-mapper.test.ts
@@ -164,3 +164,25 @@ test('mapError: TABLE_NOT_FOUND does NOT include connection-troubleshooting hint
   const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
   expect(result.hints.join(' ')).not.toContain('mysql.log')
 })
+
+test("mapError: MySQL ER_BAD_FIELD_ERROR (1054) → COLUMN_NOT_FOUND", () => {
+  const error = {
+    code: 'ER_BAD_FIELD_ERROR',
+    errno: 1054,
+    message: "Unknown column 'usr_id' in 'where clause'",
+  }
+  const result = mapError(error, 'mariadb', { ...mockOptions, system: 'mariadb' })
+  expect(result.code).toBe('COLUMN_NOT_FOUND')
+  expect(result.message).toContain('usr_id')
+  expect(result.hints.join(' ')).toContain('dbcli schema')
+})
+
+test("mapError: PostgreSQL undefined_column (42703) → COLUMN_NOT_FOUND", () => {
+  const error = {
+    code: '42703',
+    message: 'column "usr_id" does not exist',
+  }
+  const result = mapError(error, 'postgresql', mockOptions)
+  expect(result.code).toBe('COLUMN_NOT_FOUND')
+  expect(result.message).toContain('usr_id')
+})

--- a/tests/unit/commands/query-executor-autolimit.test.ts
+++ b/tests/unit/commands/query-executor-autolimit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * QueryExecutor auto-LIMIT scope tests
+ * Verifies LIMIT injection only happens for SELECT, not for SHOW/DESCRIBE/EXPLAIN.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { QueryExecutor } from '@/core/query-executor'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function makeSpyAdapter(): { adapter: DatabaseAdapter; lastSql: () => string } {
+  let captured = ''
+  const adapter: DatabaseAdapter = {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>(sql: string) => {
+      captured = sql
+      return { rows: [] as T[], affectedRows: 0 }
+    },
+    listTables: async () => [],
+    getTableSchema: async () => ({
+      name: '',
+      columns: [],
+      rowCount: 0,
+      primaryKey: undefined,
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+  return { adapter, lastSql: () => captured }
+}
+
+describe('QueryExecutor auto-LIMIT scope', () => {
+  it('injects LIMIT for plain SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SELECT * FROM users')
+    expect(lastSql()).toMatch(/LIMIT\s+1000/i)
+  })
+
+  it('does NOT inject LIMIT for SHOW INDEX in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SHOW INDEX FROM betting_logs')
+    expect(lastSql()).toBe('SHOW INDEX FROM betting_logs')
+  })
+
+  it('does NOT inject LIMIT for DESCRIBE in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('DESCRIBE users')
+    expect(lastSql()).toBe('DESCRIBE users')
+  })
+
+  it('does NOT inject LIMIT for EXPLAIN SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('EXPLAIN SELECT * FROM users')
+    expect(lastSql()).toBe('EXPLAIN SELECT * FROM users')
+  })
+
+  it('does NOT inject LIMIT for ANALYZE SELECT in query-only mode', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('ANALYZE SELECT * FROM users')
+    expect(lastSql()).toBe('ANALYZE SELECT * FROM users')
+  })
+
+  it('preserves existing LIMIT and does not add another', async () => {
+    const { adapter, lastSql } = makeSpyAdapter()
+    const exec = new QueryExecutor(adapter, 'query-only')
+    await exec.execute('SELECT * FROM users LIMIT 50')
+    expect(lastSql()).toBe('SELECT * FROM users LIMIT 50')
+  })
+})

--- a/tests/unit/commands/schema-refresh-bootstrap.test.ts
+++ b/tests/unit/commands/schema-refresh-bootstrap.test.ts
@@ -1,0 +1,100 @@
+/**
+ * schema --refresh first-time bootstrap behaviour.
+ * When config.schema is empty, --force should not be required.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { handleSchemaRefresh } from '@/commands/schema'
+import type { DatabaseAdapter } from '@/adapters/types'
+import type { DbcliConfig } from '@/utils/validation'
+
+function mockAdapter(): DatabaseAdapter {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>() => ({ rows: [] as T[], affectedRows: 0 }),
+    listTables: async () => [
+      { name: 'users', columns: [], rowCount: 0, primaryKey: undefined, foreignKeys: [] },
+      { name: 'orders', columns: [], rowCount: 0, primaryKey: undefined, foreignKeys: [] },
+    ],
+    getTableSchema: async (name: string) => ({
+      name,
+      columns: [{ name: 'id', type: 'int', nullable: false, isPrimaryKey: true }],
+      rowCount: 0,
+      primaryKey: ['id'],
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+}
+
+describe('handleSchemaRefresh first-time bootstrap', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'dbcli-schema-bootstrap-'))
+  })
+
+  it('persists schema without --force when cache is empty', async () => {
+    const config: DbcliConfig = {
+      connection: {
+        system: 'mariadb',
+        host: 'localhost',
+        port: 3306,
+        user: 'u',
+        password: 'p',
+        database: 'db',
+      },
+      permission: 'admin',
+      schema: {},
+    } as unknown as DbcliConfig
+
+    await handleSchemaRefresh(
+      mockAdapter(),
+      config,
+      { config: 'dummy', refresh: true, force: false },
+      undefined,
+      tmpDir
+    )
+
+    expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(true)
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('still requires --force when cache is non-empty', async () => {
+    const config: DbcliConfig = {
+      connection: {
+        system: 'mariadb',
+        host: 'localhost',
+        port: 3306,
+        user: 'u',
+        password: 'p',
+        database: 'db',
+      },
+      permission: 'admin',
+      schema: {
+        users: {
+          name: 'users',
+          columns: [{ name: 'id', type: 'int', nullable: false, isPrimaryKey: true }],
+          rowCount: 0,
+          primaryKey: ['id'],
+          foreignKeys: [],
+        },
+      },
+    } as unknown as DbcliConfig
+
+    await handleSchemaRefresh(
+      mockAdapter(),
+      config,
+      { config: 'dummy', refresh: true, force: false },
+      undefined,
+      tmpDir
+    )
+
+    expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(false)
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+})

--- a/tests/unit/commands/schema-refresh-bootstrap.test.ts
+++ b/tests/unit/commands/schema-refresh-bootstrap.test.ts
@@ -2,7 +2,7 @@
  * schema --refresh first-time bootstrap behaviour.
  * When config.schema is empty, --force should not be required.
  */
-import { describe, it, expect, beforeEach } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtempSync, rmSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -38,6 +38,10 @@ describe('handleSchemaRefresh first-time bootstrap', () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'dbcli-schema-bootstrap-'))
   })
 
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
   it('persists schema without --force when cache is empty', async () => {
     const config: DbcliConfig = {
       connection: {
@@ -61,7 +65,6 @@ describe('handleSchemaRefresh first-time bootstrap', () => {
     )
 
     expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(true)
-    rmSync(tmpDir, { recursive: true, force: true })
   })
 
   it('still requires --force when cache is non-empty', async () => {
@@ -95,6 +98,5 @@ describe('handleSchemaRefresh first-time bootstrap', () => {
     )
 
     expect(existsSync(path.join(tmpDir, 'schemas'))).toBe(false)
-    rmSync(tmpDir, { recursive: true, force: true })
   })
 })

--- a/tests/unit/commands/schema-suggest.test.ts
+++ b/tests/unit/commands/schema-suggest.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `dbcli schema <table>` should attach fuzzy-match suggestions when the
+ * underlying TABLE_NOT_FOUND error fires.
+ */
+import { test, expect } from 'bun:test'
+import { ConnectionError } from '@/adapters/error-mapper'
+import { attachTableSuggestions } from '@/commands/schema'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function mockAdapterWithTables(tables: string[]): DatabaseAdapter {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>() => ({ rows: [] as T[], affectedRows: 0 }),
+    listTables: async () =>
+      tables.map((name) => ({
+        name,
+        columns: [],
+        rowCount: 0,
+        primaryKey: undefined,
+        foreignKeys: [],
+      })),
+    getTableSchema: async () => {
+      throw new ConnectionError('TABLE_NOT_FOUND', "Table 'bets' not found", [
+        'Run `dbcli list` to see available tables',
+      ])
+    },
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+}
+
+test('attachTableSuggestions appends top-3 fuzzy candidates to hints', async () => {
+  // 'bet' and 'best' have Levenshtein distance < 3 from 'bets'; 'orders'/'users' do not
+  const adapter = mockAdapterWithTables(['bet', 'best', 'orders', 'users'])
+  const baseErr = new ConnectionError('TABLE_NOT_FOUND', "Table 'bets' not found", [
+    'Run `dbcli list` to see available tables',
+  ])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'bets')
+  expect(enriched.hints.some((h) => h.includes('Did you mean'))).toBe(true)
+  const suggestionLine = enriched.hints.find((h) => h.includes('Did you mean')) || ''
+  expect(suggestionLine).toMatch(/bet/i)
+})
+
+test('attachTableSuggestions returns original error when no close matches', async () => {
+  const adapter = mockAdapterWithTables(['users', 'orders', 'payments'])
+  const baseErr = new ConnectionError('TABLE_NOT_FOUND', "Table 'xyz123' not found", [
+    'Run `dbcli list` to see available tables',
+  ])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'xyz123')
+  expect(enriched.hints.some((h) => h.includes('Did you mean'))).toBe(false)
+})
+
+test('attachTableSuggestions is a no-op for non-TABLE_NOT_FOUND errors', async () => {
+  const adapter = mockAdapterWithTables(['users'])
+  const baseErr = new ConnectionError('UNKNOWN', 'something else', ['hint'])
+  const enriched = await attachTableSuggestions(baseErr, adapter, 'anything')
+  expect(enriched).toBe(baseErr)
+})

--- a/tests/unit/core/permission-guard.test.ts
+++ b/tests/unit/core/permission-guard.test.ts
@@ -98,6 +98,32 @@ test('classifyStatement: EXPLAIN SELECT', () => {
   expect(result.confidence).toBe('HIGH')
 })
 
+test('classifyStatement: MariaDB ANALYZE SELECT is treated as EXPLAIN', () => {
+  const result = classifyStatement(
+    "ANALYZE SELECT COUNT(*) FROM betting_logs WHERE settled_at >= '2026-03-01'"
+  )
+  expect(result.type).toBe('EXPLAIN')
+  expect(result.isDangerous).toBe(false)
+  expect(result.confidence).toBe('HIGH')
+})
+
+test('classifyStatement: PostgreSQL EXPLAIN (ANALYZE, BUFFERS) SELECT', () => {
+  const result = classifyStatement(
+    'EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM users WHERE id = 1'
+  )
+  expect(result.type).toBe('EXPLAIN')
+  expect(result.isDangerous).toBe(false)
+})
+
+test('checkPermission: ANALYZE SELECT allowed in query-only', () => {
+  const result = checkPermission(
+    'ANALYZE SELECT * FROM users',
+    'query-only'
+  )
+  expect(result.allowed).toBe(true)
+  expect(result.classification.type).toBe('EXPLAIN')
+})
+
 test('classifyStatement: empty string returns UNKNOWN', () => {
   const result = classifyStatement('')
   expect(result.type).toBe('UNKNOWN')

--- a/tests/unit/core/permission-guard.test.ts
+++ b/tests/unit/core/permission-guard.test.ts
@@ -373,6 +373,15 @@ test('checkPermission: DROP blocked in query-only', () => {
   expect(result.allowed).toBe(false)
 })
 
+test('checkPermission: UNKNOWN denial mentions current level and asks for issue report', () => {
+  const result = checkPermission('FOO BAR BAZ', 'query-only')
+  expect(result.allowed).toBe(false)
+  expect(result.classification.type).toBe('UNKNOWN')
+  expect(result.reason).toContain('current level: query-only')
+  expect(result.reason.toLowerCase()).toContain('unknown')
+  expect(result.reason).toContain('issue')
+})
+
 // ============================================================================
 // Suite 6: Permission Checks - Read-Write Mode
 // ============================================================================


### PR DESCRIPTION
## Summary

實作 v1.23 P1,回應 arcade-report 使用者回饋(2026-05-28):

- **#1 SHOW/DESCRIBE/EXPLAIN 不再被 auto-LIMIT 注入** — `query-only` 模式現在只對 `SELECT` 注入 `LIMIT 1000`;`SHOW INDEX FROM ...`、`DESCRIBE ...`、`EXPLAIN ...` 等不再被 server 拒絕(query-executor)
- **#2 MariaDB ANALYZE SELECT / PG EXPLAIN ANALYZE 視為 read-only** — `classifyStatement` 把 MariaDB `ANALYZE SELECT` 識別為 EXPLAIN;query-only UNKNOWN 拒絕訊息加入 current level 與 issue 連結(permission-guard)
- **#3 SQL execute 錯誤分流** — `mapError` 新增 `SQL_SYNTAX_ERROR` / `TABLE_NOT_FOUND` / `COLUMN_NOT_FOUND` 三類,附 actionable hints;`dbcli schema <table>` 在 TABLE_NOT_FOUND 時自動追加 top-3 fuzzy 候選(error-mapper, schema.ts)
- **#7 schema --refresh 首次 bootstrap 免 --force** — 首次同步時 `config.schema` 為空,不需要 `--force`;後續 refresh 偵測到 cache diff 仍要求 `--force`

Spec: `docs/superpowers/specs/2026-05-28-dbcli-feedback-fixes-design.md`
Plan: `docs/superpowers/plans/2026-05-28-v1.23-p1-error-classification.md`

## Commits (12)

```
3842ccb docs: [p1] document error classification + auto-LIMIT scope + bootstrap
caee378 test: [p1] cross-DB integration smoke for error classification
d7bb314 test: [schema] use afterEach to ensure bootstrap test temp dir cleanup
029e8fa fix: [schema] skip --force for first-time refresh bootstrap
4676ad8 feat: [schema] attach fuzzy table-name suggestions on TABLE_NOT_FOUND
f29561c feat: [error-mapper] classify COLUMN_NOT_FOUND with schema-lookup hint
0633345 feat: [error-mapper] classify TABLE_NOT_FOUND with actionable hints
882e70a feat: [error-mapper] classify SQL syntax errors separately from connection errors
2826ed7 fix: [query-executor] only auto-LIMIT SELECT in query-only mode
7b9360c fix: [permission-guard] clarify UNKNOWN denial message in query-only mode
4efbc97 fix: [permission-guard] classify ANALYZE SELECT as EXPLAIN (MariaDB)
43b4336 feat: [adapters] extend ConnectionError union for SQL error categories
```

## Test plan

- [x] `bun test` 整體 2760 pass / 12 skip / 1 fail(唯一 fail 為 `recovery-audit-link.test.ts` 中既有 Redis blacklist audit metadata 測試,**main 上同樣 fail,非本 PR 引入**)
- [x] 新增單元測試覆蓋: error-mapper SQL_SYNTAX_ERROR / TABLE_NOT_FOUND / COLUMN_NOT_FOUND、permission-guard ANALYZE SELECT / UNKNOWN 訊息、query-executor auto-LIMIT scope、schema attachTableSuggestions、schema --refresh bootstrap
- [x] 新增整合測試 `tests/integration/p1-error-classification.test.ts`(以 `TEST_MARIADB_HOST` / `TEST_POSTGRESQL_HOST` 環境變數 gate,dev 環境自動 skip)
- [ ] 對真實 MariaDB:`SHOW INDEX FROM <table>` 在 query-only 不被拒
- [ ] 對真實 MariaDB:`SELECT * FROM nonexistent` 報 TABLE_NOT_FOUND,hints 含 `dbcli list`
- [ ] 對真實 PostgreSQL:`EXPLAIN (ANALYZE, BUFFERS) SELECT ...` 在 query-only 可執行
- [ ] `dbcli schema --refresh` 首次(空 cache)直接寫入
- [x] CHANGELOG + en/zh-TW docs(md + html)同步