### PR TITLE
fix: [ agent-core ] loadEnvFile 改用 node:fs，可在 Node 執行

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.43.0",
+  "version": "1.44.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.43.0",
+  "version": "1.44.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "1.43.0",
+  "version": "1.44.1",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,19 @@ jobs:
           bun-version: ${{ matrix.bun-version }}
       - run: bun install
 
-      - name: Required validation (bun run typecheck && bun test)
-        run: |
-          bun run build
-          bun run agent-core:check
-          bun run typecheck
-          bun test
+      # Keep these as separate steps: PowerShell can otherwise let a later
+      # successful native command mask an earlier non-zero exit code on Windows.
+      - name: Build
+        run: bun run build
+
+      - name: Agent core purity
+        run: bun run agent-core:check
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
         env:
           SKIP_INTEGRATION_TESTS: 'true'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Node runtime 契約測試。** 本 repo 的測試全部跑在 Bun 上，所以 agent-core 裡的 Bun-only 呼叫對它們是隱形的 —— 這正是這個 bug 得以發布的原因。新增的契約測試會 spawn 真正的 `node` 行程去 import 建置後的 `dist/agent-core.mjs`，逐一呼叫每個匯出。還原修正後此測試會失敗（已驗證），因此這個失敗模式不會再次出貨。
 
+### Changed
+
+- **同步跨平台發版 metadata。** npm package、Codex／Claude／Cursor plugin、packaged Codex plugin 與 Gemini extension 統一為 `1.44.1`。
+
 ## [1.44.0] - 2026-08-02 - agent-core 補上錯誤型別與 env reference 型別
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.44.1] - 2026-08-02 - `agent-core` 的 `loadEnvFile` 改用 node:fs，可在 Node 執行
+
+### Fixed
+
+- **`loadEnvFile` 不再依賴 `Bun.file`。** `./agent-core` 存在的理由是給下游 agent CLI 共用，而那些工具不一定跑在 Bun 上；`loadEnvFile` 內部呼叫 `Bun.file()`，在 Node 下直接 `ReferenceError: Bun is not defined`，使整個匯出對第一個 Node 消費者（logq）不可用。改以 `node:fs/promises` 讀檔，解析與「不覆寫既有 `process.env`」的行為完全不變；檔案不存在仍拋 `ConfigError`。其餘五個匯出本來就沒有 runtime 相依，不受影響。
+
+### Added
+
+- **Node runtime 契約測試。** 本 repo 的測試全部跑在 Bun 上，所以 agent-core 裡的 Bun-only 呼叫對它們是隱形的 —— 這正是這個 bug 得以發布的原因。新增的契約測試會 spawn 真正的 `node` 行程去 import 建置後的 `dist/agent-core.mjs`，逐一呼叫每個匯出。還原修正後此測試會失敗（已驗證），因此這個失敗模式不會再次出貨。
+
 ## [1.44.0] - 2026-08-02 - agent-core 補上錯誤型別與 env reference 型別
 
 ### Added

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.43.0",
+  "version": "1.44.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.43.0",
+  "version": "1.44.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/scripts/check-agent-core-purity.ts
+++ b/scripts/check-agent-core-purity.ts
@@ -1,4 +1,8 @@
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 const root = new URL('../src/agent-core/', import.meta.url)
+const rootPath = fileURLToPath(root)
 const forbiddenSystem = /\b(postgresql|mysql|mariadb|mongodb|redis|elasticsearch)\b/i
 const violations: string[] = []
 
@@ -34,8 +38,8 @@ export function findAgentCorePurityViolations(source: string, relativePath: stri
 }
 
 if (import.meta.main) {
-  for await (const relativePath of new Bun.Glob('**/*.ts').scan({ cwd: root.pathname })) {
-    const source = await Bun.file(new URL(relativePath, root)).text()
+  for await (const relativePath of new Bun.Glob('**/*.ts').scan({ cwd: rootPath })) {
+    const source = await Bun.file(join(rootPath, relativePath)).text()
     violations.push(...findAgentCorePurityViolations(source, relativePath))
   }
 

--- a/src/agent-core/env-loader.ts
+++ b/src/agent-core/env-loader.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { ConfigError } from './errors'
 
 function parseEnvContent(content: string): Array<[string, string]> {
@@ -24,12 +25,26 @@ function parseEnvContent(content: string): Array<[string, string]> {
   return entries
 }
 
-/** Load a file into process.env without overwriting existing values. */
+/**
+ * Load a file into process.env without overwriting existing values.
+ *
+ * Uses `node:fs` rather than `Bun.file` on purpose: `agent-core` is the public
+ * surface downstream tools consume, and those tools do not necessarily run on
+ * Bun. A Bun-only builtin here makes the whole export unusable for them.
+ */
 export async function loadEnvFile(filePath: string): Promise<void> {
-  const file = Bun.file(filePath)
-  if (!(await file.exists())) throw new ConfigError(`找不到 env 檔案：${filePath}`)
+  let content: string
+  try {
+    content = await readFile(filePath, 'utf8')
+  } catch (cause) {
+    const code = (cause as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'EISDIR') {
+      throw new ConfigError(`找不到 env 檔案：${filePath}`)
+    }
+    throw cause
+  }
 
-  for (const [key, value] of parseEnvContent(await file.text())) {
+  for (const [key, value] of parseEnvContent(content)) {
     if (process.env[key] === undefined) process.env[key] = value
   }
 }

--- a/tests/contract/agent-core-node-runtime.test.ts
+++ b/tests/contract/agent-core-node-runtime.test.ts
@@ -1,0 +1,79 @@
+import { expect, test, beforeAll } from 'bun:test'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const run = promisify(execFile)
+const repoRoot = resolve(import.meta.dir, '..', '..')
+const distEntry = join(repoRoot, 'dist', 'agent-core.mjs')
+
+/**
+ * `agent-core` exists to be consumed by downstream agent-facing tools, and those
+ * tools do not necessarily run on Bun (logq runs on Node). Every other test in
+ * this repo runs under Bun, so a Bun-only builtin inside agent-core is invisible
+ * to them — that is exactly how `loadEnvFile` shipped calling `Bun.file` and
+ * broke the first Node consumer. This test spawns a real `node` process against
+ * the built bundle so that failure mode cannot ship again.
+ */
+beforeAll(async () => {
+  await run('bun', ['run', 'build'], { cwd: repoRoot })
+}, 120_000)
+
+async function inNode(script: string): Promise<string> {
+  // Deliberately `node`, not `process.execPath` — this suite runs under Bun and
+  // the whole point is to leave Bun behind.
+  const { stdout } = await run('node', ['--input-type=module', '-e', script])
+  return stdout.trim()
+}
+
+test('every agent-core export is callable from Node', async () => {
+  const output = await inNode(`
+    import * as agentCore from ${JSON.stringify(distEntry)}
+    const names = Object.keys(agentCore).sort()
+    agentCore.resolveEnvRef({ $env: 'PATH' }, 'field')
+    agentCore.trimAppliedLimit([1, 2, 3], 2)
+    agentCore.parseConnectionNames('a,b')
+    agentCore.resolveConnectionSelector({ command: 'primary' })
+    new agentCore.ConfigError('probe')
+    console.log(names.join(','))
+  `)
+
+  expect(output).toBe(
+    'ConfigError,loadEnvFile,parseConnectionNames,resolveConnectionSelector,resolveEnvRef,trimAppliedLimit'
+  )
+})
+
+test('loadEnvFile works under Node without overwriting existing values', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'dbcli-node-env-'))
+  const envFile = join(directory, '.env')
+  await writeFile(envFile, 'DBCLI_NODE_FRESH=from-file\nDBCLI_NODE_EXISTING=from-file\n', 'utf8')
+
+  try {
+    const output = await inNode(`
+      import { loadEnvFile } from ${JSON.stringify(distEntry)}
+      process.env.DBCLI_NODE_EXISTING = 'from-environment'
+      await loadEnvFile(${JSON.stringify(envFile)})
+      console.log([process.env.DBCLI_NODE_FRESH, process.env.DBCLI_NODE_EXISTING].join('|'))
+    `)
+
+    expect(output).toBe('from-file|from-environment')
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('loadEnvFile reports a missing file as ConfigError under Node', async () => {
+  const output = await inNode(`
+    import { loadEnvFile, ConfigError } from ${JSON.stringify(distEntry)}
+    try {
+      await loadEnvFile('/definitely/not/here/.env')
+      console.log('no-throw')
+    } catch (error) {
+      console.log(error instanceof ConfigError ? 'ConfigError' : error.constructor.name)
+    }
+  `)
+
+  expect(output).toBe('ConfigError')
+})

--- a/tests/contract/agent-core-node-runtime.test.ts
+++ b/tests/contract/agent-core-node-runtime.test.ts
@@ -1,13 +1,15 @@
-import { expect, test, beforeAll } from 'bun:test'
+import { afterAll, beforeAll, expect, test } from 'bun:test'
 import { execFile } from 'node:child_process'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 
 const run = promisify(execFile)
 const repoRoot = resolve(import.meta.dir, '..', '..')
-const distEntry = join(repoRoot, 'dist', 'agent-core.mjs')
+let buildDirectory = ''
+let distEntrySpecifier = ''
 
 /**
  * `agent-core` exists to be consumed by downstream agent-facing tools, and those
@@ -18,8 +20,28 @@ const distEntry = join(repoRoot, 'dist', 'agent-core.mjs')
  * the built bundle so that failure mode cannot ship again.
  */
 beforeAll(async () => {
-  await run('bun', ['run', 'build'], { cwd: repoRoot })
-}, 120_000)
+  // Use an isolated artifact. Other test files build into dist concurrently,
+  // so sharing that output would make this contract test race their full builds.
+  buildDirectory = await mkdtemp(join(tmpdir(), 'dbcli-agent-core-build-'))
+  const distEntry = join(buildDirectory, 'agent-core.mjs')
+  await run(
+    'bun',
+    [
+      'build',
+      './src/agent-core/public.ts',
+      '--outfile',
+      distEntry,
+      '--target',
+      'bun',
+    ],
+    { cwd: repoRoot }
+  )
+  distEntrySpecifier = pathToFileURL(distEntry).href
+}, 30_000)
+
+afterAll(async () => {
+  if (buildDirectory) await rm(buildDirectory, { recursive: true, force: true })
+})
 
 async function inNode(script: string): Promise<string> {
   // Deliberately `node`, not `process.execPath` — this suite runs under Bun and
@@ -30,7 +52,7 @@ async function inNode(script: string): Promise<string> {
 
 test('every agent-core export is callable from Node', async () => {
   const output = await inNode(`
-    import * as agentCore from ${JSON.stringify(distEntry)}
+    import * as agentCore from ${JSON.stringify(distEntrySpecifier)}
     const names = Object.keys(agentCore).sort()
     agentCore.resolveEnvRef({ $env: 'PATH' }, 'field')
     agentCore.trimAppliedLimit([1, 2, 3], 2)
@@ -52,7 +74,7 @@ test('loadEnvFile works under Node without overwriting existing values', async (
 
   try {
     const output = await inNode(`
-      import { loadEnvFile } from ${JSON.stringify(distEntry)}
+      import { loadEnvFile } from ${JSON.stringify(distEntrySpecifier)}
       process.env.DBCLI_NODE_EXISTING = 'from-environment'
       await loadEnvFile(${JSON.stringify(envFile)})
       console.log([process.env.DBCLI_NODE_FRESH, process.env.DBCLI_NODE_EXISTING].join('|'))
@@ -66,7 +88,7 @@ test('loadEnvFile works under Node without overwriting existing values', async (
 
 test('loadEnvFile reports a missing file as ConfigError under Node', async () => {
   const output = await inNode(`
-    import { loadEnvFile, ConfigError } from ${JSON.stringify(distEntry)}
+    import { loadEnvFile, ConfigError } from ${JSON.stringify(distEntrySpecifier)}
     try {
       await loadEnvFile('/definitely/not/here/.env')
       console.log('no-throw')

--- a/tests/contract/agent-core-node-runtime.test.ts
+++ b/tests/contract/agent-core-node-runtime.test.ts
@@ -26,14 +26,7 @@ beforeAll(async () => {
   const distEntry = join(buildDirectory, 'agent-core.mjs')
   await run(
     'bun',
-    [
-      'build',
-      './src/agent-core/public.ts',
-      '--outfile',
-      distEntry,
-      '--target',
-      'bun',
-    ],
+    ['build', './src/agent-core/public.ts', '--outfile', distEntry, '--target', 'bun'],
     { cwd: repoRoot }
   )
   distEntrySpecifier = pathToFileURL(distEntry).href


### PR DESCRIPTION
## 問題

`./agent-core` 存在的理由是給下游 agent CLI 共用設定格式與心智模型，而那些工具不一定跑在 Bun 上。`loadEnvFile` 內部呼叫 `Bun.file()`，在 Node 下直接 `ReferenceError: Bun is not defined`。

這讓整個 `agent-core` 匯出對第一個 Node 消費者（logq）不可用 —— 六個匯出裡五個能跑，就這一個掛。

實測 v1.44.0 在 Node 22 下的結果：

| 匯出 | Node |
| --- | --- |
| `resolveEnvRef` | OK |
| `trimAppliedLimit` | OK |
| `parseConnectionNames` | OK |
| `resolveConnectionSelector` | OK |
| `ConfigError` | OK |
| `loadEnvFile` | **ReferenceError: Bun is not defined** |

## 修正

改以 `node:fs/promises` 讀檔。解析邏輯與「不覆寫既有 `process.env`」的語意完全不變；檔案不存在仍拋 `ConfigError`（同時涵蓋 `EISDIR`，對應原本 `Bun.file().exists()` 對目錄回 false 的行為）。

## 為什麼這個 bug 跑得掉

本 repo 的測試全部跑在 Bun 上，所以 agent-core 裡的 Bun-only 呼叫對它們是隱形的。`agent-core:check` 擋的是資料庫相依滲入，不管 runtime 可攜性。

因此補上 Node runtime 契約測試：spawn 真正的 `node` 行程去 import 建置後的 `dist/agent-core.mjs`，逐一呼叫每個匯出，並驗證 `loadEnvFile` 的不覆寫語意與 `ConfigError` 行為。

## Test plan

- [x] `bun test tests/unit tests/core tests/contract` — 3593 pass / 0 fail
- [x] `bun run typecheck` — 乾淨
- [x] `bun run lint` — 乾淨
- [x] `bun run agent-core:check` — passed
- [x] 還原本次 src 修正後，新契約測試 3 個裡 2 個失敗（確認測試有牙齒）
- [x] `npm pack` 產物裝進一個乾淨的 Node 專案實測：`loadEnvFile` 讀得到檔案值且不覆寫既有環境變數

## 版本

patch → **1.44.1**。修的是既有匯出的壞掉行為，介面形狀不變。

> PR 只到這裡，`npm publish` 留給你。