### PR TITLE
fix: [ security ] enforce the read-only contract on every execution path (1.47.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/.cursor/rules/dbcli.mdc
+++ b/.cursor/rules/dbcli.mdc
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/.github/skills/dbcli/SKILL.md
+++ b/.github/skills/dbcli/SKILL.md
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PostgreSQL 多語句堆疊。** 權限分類只讀第一個關鍵字，而 PostgreSQL 的 simple query protocol 會執行字串裡每一個以分號分隔的語句，因此 `SELECT 1 LIMIT 1; DELETE FROM users` 會以 SELECT 的身分通過 `query-only`。影響 PostgreSQL；MySQL / MariaDB 走 prepared statement，不受影響。
 - **snippet 的偽唯讀語句。** snippet 只要求開頭是 `SELECT` 或 `WITH`，因此 `WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x` 與 `SELECT … INTO` 都能通過。一個 commit 進 repo、看起來是唯讀報表的 `.sql` 檔可以寫入資料庫。影響 PostgreSQL / MariaDB。
 - **snippet frontmatter 的 `verify.query` 未經驗證。** 過去只檢查它是非空字串，然後由 `dbcli q <name> --verify` 原封執行。
+- **唯讀證明只接在多連線 fan-out 上，單連線 `query` / `export` / REPL 沒有。** 權限判定只看第一個關鍵字，因此 `query-only` 連線接受並執行下列語句：`WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone`（data-modifying CTE）、`SELECT * INTO evil_copy FROM users`（建表）、`EXPLAIN ANALYZE DELETE FROM users`（`EXPLAIN ANALYZE` 會真的執行該語句）。同一句 SQL 加上 `--use a,b` 會被擋，不加就執行。auto-limit 補的 `LIMIT 1000` 對 CTE 無效，整張表仍會被刪。**這條在 1.47.0 以前就存在**，且不需要任何特殊語法。影響 PostgreSQL 與 MariaDB。
 - **PostgreSQL 識別字中的 `$` 被誤判為 dollar-quote 起點。** PostgreSQL 的識別字從第二個字元起允許 `$`，因此 `a$q$` 是**一個識別字**；但語句剖析器把它讀成字串起點，於是 `SELECT 1 AS a$q$ LIMIT 1; DELETE FROM users; SELECT 1 AS b$q$` 中間整段對所有安全檢查隱形，資料庫卻照常執行三段。**這條在 1.47.0 以前就存在**：多連線 fan-out 的唯讀斷言（`dbcli query --use a,b`）用的正是同一個剖析器，因此可被此手法繞過。影響 PostgreSQL。
 
 利用這些繞過需要能下達指令的一方送出 payload，也就是 agent 本身 —— 而 dbcli 的威脅模型前提正是 agent 不完全可信，因此這些屬於權限繞過，不以「使用者自己下的指令」論。
 
 ### Changed
 
+- **語句以它實際執行的寫入來判定權限等級。** 開頭是 `SELECT` 但夾帶 data-modifying CTE 或 `INTO` 的語句，比照該寫入的等級（`DELETE` 需要 `data-admin`）；`EXPLAIN ANALYZE <寫入>` 亦然。不含 `ANALYZE` 的 `EXPLAIN` 只做計畫、不執行，維持唯讀；`SHOW` / `DESCRIBE` 不接受子查詢，因此 `SHOW CREATE TABLE users` 仍是讀取。
 - **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。分隔符依**該連線實際的方言**判定：`$$…$$` 只在 PostgreSQL 是字串、反引號只在 MySQL/MariaDB 引號化識別字、`#` 只在 MySQL/MariaDB 起始註解（在 PostgreSQL 是運算子）。方言未知時從嚴。
 - **snippet 的唯讀證明依 `engine` 宣告的方言判定。** 因此 `SELECT \`update\` FROM t`（MySQL 反引號識別字）、`# drop …` 註解、`a.create` 這類欄位名不再被誤判為寫入；`FOR UPDATE` / `FOR SHARE` 是取鎖的讀取，同樣不算寫入。
 - **無法解析的 snippet 只跳過該檔並發出警告，不再讓整個 snippet 目錄失效。** `queries check` 仍會回報它們並以 exit 1 結束。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **語句以它實際執行的寫入來判定權限等級。** 開頭是 `SELECT` 但夾帶 data-modifying CTE 或 `INTO` 的語句，比照該寫入的等級（`DELETE` 需要 `data-admin`）；`EXPLAIN ANALYZE <寫入>` 亦然。不含 `ANALYZE` 的 `EXPLAIN` 只做計畫、不執行，維持唯讀；`SHOW` / `DESCRIBE` 不接受子查詢，因此 `SHOW CREATE TABLE users` 仍是讀取。
+- **⚠️ 行為收緊：開頭讀取但夾帶寫入的語句一律需要 `admin`。** 例如 `WITH x AS (INSERT … RETURNING *) SELECT …`、`SELECT … INTO`、`EXPLAIN ANALYZE <寫入>`、`DESCRIBE ANALYZE <寫入>`（`DESCRIBE` 在 MySQL/MariaDB 是 `EXPLAIN` 的同義字）。過去這些一律不檢查；中間曾嘗試「比照該寫入的等級」，但那需要為 `INSERT INTO` 的 `INTO` 加文字例外，而例外之間會互相作用出新的繞過，因此改為單一規則。**若你在 `data-admin` 連線上使用可寫的 CTE，升級後需要改用 `admin`。** 不含 `ANALYZE` 的 `EXPLAIN` 只做計畫、不執行，維持唯讀；`SHOW` / `DESCRIBE` 不接受子查詢，因此 `SHOW CREATE TABLE users` 仍是讀取；`replace()` / `TRUNCATE()` / `INSERT()` 是函式不是語句，維持唯讀。
 - **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。分隔符依**該連線實際的方言**判定：`$$…$$` 只在 PostgreSQL 是字串、反引號只在 MySQL/MariaDB 引號化識別字、`#` 只在 MySQL/MariaDB 起始註解（在 PostgreSQL 是運算子）。方言未知時從嚴。
 - **snippet 的唯讀證明依 `engine` 宣告的方言判定。** 因此 `SELECT \`update\` FROM t`（MySQL 反引號識別字）、`# drop …` 註解、`a.create` 這類欄位名不再被誤判為寫入；`FOR UPDATE` / `FOR SHARE` 是取鎖的讀取，同樣不算寫入。
 - **無法解析的 snippet 只跳過該檔並發出警告，不再讓整個 snippet 目錄失效。** `queries check` 仍會回報它們並以 exit 1 結束。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **⚠️ 行為收緊：開頭讀取但夾帶寫入的語句一律需要 `admin`。** 例如 `WITH x AS (INSERT … RETURNING *) SELECT …`、`SELECT … INTO`、`EXPLAIN ANALYZE <寫入>`、`DESCRIBE ANALYZE <寫入>`（`DESCRIBE` 在 MySQL/MariaDB 是 `EXPLAIN` 的同義字）。過去這些一律不檢查；中間曾嘗試「比照該寫入的等級」，但那需要為 `INSERT INTO` 的 `INTO` 加文字例外，而例外之間會互相作用出新的繞過，因此改為單一規則。**若你在 `data-admin` 連線上使用可寫的 CTE，升級後需要改用 `admin`。** 不含 `ANALYZE` 的 `EXPLAIN` 只做計畫、不執行，維持唯讀；`SHOW` / `DESCRIBE` 不接受子查詢，因此 `SHOW CREATE TABLE users` 仍是讀取；`replace()` / `TRUNCATE()` / `INSERT()` 是函式不是語句，維持唯讀。
+- **⚠️ 行為收緊：開頭讀取但夾帶寫入的語句一律需要 `admin`。** 例如 `WITH x AS (INSERT … RETURNING *) SELECT …`、`SELECT … INTO`、`EXPLAIN ANALYZE <寫入>`、`DESCRIBE ANALYZE <寫入>`（`DESCRIBE` 在 MySQL/MariaDB 是 `EXPLAIN` 的同義字）。過去這些一律不檢查；中間曾嘗試「比照該寫入的等級」，但那需要為 `INSERT INTO` 的 `INTO` 加文字例外，而例外之間會互相作用出新的繞過，因此改為單一規則。**升級後需要改用 `admin` 的用法有三類**：`data-admin` 連線上的可寫 CTE；對寫入語句做 `EXPLAIN ANALYZE` / `DESCRIBE ANALYZE` 效能分析（它會真的執行該語句）；以及 MySQL/MariaDB 的 `SELECT … INTO @variable`——後者其實是純讀取，只是與 PostgreSQL 會建表的 `SELECT … INTO <table>` 共用關鍵字，為它加例外正是本次反覆出問題的來源，因此選擇留下這個誤擋。被擋時的錯誤訊息會指出是哪一個關鍵字觸發的。 不含 `ANALYZE` 的 `EXPLAIN` 只做計畫、不執行，維持唯讀；`SHOW` / `DESCRIBE` 不接受子查詢，因此 `SHOW CREATE TABLE users` 仍是讀取；`replace()` / `TRUNCATE()` / `INSERT()` 是函式不是語句，維持唯讀。
 - **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。分隔符依**該連線實際的方言**判定：`$$…$$` 只在 PostgreSQL 是字串、反引號只在 MySQL/MariaDB 引號化識別字、`#` 只在 MySQL/MariaDB 起始註解（在 PostgreSQL 是運算子）。方言未知時從嚴。
 - **snippet 的唯讀證明依 `engine` 宣告的方言判定。** 因此 `SELECT \`update\` FROM t`（MySQL 反引號識別字）、`# drop …` 註解、`a.create` 這類欄位名不再被誤判為寫入；`FOR UPDATE` / `FOR SHARE` 是取鎖的讀取，同樣不算寫入。
 - **無法解析的 snippet 只跳過該檔並發出警告，不再讓整個 snippet 目錄失效。** `queries check` 仍會回報它們並以 exit 1 結束。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PostgreSQL 多語句堆疊。** 權限分類只讀第一個關鍵字，而 PostgreSQL 的 simple query protocol 會執行字串裡每一個以分號分隔的語句，因此 `SELECT 1 LIMIT 1; DELETE FROM users` 會以 SELECT 的身分通過 `query-only`。影響 PostgreSQL；MySQL / MariaDB 走 prepared statement，不受影響。
 - **snippet 的偽唯讀語句。** snippet 只要求開頭是 `SELECT` 或 `WITH`，因此 `WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x` 與 `SELECT … INTO` 都能通過。一個 commit 進 repo、看起來是唯讀報表的 `.sql` 檔可以寫入資料庫。影響 PostgreSQL / MariaDB。
 - **snippet frontmatter 的 `verify.query` 未經驗證。** 過去只檢查它是非空字串，然後由 `dbcli q <name> --verify` 原封執行。
+- **PostgreSQL 識別字中的 `$` 被誤判為 dollar-quote 起點。** PostgreSQL 的識別字從第二個字元起允許 `$`，因此 `a$q$` 是**一個識別字**；但語句剖析器把它讀成字串起點，於是 `SELECT 1 AS a$q$ LIMIT 1; DELETE FROM users; SELECT 1 AS b$q$` 中間整段對所有安全檢查隱形，資料庫卻照常執行三段。**這條在 1.47.0 以前就存在**：多連線 fan-out 的唯讀斷言（`dbcli query --use a,b`）用的正是同一個剖析器，因此可被此手法繞過。影響 PostgreSQL。
 
 利用這些繞過需要能下達指令的一方送出 payload，也就是 agent 本身 —— 而 dbcli 的威脅模型前提正是 agent 不完全可信，因此這些屬於權限繞過，不以「使用者自己下的指令」論。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。字串常值、反引號識別字、`#` 註解裡的分號不算分隔符。
+- **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。分隔符依**該連線實際的方言**判定：`$$…$$` 只在 PostgreSQL 是字串、反引號只在 MySQL/MariaDB 引號化識別字、`#` 只在 MySQL/MariaDB 起始註解（在 PostgreSQL 是運算子）。方言未知時從嚴。
+- **snippet 的唯讀證明依 `engine` 宣告的方言判定。** 因此 `SELECT \`update\` FROM t`（MySQL 反引號識別字）、`# drop …` 註解、`a.create` 這類欄位名不再被誤判為寫入；`FOR UPDATE` / `FOR SHARE` 是取鎖的讀取，同樣不算寫入。
+- **無法解析的 snippet 只跳過該檔並發出警告，不再讓整個 snippet 目錄失效。** `queries check` 仍會回報它們並以 exit 1 結束。
 - **snippet 一律拒絕寫入關鍵字。** snippet 依合約唯讀，這條規則不看 permission 等級，`admin` 連線亦然。
 - **MongoDB 寫入 stage 在單連線 `query` 需要 `data-admin` 以上；在 snippet 與 `export` 一律拒絕。**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.47.1] - 2026-08-05 - 唯讀保證涵蓋所有執行路徑（安全性修復）
+
+決策記錄：`docs/adr/0004-database-access-stays-a-cli-surface.md`。
+
+### Security
+
+修復五個「看起來是讀、實際會寫」的繞過，它們都能在設定為 `permission: query-only` 的連線上寫入資料。**建議所有把資料庫交給 AI agent 操作的使用者升級。**
+
+- **MongoDB `$out` / `$merge` 未被擋下（`query`、`q`、`export`）。** 這兩個 aggregation stage 只在多連線 fan-out 路徑被檢查，單連線 `dbcli query`、saved snippet、以及 `dbcli export` 全都會執行它們，不論 permission 等級。`$out` 可覆寫任意 collection。`--dry-run` 會把這種 pipeline 預覽成安全操作。影響 MongoDB 連線。
+- **PostgreSQL 多語句堆疊。** 權限分類只讀第一個關鍵字，而 PostgreSQL 的 simple query protocol 會執行字串裡每一個以分號分隔的語句，因此 `SELECT 1 LIMIT 1; DELETE FROM users` 會以 SELECT 的身分通過 `query-only`。影響 PostgreSQL；MySQL / MariaDB 走 prepared statement，不受影響。
+- **snippet 的偽唯讀語句。** snippet 只要求開頭是 `SELECT` 或 `WITH`，因此 `WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x` 與 `SELECT … INTO` 都能通過。一個 commit 進 repo、看起來是唯讀報表的 `.sql` 檔可以寫入資料庫。影響 PostgreSQL / MariaDB。
+- **snippet frontmatter 的 `verify.query` 未經驗證。** 過去只檢查它是非空字串，然後由 `dbcli q <name> --verify` 原封執行。
+
+利用這些繞過需要能下達指令的一方送出 payload，也就是 agent 本身 —— 而 dbcli 的威脅模型前提正是 agent 不完全可信，因此這些屬於權限繞過，不以「使用者自己下的指令」論。
+
+### Changed
+
+- **admin 以下的權限等級拒絕多語句 SQL。** 因為只有第一個語句會決定權限判定。`admin` 不受影響（它本來就允許所有語句類型）。字串常值、反引號識別字、`#` 註解裡的分號不算分隔符。
+- **snippet 一律拒絕寫入關鍵字。** snippet 依合約唯讀，這條規則不看 permission 等級，`admin` 連線亦然。
+- **MongoDB 寫入 stage 在單連線 `query` 需要 `data-admin` 以上；在 snippet 與 `export` 一律拒絕。**
+
+### Added
+
+- **執行路徑契約測試。** `src/adapters/` 以外每一處 `<x>Adapter.execute(...)` 都必須登記它倚賴的 gate，未登記的新路徑會讓測試失敗。這五個洞裡有兩個正是靠列舉全部路徑才發現的 —— 逐一稽核指令找不到它們。
+
 ## [1.47.0] - 2026-08-05 - 連線逾時可設定
 
 決策記錄：`docs/adr/0003-connection-timeout-override-resolved-at-adapter-construction.md`。

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/docs/adr/0004-database-access-stays-a-cli-surface.md
+++ b/docs/adr/0004-database-access-stays-a-cli-surface.md
@@ -34,34 +34,35 @@ server is still not the operator.
 ## Evidence: coverage is the property that matters, and only the surface owner can audit it
 
 A safety mechanism is worth what its path coverage is worth, and this project
-demonstrated the point against itself. An audit of the five positioning claims
-below found five ways a read-looking operation executed a write while bypassing
-the configured permission level: MongoDB `$out` / `$merge` on the single-connection
-`query` path and in saved snippets, PostgreSQL statement stacking through the
-simple query protocol, a data-modifying CTE and `SELECT … INTO` in a snippet
-body, a `verify.query` in snippet frontmatter executed verbatim, and the MongoDB
-branch of `export`.
+demonstrated the point against itself. An audit of the claims below, and the
+adversarial review of its own fixes that followed, found six shipped ways a
+read-looking operation executed a write while bypassing the configured
+permission level: MongoDB `$out` / `$merge` on the single-connection `query`
+path, in saved snippets, and in `export`; PostgreSQL statement stacking through
+the simple query protocol; a data-modifying CTE and `SELECT … INTO` in a snippet
+body; a `verify.query` in snippet frontmatter executed verbatim; a `$` inside an
+identifier read as the start of a dollar-quoted string, which hid the rest of a
+statement from analysis; and — the plainest of them — the read-only proof itself,
+which existed but ran only for multi-connection fan-out, so `dbcli query` accepted
+`WITH gone AS (DELETE …) SELECT …` under `permission: query-only`.
 
-The last two were not found by auditing commands. Four independent audits of the
-individual commands missed them. They were found by enumerating every call site
-that reaches an adapter — an audit that is possible only for the party that owns
-the whole surface. An operator of an MCP database server cannot perform it: the
-paths are inside the server process.
+Not one of them is a missing mechanism. Every one is a mechanism that did not
+reach a path.
 
-A sixth was found by an adversarial review of the fixes themselves: PostgreSQL
-allows `$` inside an identifier after its first character, so `a$q$` is one
-identifier, and reading it as the start of a dollar-quoted string hid everything
-up to the next `$q$` from analysis while the server still executed it. That one
-predates this work — it defeated the fan-out read-only assertion in 1.47.0, which
-was the only statement-splitting guard that existed then.
+Two of them were not found by auditing commands at all. Four independent audits
+of the individual commands missed them; they surfaced only when every call site
+reaching an adapter was enumerated — an audit available only to the party that
+owns the whole surface. An operator of an MCP database server cannot perform it:
+the paths are inside the server process.
 
-Two rounds of adversarial review were needed, and the second round found a
-bypass in the fix for the first. That is the argument, not a caveat to it: this
-class of defect is found by attacking a surface repeatedly, which requires
-holding the surface.
+Seven rounds of adversarial review were needed. Rounds two through six each
+found a defect in the fix produced by the round before it, twice in exceptions
+added only to stop a guard from rejecting legitimate queries. The seventh was
+the first with nothing to report. That history is the argument, not a caveat to
+it: this class of defect is found by attacking a surface repeatedly, and only
+the party that holds the surface can do that.
 
-The fixes are commits `fcf3502`, `92114d2`, `ee0ed5a` and their successor, and
-the enumeration is now a structural contract
+The fixes ship in 1.47.1, and the enumeration is now a structural contract
 (`tests/unit/core/execution-path-contract.test.ts`): a new path to an adapter
 fails the suite until it is registered with the gate that proves what it may
 execute. The contract does not forbid a new path; it prevents one from being

--- a/docs/adr/0004-database-access-stays-a-cli-surface.md
+++ b/docs/adr/0004-database-access-stays-a-cli-surface.md
@@ -1,0 +1,106 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# Database access stays a CLI surface
+
+dbcli exposes database access as a command-line surface and does not ship an MCP
+server. The reason is not a missing feature in MCP database servers; it is which
+party owns the vocabulary an operator writes authorization policy in.
+
+An agent host authorizes a CLI by matching the command string. In Claude Code,
+allow rules match the whole string with wildcards at any position, are aware of
+shell operators so a rule cannot be widened by chaining, and therefore express a
+*gradient*: `dbcli schema *` runs unattended while `dbcli query` still prompts.
+
+The same host authorizes an MCP tool by name. Allow rules accept
+`mcp__<server>`, `mcp__<server>__*`, or `mcp__<server>__<tool>`; the documented
+reason argument matching is confined to `deny` and `ask` is that "an allow rule
+for one parameter value wouldn't establish that the call is safe overall". An
+operator can therefore *block* by argument but cannot *permit* by argument. The
+expressible policies are "everything from this server runs" and "everything from
+this server prompts" — and an operator who is prompted on every read approves
+everything, which returns the decision to trusting the server.
+
+An MCP server can regain a gradient only by splitting its surface into separately
+named tools, such as `query_readonly` and `query_write`. That moves the policy
+into tool naming, and the naming belongs to the server author. Under a CLI the
+operator writes the policy in their own settings file, per project, and revises
+it without the tool's cooperation. This is the difference the decision rests on,
+and it survives any improvement to a competing server, because the author of that
+server is still not the operator.
+
+## Evidence: coverage is the property that matters, and only the surface owner can audit it
+
+A safety mechanism is worth what its path coverage is worth, and this project
+demonstrated the point against itself. An audit of the five positioning claims
+below found five ways a read-looking operation executed a write while bypassing
+the configured permission level: MongoDB `$out` / `$merge` on the single-connection
+`query` path and in saved snippets, PostgreSQL statement stacking through the
+simple query protocol, a data-modifying CTE and `SELECT … INTO` in a snippet
+body, a `verify.query` in snippet frontmatter executed verbatim, and the MongoDB
+branch of `export`.
+
+The last two were not found by auditing commands. Four independent audits of the
+individual commands missed them. They were found by enumerating every call site
+that reaches an adapter — an audit that is possible only for the party that owns
+the whole surface. An operator of an MCP database server cannot perform it: the
+paths are inside the server process.
+
+The fixes are commits `fcf3502` and `92114d2`, and the enumeration is now a
+structural contract (`tests/unit/core/execution-path-contract.test.ts`): a new
+path to an adapter fails the suite until it is registered with the gate that
+proves what it may execute. The contract does not forbid a new path; it prevents
+one from being added silently.
+
+## What the CLI surface leaves behind
+
+The claims this decision defends, with their state at the time of writing:
+
+| Claim | State |
+| --- | --- |
+| The operator owns the authorization vocabulary | Holds — see above |
+| The invocation is the unit of review: a human can re-run what the agent ran | Structurally available, **not yet delivered** — see Consequences |
+| A failure leaves a plan a human can read: `dbcli recover` renders the artifact as Markdown with a rationale, risk tier, and expectation per step, and `--apply` executes only steps on a code-owned allowlist | Holds |
+| Know-how accumulates as files the operator owns: snippets are `.sql` files under `.dbcli-shared/queries/`, committed and reviewed like any other source | Holds |
+| The tool outlives the agent: usable by a human, by CI, and by a Makefile, with meaningful exit codes and non-interactive escapes | Holds |
+
+Context cost was considered as a sixth claim and excluded: it was not measured,
+and an unmeasured claim does not belong in a decision record.
+
+## Considered options
+
+- Ship an MCP server in addition to the CLI, exposing the same safety mechanisms
+  through tools.
+- Ship an MCP server instead of the CLI.
+- Keep database access a CLI surface and treat host-level authorization of the
+  command string as part of the product's contract.
+
+The third option was selected. The first appears free but is not: once an MCP
+surface exists, the safety mechanisms have two enforcement paths to cover rather
+than one, and the evidence above is that path coverage — not mechanism design —
+is where this class of defect lives.
+
+## Consequences
+
+- Command strings must be self-contained for the review claim to hold, and today
+  they are not: a connection can be selected by the `DBCLI_CONNECTION`
+  environment variable when `--use` is absent, and project storage is keyed by a
+  hash of the absolute project path, so an identical string can resolve
+  differently on another checkout. Until an emitted command always carries its
+  connection and config location explicitly, the second claim is aspirational and
+  is recorded here as such.
+- Authorization guidance is part of the product. Documentation should show the
+  allow and deny rules that produce a useful gradient, because the mechanism only
+  reaches operators who write those rules.
+- `--recovery` is per-command rather than universal, and is silently skipped for
+  multi-connection requests; the recovery claim is bounded accordingly.
+
+**Falsified if:** `src/mcp/` exists, or `package.json` declares an MCP entry
+point. Either means this decision has been reversed and this record must be
+updated in the same change.
+
+Separately, if Claude Code gains parameter-level `allow` rules for MCP tools,
+the primary evidence weakens but the decision stands: the tool surface an
+operator writes policy against would still be defined by the server author.

--- a/docs/adr/0004-database-access-stays-a-cli-surface.md
+++ b/docs/adr/0004-database-access-stays-a-cli-surface.md
@@ -48,11 +48,28 @@ that reaches an adapter — an audit that is possible only for the party that ow
 the whole surface. An operator of an MCP database server cannot perform it: the
 paths are inside the server process.
 
-The fixes are commits `fcf3502` and `92114d2`, and the enumeration is now a
-structural contract (`tests/unit/core/execution-path-contract.test.ts`): a new
-path to an adapter fails the suite until it is registered with the gate that
-proves what it may execute. The contract does not forbid a new path; it prevents
-one from being added silently.
+A sixth was found by an adversarial review of the fixes themselves: PostgreSQL
+allows `$` inside an identifier after its first character, so `a$q$` is one
+identifier, and reading it as the start of a dollar-quoted string hid everything
+up to the next `$q$` from analysis while the server still executed it. That one
+predates this work — it defeated the fan-out read-only assertion in 1.47.0, which
+was the only statement-splitting guard that existed then.
+
+Two rounds of adversarial review were needed, and the second round found a
+bypass in the fix for the first. That is the argument, not a caveat to it: this
+class of defect is found by attacking a surface repeatedly, which requires
+holding the surface.
+
+The fixes are commits `fcf3502`, `92114d2`, `ee0ed5a` and their successor, and
+the enumeration is now a structural contract
+(`tests/unit/core/execution-path-contract.test.ts`): a new path to an adapter
+fails the suite until it is registered with the gate that proves what it may
+execute. The contract does not forbid a new path; it prevents one from being
+added silently.
+
+The read-only proof is keyword-based, and its ceiling is recorded in the threat
+model: SQL passed as a string to a function (`query_to_xml('DELETE …')`,
+`dblink_exec`) or a volatile UDF cannot be detected this way.
 
 ## What the CLI surface leaves behind
 

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -48,6 +48,15 @@ and credentials must be protected from the agent's writable workspace.
    defect appears as an unguarded *path*, not as a missing mechanism. See
    [ADR-0004](adr/0004-database-access-stays-a-cli-surface.md).
 
+   **Known ceiling:** the read-only proof classifies keywords, so it cannot see
+   SQL that is passed as a *string* to something that executes it —
+   `query_to_xml('DELETE …')`, `dblink_exec(…)`, or any volatile user-defined
+   function. String literals must be stripped before classification, or ordinary
+   queries would be rejected for mentioning a keyword. Saved snippets are
+   therefore read-only *by contract and by keyword proof*, not by proof of
+   effect. Treat a database account that can execute such functions as able to
+   write, and grant accordingly.
+
 ## Operator contract
 
 - Give autonomous agents only database credentials that are safe for their task.

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -38,6 +38,15 @@ and credentials must be protected from the agent's writable workspace.
 4. **Secret disclosure through machine output** — Mitigation: safe inventory,
    status, and audit projections exclude credentials, URIs, Cloud IDs, API keys,
    and environment-variable names.
+5. **Read-looking statements that write** — A statement can pass a guard that
+   judges it by its leading keyword and still write: stacked statements on
+   drivers using the simple query protocol, data-modifying CTEs, `SELECT … INTO`,
+   and MongoDB `$out` / `$merge` stages. Mitigation: statements are proven
+   read-only rather than assumed, and every path from a command to an adapter is
+   registered against the gate it relies on
+   (`tests/unit/core/execution-path-contract.test.ts`), because this class of
+   defect appears as an unguarded *path*, not as a missing mechanism. See
+   [ADR-0004](adr/0004-database-access-stays-a-cli-surface.md).
 
 ## Operator contract
 

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -136,7 +136,7 @@
                         <svg class="w-6 h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
                     </div>
                     <h3 class="mt-0 mb-2 text-lg font-bold">Permission Guard</h3>
-                    <p class="text-sm m-0">Four tiers (<code>query-only</code> to <code>admin</code>) of strict access control for every operation.</p>
+                    <p class="text-sm m-0">Four tiers (<code>query-only</code> to <code>admin</code>) of strict access control for every operation, judged by what a statement does rather than by its leading keyword — stacked statements, data-modifying CTEs, <code>SELECT … INTO</code> and MongoDB <code>$out</code> / <code>$merge</code> are all refused rather than read as reads.</p>
                 </div>
                 <div class="group p-6 paper-card">
                     <div class="w-12 h-12 bg-secondary/10 rounded-lg flex items-center justify-center mb-4 group-hover:scale-105 transition-transform">

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -32,7 +32,7 @@
 
 `dbcli` is built with a "Security-First" mindset, particularly focused on preventing AI agents from accidentally leaking or corrupting sensitive data.
 
-*   **Permission Guard**: Four tiers of access control (`query-only`, `read-write`, `data-admin`, `admin`).
+*   **Permission Guard**: Four tiers of access control (`query-only`, `read-write`, `data-admin`, `admin`). A statement is judged by what it does, not by its leading keyword: SQL holding multiple statements is refused below `admin` because only the first one would determine the check, saved snippets are refused if they contain any write or DDL keyword (so a data-modifying CTE or `SELECT … INTO` cannot hide behind a `SELECT`/`WITH` opening), and MongoDB `$out` / `$merge` require `data-admin` on `query` and are refused outright in snippets and `export`.
 *   **Blacklist Manager**: Redacts sensitive tables and columns from all query results.
 *   **Query Risk Analyzer (`plan`)**: Analyzes SQL risk without connecting to the database.
 *   **Antigravity Protocol**: A workflow separation between **Architect** (Planning) and **Builder** (Execution) to ensure strategy precedes action.

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -136,7 +136,7 @@
                         <svg class="w-6 h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
                     </div>
                     <h3 class="mt-0 mb-2 text-lg font-bold">權限守衛 (Permission Guard)</h3>
-                    <p class="text-sm m-0">四層存取控制（從 <code>query-only</code> 到 <code>admin</code>），嚴格把關每一項操作。</p>
+                    <p class="text-sm m-0">四層存取控制（從 <code>query-only</code> 到 <code>admin</code>），嚴格把關每一項操作；語句以實際行為判定而非開頭關鍵字 —— 多語句堆疊、data-modifying CTE、<code>SELECT … INTO</code> 與 MongoDB <code>$out</code> / <code>$merge</code> 一律拒絕，不會被讀成唯讀操作。</p>
                 </div>
                 <div class="group p-6 paper-card">
                     <div class="w-12 h-12 bg-secondary/10 rounded-lg flex items-center justify-center mb-4 group-hover:scale-105 transition-transform">

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -32,7 +32,7 @@
 
 `dbcli` 的設計初衷是「安全第一」，特別專注於防止 AI 代理在操作過程中意外洩漏或損壞敏感資料。
 
-*   **權限守衛 (Permission Guard)**：提供四層存取控制（`query-only`、`read-write`、`data-admin`、`admin`）。
+*   **權限守衛 (Permission Guard)**：提供四層存取控制（`query-only`、`read-write`、`data-admin`、`admin`）。語句以「實際會做什麼」判定，而非開頭關鍵字：`admin` 以下拒絕多語句 SQL（因為只有第一句會決定權限判定）；saved snippet 只要含任何寫入或 DDL 關鍵字即拒絕，因此 data-modifying CTE 與 `SELECT … INTO` 無法躲在 `SELECT`／`WITH` 開頭後面；MongoDB `$out`／`$merge` 在 `query` 需要 `data-admin`，在 snippet 與 `export` 一律拒絕。
 *   **黑名單管理器 (Blacklist Manager)**：從所有查詢結果中自動屏蔽敏感資料表與欄位。
 *   **查詢風險分析器 (`plan`)**：在不連線資料庫的情況下分析 SQL 風險。
 *   **Antigravity 協議**：將工作流程拆分為 **Architect (架構師/規劃)** 與 **Builder (建設者/執行)**，確保行動前必有策略。

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/plugins/dbcli-agent/skills/dbcli/SKILL.md
+++ b/plugins/dbcli-agent/skills/dbcli/SKILL.md
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/skills/dbcli/SKILL.md
+++ b/skills/dbcli/SKILL.md
@@ -217,7 +217,10 @@ or `doctor` / `status` reports a missing or invalid config, follow this flow.
      `--password` / `--name` (and `--system`).
 3. **What permission tier?** Default to the **lowest** that satisfies the task:
    `query-only` → `read-write` → `data-admin` → `admin`. Set with `--permission`
-   (defaults to `query-only`).
+   (defaults to `query-only`). Tiers judge what a statement does, not how it
+   opens: below `admin`, multi-statement SQL is rejected; snippets must be free
+   of write and DDL keywords; MongoDB `$out` / `$merge` need `data-admin` and are
+   refused entirely in snippets and `export`.
 4. **Verify, never assume.** After init: `dbcli status` (system + permission +
    blacklist summary, no creds) and `dbcli doctor --format json` (env, config
    shape, connectivity, schema-cache age, Mongo SRV path).

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -223,6 +223,13 @@ dbcli query "SELECT * FROM orders" --format html > orders.html   # pipe to stdou
 **Options:** `--format <table|json|csv|html>`, `--ui` (open the dashboard in the system browser; implies `--format html`), `--limit <number>`, `--no-limit`, `--collection <name>` (MongoDB / Elasticsearch), `--index <name>` (Elasticsearch alias for `--collection`), `--fields <list>`, `--truncate <number>` / `--no-truncate`, `-f, --query-file <path>`, `--use <name[,name]>`, `--recovery`
 **Permission:** query-only+ (Redis: per-command; Elasticsearch: per HTTP method/path)
 
+Below `admin`, SQL holding more than one statement is rejected, because only the
+first statement would decide the permission check while a driver on the simple
+query protocol executes them all. Semicolons inside string literals, backtick
+identifiers, and `#` comments are not separators. A MongoDB pipeline containing
+`$out` or `$merge` requires `data-admin`, and is rejected outright on `export`,
+in snippets, and in multi-connection fan-out.
+
 #### Field projection (`--fields`)
 
 ```bash
@@ -279,7 +286,7 @@ instead of silently running its only connection.
 An explicit comma-separated `--use primary,staging` fans one query out to several named
 connections. `DBCLI_CONNECTION` always names one literal connection and never enables
 fan-out. SQL permits `SELECT`, `SHOW`, `DESCRIBE`, and `EXPLAIN`; MongoDB permits filters and
-read-only pipelines without top-level `$out` / `$merge`; Elasticsearch permits searches.
+read-only pipelines without `$out` / `$merge`; Elasticsearch permits searches.
 Redis, writes, `--recovery`, `--ui`, CSV, and HTML are rejected before execution. Each
 connection keeps its own blacklist, limit metadata, audit entry, and error. Aggregate exit
 codes are `0` when all succeed, `2` for mixed outcomes, and `1` when all fail or preflight
@@ -530,6 +537,13 @@ dbcli q @analytics/revenue --param days=30 --format html > report.html
 #### Snippet file format
 
 Each `.sql` file is plain SQL with optional YAML frontmatter inside a leading `-- ---` block. Lines outside frontmatter form the SQL body.
+
+Snippets are read-only by contract, at every permission level including `admin`.
+A body must be a single statement opening with `SELECT` or `WITH` **and** free of
+write or DDL keywords, so a data-modifying CTE (`WITH x AS (DELETE … RETURNING *)
+SELECT * FROM x`) and `SELECT … INTO` are rejected at parse time rather than at
+execution. A MongoDB body may not contain `$out` or `$merge`. The same rule
+applies to `verify.query` in frontmatter, which `q --verify` executes verbatim.
 
 ```sql
 -- ---

--- a/src/commands/dml-plan.ts
+++ b/src/commands/dml-plan.ts
@@ -8,6 +8,7 @@ import { buildDeletePlanSql, buildInsertPlanSql, buildUpdatePlanSql } from '@/co
 import { analyzeMongoDmlRisk } from '@/core/mongo/dml-plan'
 import { analyzeRedisDmlRisk } from '@/core/redis/dml-plan'
 import { analyzeElasticsearchDmlRisk } from '@/core/elasticsearch/dml-plan'
+import { toSqlDialect } from '@/core/permission-guard'
 
 const ALLOWED_FORMATS = ['text', 'json'] as const
 const SQL_SYSTEMS = new Set(['postgresql', 'mysql', 'mariadb'])
@@ -60,6 +61,7 @@ export async function runDmlPlanAnalysis(
       const result = analyzeQueryRisk({
         sql: planSql,
         permission: config.permission,
+        dialect: toSqlDialect(config.connection?.system),
         blacklist,
         schemaLookup: {
           tables: schema as never,

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -98,7 +98,7 @@ export async function exportCommand(
     )
     await adapter.connect()
 
-    const executor = new QueryExecutor(adapter, config.permission, undefined, undefined, {
+    const executor = new QueryExecutor(adapter, config.permission, undefined, config, {
       recovery: options.recovery,
       deferDiagnostics: true,
     })

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -386,6 +386,13 @@ async function mongoExportBranch(
 
   const collection = options.collection
 
+  // `$out` / `$merge` write to a collection; export is a read operation.
+  const { assertNoMongoWriteStages } = await import('@/core/mongo/write-stage-guard')
+  assertNoMongoWriteStages(JSON.parse(query), config.permission, {
+    allowWithPermission: false,
+    context: 'MongoDB export',
+  })
+
   const blacklistManager = new BlacklistManager(config)
   const blacklistValidator = new BlacklistValidator(blacklistManager)
   blacklistValidator.checkTableBlacklist('SELECT', collection, [])

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -5,6 +5,7 @@ import { resolveConfigPath } from '@/utils/config-path'
 import { validateFormat } from '@/utils/validation'
 import { writeAuditEntry } from '@/core/audit/integration-helper'
 import type { DbcliConfig } from '@/utils/validation'
+import { toSqlDialect } from '@/core/permission-guard'
 
 const ALLOWED_FORMATS = ['text', 'json'] as const
 
@@ -38,6 +39,7 @@ export async function planCommand(
     const result = analyzeQueryRisk({
       sql: sql.trim(),
       permission: config.permission,
+      dialect: toSqlDialect(config.connection?.system),
       blacklist: config.blacklist ?? { tables: [], columns: {} },
       schemaLookup: {
         tables: schema as never,

--- a/src/commands/q-mongo.ts
+++ b/src/commands/q-mongo.ts
@@ -25,6 +25,21 @@ export async function qMongoBranch(
       `MongoDB snippet '${snippet.query.meta.key}' resolved without a target collection`
     )
   }
+  // Saved snippets are read-only by contract, so a write stage is refused at
+  // every permission level — including inside --dry-run, which would otherwise
+  // present a writing pipeline as a safe preview.
+  const { assertNoMongoWriteStages } = await import('@/core/mongo/write-stage-guard')
+  let parsedBody: unknown
+  try {
+    parsedBody = JSON.parse(prepared.driver.sql)
+  } catch {
+    parsedBody = undefined
+  }
+  assertNoMongoWriteStages(parsedBody, config.permission, {
+    allowWithPermission: false,
+    context: `MongoDB snippet '${snippet.query.meta.key}'`,
+  })
+
   const blacklistManager = new BlacklistManager(config)
   const blacklistValidator = new BlacklistValidator(blacklistManager)
   blacklistValidator.checkTableBlacklist('SELECT', collection)

--- a/src/commands/q-mongo.ts
+++ b/src/commands/q-mongo.ts
@@ -32,8 +32,13 @@ export async function qMongoBranch(
   let parsedBody: unknown
   try {
     parsedBody = JSON.parse(prepared.driver.sql)
-  } catch {
-    parsedBody = undefined
+  } catch (error) {
+    // A body the guard cannot read is a body it cannot clear. Refuse rather
+    // than pass an unexamined pipeline through.
+    throw new Error(
+      `MongoDB snippet '${snippet.query.meta.key}' body is not valid JSON, so it cannot be ` +
+        `proven free of write stages: ${(error as Error).message}`
+    )
   }
   assertNoMongoWriteStages(parsedBody, config.permission, {
     allowWithPermission: false,

--- a/src/commands/queries.ts
+++ b/src/commands/queries.ts
@@ -207,7 +207,16 @@ export async function queriesCheck(options: CheckOptions): Promise<void> {
   let failed = 0
   let total = 0
   try {
-    const map = await loadSnippets(dirs)
+    // A file that fails to parse is skipped by the loader so it cannot break
+    // every other command; `check` exists to report exactly those.
+    const map = await loadSnippets({
+      ...dirs,
+      onError: ({ key, error }) => {
+        total++
+        failed++
+        console.error(`✗ ${key}: ${error.message}`)
+      },
+    })
     for (const variants of map.values()) {
       for (const snippet of variants) {
         total++

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -335,19 +335,13 @@ async function preflightMongoQuery(
   ) {
     throw new Error('MongoDB multi-connection query must be an object filter or array pipeline')
   }
-  if (
-    multiConnection &&
-    Array.isArray(parsedQuery) &&
-    parsedQuery.some(
-      (stage) =>
-        stage !== null &&
-        typeof stage === 'object' &&
-        (Object.prototype.hasOwnProperty.call(stage, '$out') ||
-          Object.prototype.hasOwnProperty.call(stage, '$merge'))
-    )
-  ) {
-    throw new Error('MongoDB multi-connection pipelines cannot contain $out or $merge')
-  }
+  // `$out` / `$merge` write to a collection. Fan-out is read-only by contract;
+  // a single connection may write only at data-admin or above.
+  const { assertNoMongoWriteStages } = await import('@/core/mongo/write-stage-guard')
+  assertNoMongoWriteStages(parsedQuery, config.permission, {
+    allowWithPermission: !multiConnection,
+    context: 'MongoDB multi-connection pipelines',
+  })
 
   const blacklistValidator = new BlacklistValidator(new BlacklistManager(config))
   blacklistValidator.checkTableBlacklist('SELECT', collection, [])

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -464,7 +464,7 @@ async function sqlQueryBranch(
   try {
     await adapter.connect()
     const blacklistValidator = new BlacklistValidator(new BlacklistManager(config))
-    const executor = new QueryExecutor(adapter, config.permission, blacklistValidator, undefined, {
+    const executor = new QueryExecutor(adapter, config.permission, blacklistValidator, config, {
       ...options,
       deferDiagnostics: true,
     })

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -18,6 +18,7 @@ import { writeAuditEntry } from '@/core/audit/integration-helper'
 import { writeVerificationArtifact } from '@/core/verification'
 import type { BlacklistConfig } from '@/types/blacklist'
 import type { TableSchema } from '@/adapters/types'
+import { toSqlDialect } from '@/core/permission-guard'
 import {
   normalizeSafeBackfillInput,
   runSafeBackfillPreflight,
@@ -93,14 +94,14 @@ function buildRealRunners(ctx: RealRunnerContext): SafeBackfillRunners {
 
   // analyze with the live connection permission (used for verify-query readonly check)
   const analyze = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
 
   // analyzePlan uses read-write permission so the plan guard can approve a valid UPDATE
   // even when the connection is query-only. The plan guard validates structural safety
   // (UPDATE with WHERE, no mass-delete risk, etc.); connection permission is enforced
   // separately by the execution layer — which never actually runs the backfill write.
   const analyzePlan = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: 'read-write', blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: 'read-write', blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
 
   return {
     blacklistGuard: async (table): Promise<GuardOutcome> => {
@@ -190,7 +191,7 @@ function buildMigrationRunners(ctx: RealRunnerContext): MigrationRunners {
   const schemaLookup = { tables: schema, cacheAvailable: Object.keys(schema).length > 0 }
 
   const analyze = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
 
   return {
     blacklistGuard: async (table): Promise<GuardOutcome> => {
@@ -279,11 +280,11 @@ function buildRollbackRunners(ctx: RealRunnerContext, input: RollbackInput): Rol
   const schemaLookup = { tables: schema, cacheAvailable: Object.keys(schema).length > 0 }
 
   const analyze = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
   // read-write so the plan guard can approve a valid reverting UPDATE even on a
   // query-only connection; the reverting write is never executed here.
   const analyzePlan = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: 'read-write', blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: 'read-write', blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
 
   const ddlStatementGuard = async (statement: string, table: string): Promise<GuardOutcome> => {
     if (!isSingleStatement(statement)) {
@@ -421,7 +422,7 @@ function buildConstraintRunners(ctx: RealRunnerContext, input: ConstraintInput):
   const schema = (config.schema ?? {}) as Record<string, TableSchema>
   const schemaLookup = { tables: schema, cacheAvailable: Object.keys(schema).length > 0 }
   const analyze = (sql: string) =>
-    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup })
+    analyzeQueryRisk({ sql: sql.trim(), permission: config.permission, blacklist, schemaLookup, dialect: toSqlDialect(config.connection?.system) })
 
   const engine = constraintEngineOf((config.connection as ConnectionOptions).system)
   const violationSql = buildViolationQuery(input, engine)

--- a/src/core/mongo/write-stage-guard.ts
+++ b/src/core/mongo/write-stage-guard.ts
@@ -1,0 +1,79 @@
+import { permissionAtLeast } from '@/core/permission-guard'
+import type { Permission } from '@/types'
+
+/**
+ * Aggregation stages that write to a collection. MongoDB only permits them at
+ * the top level of a pipeline, and forbids them inside `$facet`, `$lookup`, and
+ * `$unionWith` sub-pipelines — we still scan those so enforcement does not
+ * depend on the server rejecting them.
+ */
+export const MONGO_WRITE_STAGES = ['$out', '$merge'] as const
+
+const SUB_PIPELINE_HOLDERS = ['$facet', '$lookup', '$unionWith'] as const
+
+/** Permission level required to run a pipeline that writes. */
+export const MONGO_WRITE_STAGE_MIN_PERMISSION: Permission = 'data-admin'
+
+function collect(pipeline: unknown, found: Set<string>): void {
+  if (!Array.isArray(pipeline)) return
+  for (const stage of pipeline) {
+    if (stage === null || typeof stage !== 'object') continue
+    const record = stage as Record<string, unknown>
+    for (const name of MONGO_WRITE_STAGES) {
+      if (Object.prototype.hasOwnProperty.call(record, name)) found.add(name)
+    }
+    for (const holder of SUB_PIPELINE_HOLDERS) {
+      const value = record[holder]
+      if (value === undefined || value === null) continue
+      if (Array.isArray(value)) {
+        collect(value, found)
+        continue
+      }
+      if (typeof value !== 'object') continue
+      // `$facet` maps names to pipelines; `$lookup` / `$unionWith` carry a
+      // `pipeline` field.
+      for (const nested of Object.values(value as Record<string, unknown>)) {
+        collect(nested, found)
+      }
+    }
+  }
+}
+
+/** Write stages present in an aggregation pipeline, in declaration order. */
+export function findMongoWriteStages(pipeline: unknown): string[] {
+  const found = new Set<string>()
+  collect(pipeline, found)
+  return MONGO_WRITE_STAGES.filter((name) => found.has(name))
+}
+
+/**
+ * Reject a pipeline that writes when the caller is not permitted to write.
+ *
+ * `allowWithPermission: false` refuses write stages outright regardless of the
+ * configured permission — used by paths that are read-only by contract, such as
+ * multi-connection fan-out and saved snippets.
+ */
+export function assertNoMongoWriteStages(
+  pipeline: unknown,
+  permission: Permission,
+  options: { allowWithPermission?: boolean; context?: string } = {}
+): void {
+  const stages = findMongoWriteStages(pipeline)
+  if (stages.length === 0) return
+
+  const listed = stages.join(' / ')
+  const { allowWithPermission = true, context } = options
+
+  if (!allowWithPermission) {
+    throw new Error(
+      `${context ?? 'This pipeline'} cannot contain ${listed}: the stage writes to a collection.`
+    )
+  }
+
+  if (!permissionAtLeast(permission, MONGO_WRITE_STAGE_MIN_PERMISSION)) {
+    throw new Error(
+      `Aggregation stage ${listed} writes to a collection and requires ` +
+        `${MONGO_WRITE_STAGE_MIN_PERMISSION} permission (current level: ${permission}).`
+    )
+  }
+}

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -465,33 +465,72 @@ export function classifyStatement(sql: string): StatementClassification {
  * statement is read-only despite a read-looking leading keyword — data-modifying
  * CTEs, `SELECT … INTO`, and `EXPLAIN ANALYZE` of a write.
  */
+/** SQL dialects whose quoting rules differ in ways that affect statement splitting. */
+export const SQL_DIALECTS = ['postgresql', 'mysql', 'mariadb'] as const
+export type SqlDialect = (typeof SQL_DIALECTS)[number]
+
 export const SQL_WRITE_OR_DDL_KEYWORDS =
-  /\b(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i
+  /(?<![.\w])(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i
+
+/**
+ * `FOR UPDATE` and `FOR SHARE` take row locks. They read, and the `UPDATE`
+ * inside them must not be mistaken for a write.
+ */
+const SQL_LOCK_CLAUSE = /\bFOR\s+(?:NO\s+KEY\s+)?UPDATE\b|\bFOR\s+(?:KEY\s+)?SHARE\b/gi
+
+/**
+ * The write or DDL keyword a statement would actually execute, or undefined if
+ * it proves read-only. Comments, string literals and quoted identifiers are
+ * removed per dialect first, so `SELECT \`update\` FROM t` and `# drop this`
+ * are reads while `WITH x AS (DELETE …)` is not.
+ *
+ * With several candidate dialects the check fails closed: a keyword executable
+ * under any of them counts, since the body may run under any of them.
+ */
+export function findWriteKeyword(
+  sql: string,
+  dialects?: readonly SqlDialect[]
+): string | undefined {
+  const candidates = dialects && dialects.length > 0 ? dialects : SQL_DIALECTS
+  for (const dialect of candidates) {
+    const executable = stripCommentsAndStrings(sql, { dialect }).replace(SQL_LOCK_CLAUSE, ' ')
+    const match = executable.match(SQL_WRITE_OR_DDL_KEYWORDS)
+    if (match?.[1]) return match[1].toUpperCase()
+  }
+  return undefined
+}
 
 /**
  * True when the SQL holds more than one statement, ignoring semicolons inside
  * comments and string literals and a single trailing separator.
  */
-export function containsMultipleStatements(sql: string): boolean {
-  const normalized = normalizeSQL(sql)
-  const dialects = ['postgresql', 'mysql', 'mariadb'] as const
+export function containsMultipleStatements(sql: string, dialect?: SqlDialect): boolean {
+  // Strip the raw SQL. Running a string-blind comment pass first (normalizeSQL)
+  // would let `SELECT 'x--' ; DELETE …` lose its tail before it is counted.
+  const statementCount = (candidate: SqlDialect): number =>
+    stripCommentsAndStrings(sql, { dialect: candidate })
+      .split(';')
+      .filter((part) => part.trim().length > 0).length
 
-  // Quoting differs per dialect ($$…$$, `identifiers`, # comments), and this
-  // check runs where the dialect is not always known. Only treat the SQL as
-  // stacked when every dialect reads it that way: a separator that one dialect
-  // hides inside a literal is not executable in the dialect that does not.
-  return dialects.every(
-    (dialect) =>
-      stripCommentsAndStrings(normalized, { dialect })
-        .split(';')
-        .filter((part) => part.trim().length > 0).length > 1
-  )
+  if (dialect) return statementCount(dialect) > 1
+
+  // Quoting differs per dialect: $$…$$ and $tag$…$tag$ are strings only in
+  // PostgreSQL, backticks quote identifiers only in MySQL/MariaDB, and `#`
+  // starts a comment in MySQL/MariaDB while PostgreSQL reads it as an operator.
+  // Without a dialect to judge by, fail closed — any reading that finds a
+  // separator wins, because the alternative hides a separator the real dialect
+  // would execute.
+  return SQL_DIALECTS.some((candidate) => statementCount(candidate) > 1)
 }
 
 /**
  * Check if statement is allowed under given permission level
  */
-export function checkPermission(sql: string, permission: Permission): PermissionCheckResult {
+export function checkPermission(
+  sql: string,
+  permission: Permission,
+  dialect?: SqlDialect
+): PermissionCheckResult {
   const classification = classifyStatement(sql)
 
   // Classification describes one statement, but drivers using the simple query
@@ -499,7 +538,7 @@ export function checkPermission(sql: string, permission: Permission): Permission
   // string. A stacked statement would therefore be judged by its first keyword
   // alone and smuggle a trailing write past the permission level. Admin already
   // permits every statement type, so stacking grants it nothing.
-  if (permission !== 'admin' && containsMultipleStatements(sql)) {
+  if (permission !== 'admin' && containsMultipleStatements(sql, dialect)) {
     return {
       allowed: false,
       reason:
@@ -584,8 +623,12 @@ export function checkPermission(sql: string, permission: Permission): Permission
  * Throws PermissionError if statement not allowed, otherwise returns classification
  * Use in command handlers before execution
  */
-export function enforcePermission(sql: string, permission: Permission): StatementClassification {
-  const result = checkPermission(sql, permission)
+export function enforcePermission(
+  sql: string,
+  permission: Permission,
+  dialect?: SqlDialect
+): StatementClassification {
+  const result = checkPermission(sql, permission, dialect)
 
   if (!result.allowed) {
     throw new PermissionError(result.reason, result.classification, permission)

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -525,36 +525,12 @@ export function findWriteKeyword(
   dialects?: readonly SqlDialect[]
 ): string | undefined {
   const candidates = dialects && dialects.length > 0 ? dialects : SQL_DIALECTS
-  const global = new RegExp(SQL_WRITE_OR_DDL_KEYWORDS.source, 'gi')
-  let strictest: string | undefined
   for (const dialect of candidates) {
-    const executable = stripCommentsAndStrings(sql, { dialect })
-      .replace(SQL_LOCK_CLAUSE, ' ')
-      // `INTO` marks a table creation only in `SELECT … INTO`. In
-      // `INSERT INTO` / `REPLACE INTO` / `MERGE INTO` it belongs to the verb
-      // already counted, and counting it again would push every insert to the
-      // admin tier.
-      .replace(/\b(INSERT|REPLACE|MERGE)\s+INTO\b/gi, '$1 ')
-    for (const match of executable.matchAll(global)) {
-      const keyword = match[1]?.toUpperCase()
-      if (!keyword) continue
-      // The strictest keyword decides, not the leftmost one: a statement that
-      // opens with an INSERT CTE and then deletes must be judged as the delete,
-      // or a harmless leading write would launder a stricter one past its tier.
-      if (strictest === undefined || tierRank(keyword) > tierRank(strictest)) {
-        strictest = keyword
-      }
-    }
+    const executable = stripCommentsAndStrings(sql, { dialect }).replace(SQL_LOCK_CLAUSE, ' ')
+    const match = executable.match(SQL_WRITE_OR_DDL_KEYWORDS)
+    if (match?.[1]) return match[1].toUpperCase()
   }
-  return strictest
-}
-
-/** How restrictive the permission tier for a write keyword is. Higher is stricter. */
-function tierRank(keyword: string): number {
-  const type = mapKeywordToType(keyword)
-  if (type === 'INSERT' || type === 'UPDATE') return 1
-  if (type === 'DELETE') return 2
-  return 3 // DDL and anything unrecognised — admin only
+  return undefined
 }
 
 /**
@@ -610,9 +586,16 @@ function escalateHiddenWrite(
   const hidden = findWriteKeyword(sql, dialect ? [dialect] : undefined)
   if (!hidden) return classification
 
+  // A statement that claims to read and does not is judged admin-only, rather
+  // than by the tier of the keyword found. Ranking the keyword invited two
+  // rounds of defects: the leftmost write laundered a stricter one, and the
+  // textual exceptions needed to rank `INTO` correctly interacted with each
+  // other to erase the write completely. A writable CTE below admin is a rare
+  // shape; treating every one of them as admin-only costs little and removes
+  // the whole class.
   return {
     ...classification,
-    type: mapKeywordToType(hidden),
+    type: 'UNKNOWN',
     isDangerous: true,
     confidence: 'HIGH',
   }

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -503,7 +503,7 @@ export function toSqlDialect(system: string | undefined): SqlDialect | undefined
 }
 
 export const SQL_WRITE_OR_DDL_KEYWORDS =
-  /(?<![.\w])(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i
+  /(?<![.\w])(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b(?!\s*\()/i
 
 /**
  * `FOR UPDATE` and `FOR SHARE` take row locks. They read, and the `UPDATE`
@@ -525,12 +525,36 @@ export function findWriteKeyword(
   dialects?: readonly SqlDialect[]
 ): string | undefined {
   const candidates = dialects && dialects.length > 0 ? dialects : SQL_DIALECTS
+  const global = new RegExp(SQL_WRITE_OR_DDL_KEYWORDS.source, 'gi')
+  let strictest: string | undefined
   for (const dialect of candidates) {
-    const executable = stripCommentsAndStrings(sql, { dialect }).replace(SQL_LOCK_CLAUSE, ' ')
-    const match = executable.match(SQL_WRITE_OR_DDL_KEYWORDS)
-    if (match?.[1]) return match[1].toUpperCase()
+    const executable = stripCommentsAndStrings(sql, { dialect })
+      .replace(SQL_LOCK_CLAUSE, ' ')
+      // `INTO` marks a table creation only in `SELECT … INTO`. In
+      // `INSERT INTO` / `REPLACE INTO` / `MERGE INTO` it belongs to the verb
+      // already counted, and counting it again would push every insert to the
+      // admin tier.
+      .replace(/\b(INSERT|REPLACE|MERGE)\s+INTO\b/gi, '$1 ')
+    for (const match of executable.matchAll(global)) {
+      const keyword = match[1]?.toUpperCase()
+      if (!keyword) continue
+      // The strictest keyword decides, not the leftmost one: a statement that
+      // opens with an INSERT CTE and then deletes must be judged as the delete,
+      // or a harmless leading write would launder a stricter one past its tier.
+      if (strictest === undefined || tierRank(keyword) > tierRank(strictest)) {
+        strictest = keyword
+      }
+    }
   }
-  return undefined
+  return strictest
+}
+
+/** How restrictive the permission tier for a write keyword is. Higher is stricter. */
+function tierRank(keyword: string): number {
+  const type = mapKeywordToType(keyword)
+  if (type === 'INSERT' || type === 'UPDATE') return 1
+  if (type === 'DELETE') return 2
+  return 3 // DDL and anything unrecognised — admin only
 }
 
 /**
@@ -562,7 +586,7 @@ export function containsMultipleStatements(sql: string, dialect?: SqlDialect): b
  * `DESCRIBE` take no subquery, so `SHOW CREATE TABLE users` is a read whose text
  * merely contains a keyword.
  */
-const ESCALATABLE_READ_TYPES = new Set<StatementType>(['SELECT', 'EXPLAIN'])
+const ESCALATABLE_READ_TYPES = new Set<StatementType>(['SELECT', 'EXPLAIN', 'DESCRIBE'])
 
 /**
  * Re-classify a read-looking statement by the write it actually performs, so the
@@ -577,8 +601,11 @@ function escalateHiddenWrite(
   if (!ESCALATABLE_READ_TYPES.has(classification.type)) return classification
 
   // `EXPLAIN` without `ANALYZE` only plans; it never runs the statement it
-  // describes, so a write keyword inside it is not executed either.
-  if (classification.type === 'EXPLAIN' && !/\bANALYZE\b/i.test(sql)) return classification
+  // describes, so a write keyword inside it is not executed either. `DESCRIBE`
+  // and `DESC` are synonyms for `EXPLAIN` on MySQL and MariaDB and take the same
+  // `ANALYZE` form.
+  const plansOnly = classification.type === 'EXPLAIN' || classification.type === 'DESCRIBE'
+  if (plansOnly && !/\bANALYZE\b/i.test(sql)) return classification
 
   const hidden = findWriteKeyword(sql, dialect ? [dialect] : undefined)
   if (!hidden) return classification

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -461,10 +461,53 @@ export function classifyStatement(sql: string): StatementClassification {
 }
 
 /**
+ * Keywords that write or change schema. Used by every path that has to prove a
+ * statement is read-only despite a read-looking leading keyword — data-modifying
+ * CTEs, `SELECT … INTO`, and `EXPLAIN ANALYZE` of a write.
+ */
+export const SQL_WRITE_OR_DDL_KEYWORDS =
+  /\b(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i
+
+/**
+ * True when the SQL holds more than one statement, ignoring semicolons inside
+ * comments and string literals and a single trailing separator.
+ */
+export function containsMultipleStatements(sql: string): boolean {
+  const normalized = normalizeSQL(sql)
+  const dialects = ['postgresql', 'mysql', 'mariadb'] as const
+
+  // Quoting differs per dialect ($$…$$, `identifiers`, # comments), and this
+  // check runs where the dialect is not always known. Only treat the SQL as
+  // stacked when every dialect reads it that way: a separator that one dialect
+  // hides inside a literal is not executable in the dialect that does not.
+  return dialects.every(
+    (dialect) =>
+      stripCommentsAndStrings(normalized, { dialect })
+        .split(';')
+        .filter((part) => part.trim().length > 0).length > 1
+  )
+}
+
+/**
  * Check if statement is allowed under given permission level
  */
 export function checkPermission(sql: string, permission: Permission): PermissionCheckResult {
   const classification = classifyStatement(sql)
+
+  // Classification describes one statement, but drivers using the simple query
+  // protocol (PostgreSQL) execute every semicolon-separated statement in the
+  // string. A stacked statement would therefore be judged by its first keyword
+  // alone and smuggle a trailing write past the permission level. Admin already
+  // permits every statement type, so stacking grants it nothing.
+  if (permission !== 'admin' && containsMultipleStatements(sql)) {
+    return {
+      allowed: false,
+      reason:
+        'SQL containing multiple statements is refused below admin permission, because only ' +
+        'the first statement determines the permission check. Run each statement separately.',
+      classification,
+    }
+  }
 
   // Admin allows everything
   if (permission === 'admin') {

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -149,11 +149,22 @@ export function stripCommentsAndStrings(
         i = closingIndex === -1 ? sql.length : closingIndex + 2
         continue
       }
+      // PostgreSQL block comments nest: `/* a /* b */ still comment */`.
+      // Stopping at the first `*/` would leave the tail of the comment visible
+      // and its semicolons counted as separators.
+      const nests = options.dialect === 'postgresql'
+      let depth = 1
       i += 2
-      while (i < sql.length) {
-        if (sql[i] === '*' && sql[i + 1] === '/') {
+      while (i < sql.length && depth > 0) {
+        if (nests && sql[i] === '/' && sql[i + 1] === '*') {
+          depth++
           i += 2
-          break
+          continue
+        }
+        if (sql[i] === '*' && sql[i + 1] === '/') {
+          depth--
+          i += 2
+          continue
         }
         i++
       }
@@ -165,7 +176,15 @@ export function stripCommentsAndStrings(
     // The closing delimiter is case-sensitive and may contain SQL-looking
     // text or semicolons that must not participate in permission analysis.
     if (options.dialect === 'postgresql' && char === '$') {
-      const delimiter = sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)?.[0]
+      // A dollar-quote only opens at a token boundary. PostgreSQL identifiers
+      // may contain `$` from the second character on, so in `SELECT 1 AS a$q$`
+      // the `$q$` belongs to the identifier `a$q$` and quotes nothing — reading
+      // it as a quote would hide everything up to the next `$q$` from analysis
+      // while the server still executes it.
+      const opensToken = !/[A-Za-z0-9_$]/.test(sql[i - 1] ?? '')
+      const delimiter = opensToken
+        ? sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)?.[0]
+        : undefined
       if (delimiter) {
         i += delimiter.length
         const closingIndex = sql.indexOf(delimiter, i)

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -36,6 +36,12 @@ export interface StatementClassification {
   keywords: string[]
   isComposite: boolean
   confidence: 'HIGH' | 'MEDIUM' | 'LOW'
+  /**
+   * Set when a read-looking statement was re-classified because it contains an
+   * executable write. Holds that keyword, so a refusal can say what was found
+   * rather than reporting the statement as unrecognised.
+   */
+  escalatedFrom?: string
 }
 
 /**
@@ -598,6 +604,7 @@ function escalateHiddenWrite(
     type: 'UNKNOWN',
     isDangerous: true,
     confidence: 'HIGH',
+    escalatedFrom: hidden,
   }
 }
 
@@ -627,6 +634,20 @@ export function checkPermission(
       reason:
         'SQL containing multiple statements is refused below admin permission, because only ' +
         'the first statement determines the permission check. Run each statement separately.',
+      classification,
+    }
+  }
+
+  // A statement re-classified because it hides a write is refused with what was
+  // actually found. The generic messages below name the next tier up, which is
+  // wrong here: every tier short of admin refuses it.
+  if (permission !== 'admin' && classification.escalatedFrom) {
+    return {
+      allowed: false,
+      reason:
+        `This statement opens as a read but contains an executable ` +
+        `${classification.escalatedFrom}. A write hidden inside a read statement ` +
+        `requires admin permission (current level: ${permission}).`,
       classification,
     }
   }

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -557,6 +557,41 @@ export function containsMultipleStatements(sql: string, dialect?: SqlDialect): b
 }
 
 /**
+ * Read-looking statement types that can nevertheless carry an executable write:
+ * a `SELECT` through a CTE or `INTO`, an `EXPLAIN` through `ANALYZE`. `SHOW` and
+ * `DESCRIBE` take no subquery, so `SHOW CREATE TABLE users` is a read whose text
+ * merely contains a keyword.
+ */
+const ESCALATABLE_READ_TYPES = new Set<StatementType>(['SELECT', 'EXPLAIN'])
+
+/**
+ * Re-classify a read-looking statement by the write it actually performs, so the
+ * permission tiers judge what runs rather than what the statement opens with.
+ * Returns the classification unchanged when the statement really is a read.
+ */
+function escalateHiddenWrite(
+  sql: string,
+  classification: StatementClassification,
+  dialect: SqlDialect | undefined
+): StatementClassification {
+  if (!ESCALATABLE_READ_TYPES.has(classification.type)) return classification
+
+  // `EXPLAIN` without `ANALYZE` only plans; it never runs the statement it
+  // describes, so a write keyword inside it is not executed either.
+  if (classification.type === 'EXPLAIN' && !/\bANALYZE\b/i.test(sql)) return classification
+
+  const hidden = findWriteKeyword(sql, dialect ? [dialect] : undefined)
+  if (!hidden) return classification
+
+  return {
+    ...classification,
+    type: mapKeywordToType(hidden),
+    isDangerous: true,
+    confidence: 'HIGH',
+  }
+}
+
+/**
  * Check if statement is allowed under given permission level
  */
 export function checkPermission(
@@ -564,7 +599,12 @@ export function checkPermission(
   permission: Permission,
   dialect?: SqlDialect
 ): PermissionCheckResult {
-  const classification = classifyStatement(sql)
+  // A read-looking leading keyword does not make a statement a read: a CTE can
+  // carry DELETE/UPDATE/INSERT … RETURNING, `SELECT … INTO` creates a table, and
+  // `EXPLAIN ANALYZE <write>` executes the write it explains. Judging the
+  // statement by the write it performs lets the ordinary tiers decide, instead
+  // of this proof living only on the multi-connection path as it used to.
+  const classification = escalateHiddenWrite(sql, classifyStatement(sql), dialect)
 
   // Classification describes one statement, but drivers using the simple query
   // protocol (PostgreSQL) execute every semicolon-separated statement in the

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -86,6 +86,15 @@ export function normalizeSQL(sql: string): string {
 }
 
 /**
+ * A character that can continue a PostgreSQL identifier. Its lexer accepts any
+ * high byte (`ident_cont` is `[A-Za-z\200-\377_0-9$]`), so accented and
+ * non-Latin letters count — `café$q$` is one identifier, not `café` followed by
+ * a dollar-quote. Treating a character as part of an identifier only ever makes
+ * the analysis stricter, since fewer regions get stripped from view.
+ */
+const IDENTIFIER_CONTINUATION = /[A-Za-z0-9_$]|[\u0080-\uFFFF]/
+
+/**
  * Strip comments AND string literals using character-by-character state machine
  * More reliable than regex for handling escape sequences
  */
@@ -181,7 +190,7 @@ export function stripCommentsAndStrings(
       // the `$q$` belongs to the identifier `a$q$` and quotes nothing — reading
       // it as a quote would hide everything up to the next `$q$` from analysis
       // while the server still executes it.
-      const opensToken = !/[A-Za-z0-9_$]/.test(sql[i - 1] ?? '')
+      const opensToken = !IDENTIFIER_CONTINUATION.test(sql[i - 1] ?? '')
       const delimiter = opensToken
         ? sql.slice(i).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)?.[0]
         : undefined
@@ -224,7 +233,7 @@ export function stripCommentsAndStrings(
         options.dialect === 'postgresql' &&
         quote === "'" &&
         /[eE]/.test(sql[quoteIndex - 1] ?? '') &&
-        !/[A-Za-z0-9_$]/.test(sql[quoteIndex - 2] ?? '')
+        !IDENTIFIER_CONTINUATION.test(sql[quoteIndex - 2] ?? '')
       const backslashEscapes = options.dialect === undefined || postgresEscapeString
       i++
       while (i < sql.length) {
@@ -487,6 +496,11 @@ export function classifyStatement(sql: string): StatementClassification {
 /** SQL dialects whose quoting rules differ in ways that affect statement splitting. */
 export const SQL_DIALECTS = ['postgresql', 'mysql', 'mariadb'] as const
 export type SqlDialect = (typeof SQL_DIALECTS)[number]
+
+/** The SQL dialect of a connection system, or undefined for a non-SQL engine. */
+export function toSqlDialect(system: string | undefined): SqlDialect | undefined {
+  return SQL_DIALECTS.find((dialect) => dialect === system)
+}
 
 export const SQL_WRITE_OR_DDL_KEYWORDS =
   /(?<![.\w])(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i

--- a/src/core/query-executor.ts
+++ b/src/core/query-executor.ts
@@ -12,6 +12,8 @@ import {
   enforcePermission,
   PermissionError,
   stripCommentsAndStrings,
+  SQL_DIALECTS,
+  type SqlDialect,
 } from '@/core/permission-guard'
 import { suggestTableName } from '@/utils/error-suggester'
 import { extractTableName } from '@/utils/engine-hints'
@@ -38,8 +40,24 @@ export class QueryExecutor {
       connectionName?: string
       recovery?: boolean
       deferDiagnostics?: boolean
+      /**
+       * Quoting rules that decide what counts as a statement separator differ
+       * per dialect. Without this, the stacking check has to fail closed.
+       */
+      dialect?: SqlDialect
     } = {}
   ) {}
+
+  /**
+   * The dialect the statement will actually run under. Falls back to the
+   * connection config, then to undefined — where the stacking check fails
+   * closed rather than guessing.
+   */
+  private resolveDialect(): SqlDialect | undefined {
+    if (this.options.dialect) return this.options.dialect
+    const system = this.config?.connection?.system
+    return SQL_DIALECTS.find((dialect) => dialect === system)
+  }
 
   takeDiagnostics(): string[] {
     const diagnostics = this.pendingDiagnostics
@@ -70,7 +88,7 @@ export class QueryExecutor {
     this.pendingDiagnostics = []
     try {
       // 1. Enforce permission before execution
-      const classification = enforcePermission(sql, this.permission)
+      const classification = enforcePermission(sql, this.permission, this.resolveDialect())
 
       // 1b. Warn on dangerous DDL operations even in admin mode
       const dangerousOperationWarning =

--- a/src/core/query-fanout.ts
+++ b/src/core/query-fanout.ts
@@ -1,6 +1,7 @@
 import type { QueryResult } from '@/types/query'
 import { mapCliError, type CliErrorPresentation } from '@/utils/cli-error'
 import {
+  classifyStatement,
   enforcePermission,
   stripCommentsAndStrings,
   SQL_WRITE_OR_DDL_KEYWORDS,
@@ -58,11 +59,16 @@ export function assertFanOutReadOnlySql(
   if (statements.length !== 1) {
     throw new Error('Multi-connection SQL must contain exactly one read-only statement')
   }
-  const classification = enforcePermission(sql, 'query-only', dialect)
+  // Prove read-only first, so the fan-out contract is what the caller is told;
+  // the permission check would otherwise report the same rejection as a tier
+  // error, which is true but says nothing about why fan-out is stricter.
   const containsWrite = SQL_WRITE_OR_DDL_KEYWORDS.test(executableSql)
+  const classification = classifyStatement(sql)
   const explainExecutes = classification.type === 'EXPLAIN' && /\bANALYZE\b/i.test(executableSql)
 
   if ((classification.type === 'SELECT' && containsWrite) || (explainExecutes && containsWrite)) {
     throw new Error('Multi-connection SQL must be proven read-only before any connection executes')
   }
+
+  enforcePermission(sql, 'query-only', dialect)
 }

--- a/src/core/query-fanout.ts
+++ b/src/core/query-fanout.ts
@@ -1,6 +1,10 @@
 import type { QueryResult } from '@/types/query'
 import { mapCliError, type CliErrorPresentation } from '@/utils/cli-error'
-import { enforcePermission, stripCommentsAndStrings } from '@/core/permission-guard'
+import {
+  enforcePermission,
+  stripCommentsAndStrings,
+  SQL_WRITE_OR_DDL_KEYWORDS,
+} from '@/core/permission-guard'
 
 export type ConnectionQueryOutcome =
   | {
@@ -36,9 +40,6 @@ export function aggregateFanOutExitCode(outcomes: readonly ConnectionQueryOutcom
   return 2
 }
 
-const SQL_WRITE_OR_DDL_KEYWORDS =
-  /\b(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|RENAME|INTO)\b/i
-
 /**
  * Fail closed around SQL shapes whose leading keyword looks read-only but can
  * execute writes, notably data-modifying CTEs and EXPLAIN ANALYZE writes.
@@ -47,7 +48,8 @@ export function assertFanOutReadOnlySql(
   sql: string,
   dialect: 'postgresql' | 'mysql' | 'mariadb'
 ): void {
-  const classification = enforcePermission(sql, 'query-only')
+  // The dialect is known here, so the statement count is checked first and
+  // reports the fan-out contract rather than the generic stacking message.
   const executableSql = stripCommentsAndStrings(sql, { dialect })
   const statements = executableSql
     .split(';')
@@ -56,6 +58,7 @@ export function assertFanOutReadOnlySql(
   if (statements.length !== 1) {
     throw new Error('Multi-connection SQL must contain exactly one read-only statement')
   }
+  const classification = enforcePermission(sql, 'query-only')
   const containsWrite = SQL_WRITE_OR_DDL_KEYWORDS.test(executableSql)
   const explainExecutes = classification.type === 'EXPLAIN' && /\bANALYZE\b/i.test(executableSql)
 

--- a/src/core/query-fanout.ts
+++ b/src/core/query-fanout.ts
@@ -58,7 +58,7 @@ export function assertFanOutReadOnlySql(
   if (statements.length !== 1) {
     throw new Error('Multi-connection SQL must contain exactly one read-only statement')
   }
-  const classification = enforcePermission(sql, 'query-only')
+  const classification = enforcePermission(sql, 'query-only', dialect)
   const containsWrite = SQL_WRITE_OR_DDL_KEYWORDS.test(executableSql)
   const explainExecutes = classification.type === 'EXPLAIN' && /\bANALYZE\b/i.test(executableSql)
 

--- a/src/core/query-risk-analyzer.ts
+++ b/src/core/query-risk-analyzer.ts
@@ -99,7 +99,7 @@ export function analyzeQueryRisk(input: AnalyzeQueryRiskInput): QueryRiskResult 
   const facts = collectSqlFacts(input.sql)
   const factors: QueryRiskFactor[] = []
 
-  applyPermissionRules(input.sql, input.permission, factors)
+  applyPermissionRules(input.sql, input.permission, factors, input.dialect)
   applyWriteWhereRules(facts, factors)
   applyDdlAndUnknownRules(facts, factors)
   applySelectPatternRules(facts, factors)
@@ -249,9 +249,10 @@ function extractReferencedColumns(sql: string, operation: QueryRiskOperation): s
 function applyPermissionRules(
   sql: string,
   permission: AnalyzeQueryRiskInput['permission'],
-  factors: QueryRiskFactor[]
+  factors: QueryRiskFactor[],
+  dialect: AnalyzeQueryRiskInput['dialect']
 ): void {
-  const permissionResult = checkPermission(sql, permission)
+  const permissionResult = checkPermission(sql, permission, dialect)
   if (!permissionResult.allowed) {
     pushFactor(factors, 'permission_denied', 'block', permissionResult.reason)
   }

--- a/src/core/repl/repl-engine.ts
+++ b/src/core/repl/repl-engine.ts
@@ -7,7 +7,12 @@ import { MultilineBuffer } from './multiline-buffer'
 import { handleMetaCommand } from './meta-commands'
 import { parseCommandLine, isKnownCommand } from './command-dispatcher'
 import { HistoryManager } from './history-manager'
-import { checkPermission, classifyRedisCommand, permissionAtLeast } from '../permission-guard'
+import {
+  checkPermission,
+  classifyRedisCommand,
+  permissionAtLeast,
+  SQL_DIALECTS,
+} from '../permission-guard'
 import { QueryResultFormatter } from '../../formatters/query-result-formatter'
 import type { QueryResult } from '../../types/query'
 import { t_vars, t } from '../../i18n/message-loader'
@@ -175,7 +180,11 @@ export class ReplEngine {
       const denied = this.checkRedisPermission(sql)
       if (denied) return denied
     } else {
-      const permResult = checkPermission(sql, this.context.permission)
+      const permResult = checkPermission(
+        sql,
+        this.context.permission,
+        SQL_DIALECTS.find((dialect) => dialect === this.context.system)
+      )
       if (!permResult.allowed) {
         return {
           action: 'continue',

--- a/src/core/saved-queries/loader.ts
+++ b/src/core/saved-queries/loader.ts
@@ -14,6 +14,12 @@ export interface LoadOptions {
   builtinDir: string
   sharedDir: string
   localDir: string
+  /**
+   * Called for a snippet file that cannot be parsed. Loading continues either
+   * way, so one bad file never hides the rest of the directory; commands that
+   * must fail on a bad snippet (`queries check`) collect them here.
+   */
+  onError?: (failure: { file: string; key: string; error: Error }) => void
 }
 
 const ENGINE_SUFFIXES: ReadonlyArray<EngineTag> = [
@@ -30,9 +36,9 @@ const ENGINE_SUFFIXES: ReadonlyArray<EngineTag> = [
  * 會根據目前連線的 engine 挑選對應變體。
  */
 export async function loadSnippets(opts: LoadOptions): Promise<Map<string, ResolvedSnippet[]>> {
-  const builtin = await walkAndParse(opts.builtinDir, 'builtin')
-  const shared = await walkAndParse(opts.sharedDir, 'shared')
-  const local = await walkAndParse(opts.localDir, 'local')
+  const builtin = await walkAndParse(opts.builtinDir, 'builtin', opts.onError)
+  const shared = await walkAndParse(opts.sharedDir, 'shared', opts.onError)
+  const local = await walkAndParse(opts.localDir, 'local', opts.onError)
 
   const merged = new Map<string, ResolvedSnippet[]>()
   pushTier(merged, builtin)
@@ -58,7 +64,11 @@ function sameEngineSet(a: SavedQuery, b: SavedQuery): boolean {
   return ae === be
 }
 
-async function walkAndParse(root: string, source: SnippetSource): Promise<SavedQuery[]> {
+async function walkAndParse(
+  root: string,
+  source: SnippetSource,
+  onError?: LoadOptions['onError']
+): Promise<SavedQuery[]> {
   const out: SavedQuery[] = []
   let entries: string[]
   try {
@@ -71,9 +81,17 @@ async function walkAndParse(root: string, source: SnippetSource): Promise<SavedQ
     const rel = relative(root, file).replace(new RegExp(`\\${sep}`, 'g'), '/')
     const { logicalKey, suffixEngine } = parseFilename(rel)
     const text = await Bun.file(file).text()
-    const { query } = parseSavedQuery({ key: logicalKey, file, source, text })
-    enforceSuffixEngineConsistency(query, suffixEngine)
-    out.push(query)
+    // One unparseable file must not take the whole directory with it: a single
+    // rejected snippet would otherwise break `q list`, every `q @name`, and
+    // `report`, since they all load through here.
+    try {
+      const { query } = parseSavedQuery({ key: logicalKey, file, source, text })
+      enforceSuffixEngineConsistency(query, suffixEngine)
+      out.push(query)
+    } catch (error) {
+      if (onError) onError({ file, key: logicalKey, error: error as Error })
+      else console.error(`⚠ Skipping snippet ${logicalKey}: ${(error as Error).message}`)
+    }
   }
   return out
 }

--- a/src/core/saved-queries/parser.ts
+++ b/src/core/saved-queries/parser.ts
@@ -12,7 +12,11 @@
 
 import { engineFamily, getStrategy } from './strategies'
 import { parseYamlMini } from './yaml-mini'
-import { SQL_WRITE_OR_DDL_KEYWORDS } from '@/core/permission-guard'
+import {
+  findWriteKeyword,
+  SQL_DIALECTS,
+  type SqlDialect,
+} from '@/core/permission-guard'
 import {
   SavedQueryError,
   SUPPORTED_CHART_TYPES,
@@ -45,6 +49,23 @@ export interface ParseInput {
   text: string
 }
 
+const ENGINE_DIALECT: Record<string, SqlDialect> = {
+  postgres: 'postgresql',
+  postgresql: 'postgresql',
+  mysql: 'mysql',
+  mariadb: 'mariadb',
+}
+
+/**
+ * SQL dialects a snippet may run under. An undeclared engine leaves every
+ * dialect a candidate, which makes the read-only proof stricter rather than
+ * weaker.
+ */
+function dialectsFor(engines: readonly string[] | undefined): readonly SqlDialect[] {
+  const mapped = (engines ?? []).map((engine) => ENGINE_DIALECT[engine]).filter(Boolean)
+  return mapped.length > 0 ? (mapped as SqlDialect[]) : SQL_DIALECTS
+}
+
 export interface ParseOutput {
   query: SavedQuery
   warnings: string[]
@@ -68,7 +89,7 @@ export function parseSavedQuery(input: ParseInput): ParseOutput {
   if (meta.engine && meta.engine.length > 0) {
     const family = engineFamily(meta.engine[0]!)
     if (family === 'sql') {
-      validateBody(body, input)
+      validateBody(body, { ...input, engine: meta.engine })
     } else {
       try {
         getStrategy(family).validateBody(body, meta, input.file)
@@ -81,7 +102,7 @@ export function parseSavedQuery(input: ParseInput): ParseOutput {
       }
     }
   } else {
-    validateBody(body, input)
+    validateBody(body, { ...input, engine: meta.engine })
   }
 
   if (meta.engine?.includes('elasticsearch') && !meta.index) {
@@ -232,11 +253,11 @@ function normaliseVerify(value: unknown, input: ParseInput): SavedQueryVerify | 
   }
   // The verification query is executed verbatim by `q --verify`, so it carries
   // the same read-only contract as the snippet body.
-  const verifyWrite = stripCommentsAndStrings(raw.query).match(SQL_WRITE_OR_DDL_KEYWORDS)
+  const verifyWrite = findWriteKeyword(raw.query)
   if (verifyWrite) {
     throw new SavedQueryError(
       `Snippet '${input.key}' has a 'verify.query' that must be read-only, ` +
-        `but contains '${verifyWrite[0].toUpperCase()}'`,
+        `but contains '${verifyWrite}'`,
       'NOT_SELECT',
       input.file
     )
@@ -331,7 +352,10 @@ function normaliseParams(value: unknown, input: ParseInput): ParamSpec[] {
   )
 }
 
-export function validateBody(body: string, input: ParseInput): void {
+export function validateBody(
+  body: string,
+  input: ParseInput & { engine?: readonly string[] }
+): void {
   const stripped = stripCommentsAndStrings(body)
   const trimmed = stripped.trim()
   if (!trimmed) {
@@ -353,11 +377,13 @@ export function validateBody(body: string, input: ParseInput): void {
 
   // A read-looking leading keyword does not prove the statement reads: a CTE can
   // carry DELETE/UPDATE/INSERT … RETURNING, and `SELECT … INTO` creates a table.
-  // Snippets are read-only by contract, so refuse them at parse time.
-  const write = trimmed.match(SQL_WRITE_OR_DDL_KEYWORDS)
+  // Snippets are read-only by contract, so refuse them at parse time. The check
+  // runs on the original body under the declared engines' quoting rules, so a
+  // quoted identifier or a dialect comment is not mistaken for a write.
+  const write = findWriteKeyword(body, dialectsFor(input.engine))
   if (write) {
     throw new SavedQueryError(
-      `Snippet '${input.key}' must be read-only, but contains '${write[0].toUpperCase()}'`,
+      `Snippet '${input.key}' must be read-only, but contains '${write}'`,
       'NOT_SELECT',
       input.file
     )

--- a/src/core/saved-queries/parser.ts
+++ b/src/core/saved-queries/parser.ts
@@ -12,6 +12,7 @@
 
 import { engineFamily, getStrategy } from './strategies'
 import { parseYamlMini } from './yaml-mini'
+import { SQL_WRITE_OR_DDL_KEYWORDS } from '@/core/permission-guard'
 import {
   SavedQueryError,
   SUPPORTED_CHART_TYPES,
@@ -334,6 +335,18 @@ export function validateBody(body: string, input: ParseInput): void {
   if (firstKeyword !== 'SELECT' && firstKeyword !== 'WITH') {
     throw new SavedQueryError(
       `Snippet '${input.key}' must start with SELECT or WITH (got '${firstKeyword || '<empty>'}')`,
+      'NOT_SELECT',
+      input.file
+    )
+  }
+
+  // A read-looking leading keyword does not prove the statement reads: a CTE can
+  // carry DELETE/UPDATE/INSERT … RETURNING, and `SELECT … INTO` creates a table.
+  // Snippets are read-only by contract, so refuse them at parse time.
+  const write = trimmed.match(SQL_WRITE_OR_DDL_KEYWORDS)
+  if (write) {
+    throw new SavedQueryError(
+      `Snippet '${input.key}' must be read-only, but contains '${write[0].toUpperCase()}'`,
       'NOT_SELECT',
       input.file
     )

--- a/src/core/saved-queries/parser.ts
+++ b/src/core/saved-queries/parser.ts
@@ -230,6 +230,17 @@ function normaliseVerify(value: unknown, input: ParseInput): SavedQueryVerify | 
       input.file
     )
   }
+  // The verification query is executed verbatim by `q --verify`, so it carries
+  // the same read-only contract as the snippet body.
+  const verifyWrite = stripCommentsAndStrings(raw.query).match(SQL_WRITE_OR_DDL_KEYWORDS)
+  if (verifyWrite) {
+    throw new SavedQueryError(
+      `Snippet '${input.key}' has a 'verify.query' that must be read-only, ` +
+        `but contains '${verifyWrite[0].toUpperCase()}'`,
+      'NOT_SELECT',
+      input.file
+    )
+  }
   if (typeof raw.expects !== 'string' || !raw.expects.trim()) {
     throw new SavedQueryError(
       `Snippet '${input.key}' has invalid 'verify.expects' (must be a non-empty string)`,

--- a/src/core/saved-queries/strategies/mongodb.ts
+++ b/src/core/saved-queries/strategies/mongodb.ts
@@ -2,6 +2,7 @@ import type { ParamMap } from '../binder'
 import type { RunOptions } from '../runner'
 import { SavedQueryError, type SavedQuery, type SavedQueryMeta } from '../types'
 import type { EngineStrategy, PreparedExecution } from './types'
+import { findMongoWriteStages } from '@/core/mongo/write-stage-guard'
 
 const TEMPLATE_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g
 
@@ -40,6 +41,17 @@ export const mongoStrategy: EngineStrategy = {
     if (meta.operation === 'aggregate' && !Array.isArray(parsed)) {
       throw new SavedQueryError(
         `MongoDB aggregate snippet '${meta.key}' body must be a JSON array (got ${describe(parsed)})`,
+        'MONGO_INVALID_BODY',
+        file
+      )
+    }
+    // Snippets are read-only by contract: refuse writing stages at load time so
+    // a pipeline that writes cannot be saved, shared, or reviewed as a read.
+    const writeStages = findMongoWriteStages(parsed)
+    if (writeStages.length > 0) {
+      throw new SavedQueryError(
+        `MongoDB snippet '${meta.key}' cannot contain ${writeStages.join(' / ')}: ` +
+          `the stage writes to a collection and snippets are read-only`,
         'MONGO_INVALID_BODY',
         file
       )

--- a/src/types/query-risk.ts
+++ b/src/types/query-risk.ts
@@ -1,7 +1,7 @@
 import type { TableSchema } from '@/adapters/types'
 import type { BlacklistConfig } from '@/types/blacklist'
 import type { Permission } from '@/types'
-import type { StatementType } from '@/core/permission-guard'
+import type { SqlDialect, StatementType } from '@/core/permission-guard'
 
 export type QueryRiskDecision = 'ALLOW' | 'WARN' | 'BLOCK'
 export type QueryRiskSeverity = 'warn' | 'block'
@@ -70,6 +70,12 @@ export interface AnalyzeQueryRiskInput {
   permission: Permission
   blacklist: BlacklistConfig
   schemaLookup: SchemaLookup
+  /**
+   * The connection's SQL dialect. Without it the permission check falls back to
+   * judging every dialect at once, which reports a legitimate MySQL query as
+   * multi-statement when a `#` comment or backtick identifier holds a semicolon.
+   */
+  dialect?: SqlDialect
 }
 
 export interface QueryRiskFormatOptions {

--- a/tests/unit/commands/mongo-write-stage-guard.test.ts
+++ b/tests/unit/commands/mongo-write-stage-guard.test.ts
@@ -193,3 +193,30 @@ describe('MongoDB write-stage guard on saved snippets', () => {
     }
   })
 })
+
+describe('MongoDB write-stage guard on export', () => {
+  beforeEach(() => {
+    mockAdapter = new MockMongoAdapter()
+    createMongoAdapterSpy = spyOn(AdapterFactory, 'createMongoDBAdapter').mockReturnValue(
+      mockAdapter
+    )
+    useConfig('query-only')
+  })
+
+  afterEach(() => {
+    configReadSpy.mockRestore()
+    createMongoAdapterSpy.mockRestore()
+  })
+
+  test('rejects a $out pipeline under query-only permission', async () => {
+    const { exportCommand } = await import('@/commands/export')
+
+    await expect(
+      exportCommand('[{"$match":{}},{"$out":"users_copy"}]', {
+        collection: 'users',
+        format: 'jsonl',
+      } as any)
+    ).rejects.toThrow(/\$out/)
+    expect(mockAdapter.lastQuery).toBeUndefined()
+  })
+})

--- a/tests/unit/commands/mongo-write-stage-guard.test.ts
+++ b/tests/unit/commands/mongo-write-stage-guard.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test'
+import type { ExecutionResult, QueryableAdapter } from '@/adapters/types'
+import { AdapterFactory } from '@/adapters'
+import { configModule } from '@/core/config'
+import { queryCommand } from '@/commands/query'
+
+/**
+ * Regression guard: a MongoDB aggregation pipeline can write through `$out` and
+ * `$merge`. Those stages were only rejected on the multi-connection fan-out
+ * path, so a single-connection `dbcli query` executed them even under
+ * `permission: query-only`.
+ */
+class MockMongoAdapter implements QueryableAdapter {
+  lastQuery?: string
+  async connect() {}
+  async disconnect() {}
+  async execute<T>(query: string): Promise<ExecutionResult<T>> {
+    this.lastQuery = query
+    return { rows: [] as T[], affectedRows: 0 }
+  }
+  async listCollections() {
+    return []
+  }
+  async testConnection() {
+    return true
+  }
+  async getServerVersion() {
+    return '6.0.1'
+  }
+  async insert() {
+    return { rows: [], affectedRows: 1 }
+  }
+  async update() {
+    return { rows: [], affectedRows: 1 }
+  }
+  async delete() {
+    return { rows: [], affectedRows: 1 }
+  }
+}
+
+function mongoConfig(permission: 'query-only' | 'data-admin') {
+  return {
+    connection: {
+      system: 'mongodb' as const,
+      uri: 'mongodb://localhost:27017/testdb',
+      host: '',
+      port: 27017,
+      user: '',
+      password: '',
+      database: 'testdb',
+    },
+    permission,
+    schema: {},
+    metadata: { version: '1.0' },
+  }
+}
+
+let configReadSpy: any
+let createMongoAdapterSpy: any
+let mockAdapter: MockMongoAdapter
+
+function useConfig(permission: 'query-only' | 'data-admin') {
+  configReadSpy?.mockRestore()
+  configReadSpy = spyOn(configModule, 'read').mockResolvedValue(mongoConfig(permission) as any)
+}
+
+describe('MongoDB write-stage guard on single-connection query', () => {
+  beforeEach(() => {
+    mockAdapter = new MockMongoAdapter()
+    createMongoAdapterSpy = spyOn(AdapterFactory, 'createMongoDBAdapter').mockReturnValue(
+      mockAdapter
+    )
+    useConfig('query-only')
+  })
+
+  afterEach(() => {
+    configReadSpy.mockRestore()
+    createMongoAdapterSpy.mockRestore()
+  })
+
+  test('rejects a $out pipeline under query-only permission', async () => {
+    const pipeline = '[{"$match":{"status":"active"}},{"$out":"users_copy"}]'
+
+    await expect(queryCommand(pipeline, { collection: 'users', format: 'json' })).rejects.toThrow(
+      /\$out/
+    )
+    expect(mockAdapter.lastQuery).toBeUndefined()
+  })
+
+  test('rejects a $merge pipeline under query-only permission', async () => {
+    const pipeline = '[{"$match":{"status":"active"}},{"$merge":{"into":"users_copy"}}]'
+
+    await expect(queryCommand(pipeline, { collection: 'users', format: 'json' })).rejects.toThrow(
+      /\$merge/
+    )
+    expect(mockAdapter.lastQuery).toBeUndefined()
+  })
+
+  test('rejects a write stage nested later in the pipeline', async () => {
+    const pipeline =
+      '[{"$match":{"status":"active"}},{"$group":{"_id":"$city"}},{"$out":"city_rollup"}]'
+
+    await expect(queryCommand(pipeline, { collection: 'users', format: 'json' })).rejects.toThrow(
+      /\$out/
+    )
+    expect(mockAdapter.lastQuery).toBeUndefined()
+  })
+
+  test('still allows an ordinary read pipeline under query-only permission', async () => {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      await queryCommand('[{"$match":{"status":"active"}}]', {
+        collection: 'users',
+        format: 'json',
+      })
+      expect(mockAdapter.lastQuery).toBe('[{"$match":{"status":"active"}}]')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})
+
+function mongoSnippet(body: string) {
+  return {
+    snippet: {
+      query: {
+        meta: {
+          key: '@rollup',
+          name: 'rollup',
+          params: [],
+          tags: [],
+          engine: ['mongodb'],
+          operation: 'aggregate',
+        },
+        sqlBody: body,
+        file: '/tmp/rollup.mongodb.sql',
+        source: 'shared',
+      },
+      hasLocalOverride: false,
+    } as any,
+    prepared: {
+      driver: { sql: body, values: [] },
+      rewrittenBody: body,
+      warnings: [],
+      execHints: { collection: 'users', mongoOperation: 'aggregate' },
+    } as any,
+  }
+}
+
+describe('MongoDB write-stage guard on saved snippets', () => {
+  beforeEach(() => {
+    mockAdapter = new MockMongoAdapter()
+    createMongoAdapterSpy = spyOn(AdapterFactory, 'createMongoDBAdapter').mockReturnValue(
+      mockAdapter
+    )
+  })
+
+  afterEach(() => {
+    createMongoAdapterSpy.mockRestore()
+  })
+
+  test('refuses a $out snippet even at admin permission', async () => {
+    const { qMongoBranch } = await import('@/commands/q-mongo')
+    const { snippet, prepared } = mongoSnippet('[{"$match":{}},{"$out":"users_copy"}]')
+
+    await expect(
+      qMongoBranch(snippet, prepared, {}, mongoConfig('data-admin') as any)
+    ).rejects.toThrow(/\$out/)
+    expect(createMongoAdapterSpy).not.toHaveBeenCalled()
+  })
+
+  test('refuses a $merge snippet even at admin permission', async () => {
+    const { qMongoBranch } = await import('@/commands/q-mongo')
+    const { snippet, prepared } = mongoSnippet('[{"$match":{}},{"$merge":{"into":"users_copy"}}]')
+
+    await expect(
+      qMongoBranch(snippet, prepared, {}, mongoConfig('data-admin') as any)
+    ).rejects.toThrow(/\$merge/)
+    expect(createMongoAdapterSpy).not.toHaveBeenCalled()
+  })
+
+  test('refuses a $out snippet in --dry-run instead of previewing it as safe', async () => {
+    const { qMongoBranch } = await import('@/commands/q-mongo')
+    const { snippet, prepared } = mongoSnippet('[{"$out":"users_copy"}]')
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      await expect(
+        qMongoBranch(snippet, prepared, { dryRun: true }, mongoConfig('data-admin') as any)
+      ).rejects.toThrow(/\$out/)
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})

--- a/tests/unit/core/execution-path-contract.test.ts
+++ b/tests/unit/core/execution-path-contract.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, test, expect } from 'bun:test'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { join, relative, sep } from 'node:path'
 
 const SRC = join(import.meta.dir, '../../../src')
 
@@ -106,7 +106,10 @@ function walk(dir: string, out: string[] = []): string[] {
 function findExecutionPaths(): Record<string, number> {
   const found: Record<string, number> = {}
   for (const file of walk(SRC)) {
-    const rel = relative(SRC, file)
+    // Keys in REGISTERED_PATHS are POSIX-style, so the walk must be too —
+    // otherwise Windows both mismatches every key and, worse, silently loses
+    // the `adapters/` exclusion below.
+    const rel = relative(SRC, file).split(sep).join('/')
     if (rel.startsWith('adapters/')) continue
     const matches = readFileSync(file, 'utf8').match(EXECUTE_CALL)
     if (matches && matches.length > 0) found[rel] = matches.length

--- a/tests/unit/core/execution-path-contract.test.ts
+++ b/tests/unit/core/execution-path-contract.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Structural contract for database execution paths.
+ *
+ * Every hole fixed in this area had the same shape: a gate existed, but a path
+ * to the adapter did not pass through it. Enumerating the paths is what found
+ * the last two — `q --verify` and the MongoDB export branch — after four
+ * separate audits had missed them.
+ *
+ * This test does not prevent a new path. It makes one impossible to add
+ * silently: any new or moved `<something>Adapter.execute(...)` call outside
+ * `src/adapters/` fails here until it is registered below with the gate that
+ * proves what it may execute.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const SRC = join(import.meta.dir, '../../../src')
+const EXECUTE_CALL = /\w*[Aa]dapter\.execute\s*[<(]/g
+
+/**
+ * Registered execution paths and the gate each relies on. Update this table in
+ * the same change that adds a call site, and say which gate proves it safe.
+ */
+const REGISTERED_PATHS: Record<string, { calls: number; gate: string }> = {
+  'core/query-executor.ts': {
+    calls: 1,
+    gate: 'enforcePermission() — permission tier, stacked statements, blacklist',
+  },
+  'core/data-executor.ts': {
+    calls: 3,
+    gate: 'enforcePermission() per operation — insert/update/delete require data-admin',
+  },
+  'core/ddl-executor.ts': {
+    calls: 1,
+    gate: 'migrate command — DDL is dry-run unless --execute, admin permission required',
+  },
+  'core/health-checker.ts': {
+    calls: 5,
+    gate: 'no user SQL — fixed count/null/orphan/duplicate probes built from schema metadata',
+  },
+  'core/repl/repl-engine.ts': {
+    calls: 1,
+    gate: 'checkPermission() before execution in the interactive shell',
+  },
+  'core/report/run-diagnostic.ts': {
+    calls: 1,
+    gate: 'built-in diagnostic snippets only, parsed under the snippet read-only contract',
+  },
+  'commands/query.ts': {
+    calls: 3,
+    gate: 'preflightQuery() — Redis/Elasticsearch permission, MongoDB write-stage guard',
+  },
+  'commands/export.ts': {
+    calls: 3,
+    gate: 'QueryExecutor for SQL; Redis permission; MongoDB write-stage guard',
+  },
+  'commands/q.ts': {
+    calls: 2,
+    gate: 'snippet body and verify.query proven read-only at parse time; blacklist at run time',
+  },
+  'commands/q-mongo.ts': {
+    calls: 1,
+    gate: 'MongoDB write-stage guard — snippets refuse $out/$merge at every permission level',
+  },
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      walk(full, out)
+    } else if (entry.endsWith('.ts')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function findExecutionPaths(): Record<string, number> {
+  const found: Record<string, number> = {}
+  for (const file of walk(SRC)) {
+    const rel = relative(SRC, file)
+    if (rel.startsWith('adapters/')) continue
+    const matches = readFileSync(file, 'utf8').match(EXECUTE_CALL)
+    if (matches && matches.length > 0) found[rel] = matches.length
+  }
+  return found
+}
+
+describe('database execution paths are registered with a gate', () => {
+  test('no adapter execution happens outside a registered path', () => {
+    const actual = findExecutionPaths()
+    const expected = Object.fromEntries(
+      Object.entries(REGISTERED_PATHS).map(([file, entry]) => [file, entry.calls])
+    )
+
+    // A diff here means a call site was added, removed, or moved. Register it
+    // in REGISTERED_PATHS with the gate that proves what it may execute — and
+    // if there is no such gate, that is the finding, not the test.
+    expect(actual).toEqual(expected)
+  })
+
+  test('every registered path states its gate', () => {
+    for (const [file, entry] of Object.entries(REGISTERED_PATHS)) {
+      expect(entry.gate.trim().length, `${file} must state a gate`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/tests/unit/core/execution-path-contract.test.ts
+++ b/tests/unit/core/execution-path-contract.test.ts
@@ -17,7 +17,18 @@ import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
 const SRC = join(import.meta.dir, '../../../src')
-const EXECUTE_CALL = /\w*[Aa]dapter\.execute\s*[<(]/g
+
+/**
+ * Adapter entry points that reach the database. `execute` carries user SQL;
+ * `insert` / `update` / `delete` are the typed write paths, which an earlier
+ * version of this contract did not count at all.
+ *
+ * This is a heuristic over source text, not a type-level guarantee: a receiver
+ * not named `*adapter`, a call split across lines, or `adapter['execute']`
+ * would evade it. It is a tripwire for the ordinary case, and the registry
+ * below is the actual record.
+ */
+const EXECUTE_CALL = /\w*[Aa]dapter\.(?:execute|insert|update|delete)\s*[<(]/g
 
 /**
  * Registered execution paths and the gate each relies on. Update this table in
@@ -46,7 +57,21 @@ const REGISTERED_PATHS: Record<string, { calls: number; gate: string }> = {
   },
   'core/report/run-diagnostic.ts': {
     calls: 1,
-    gate: 'built-in diagnostic snippets only, parsed under the snippet read-only contract',
+    gate:
+      'snippet read-only contract at parse time ONLY — no permission tier is applied here, ' +
+      'and the collector loads shared/local user snippets, not just built-ins',
+  },
+  'commands/insert.ts': {
+    calls: 2,
+    gate: 'enforcePermission() — requires data-admin before the typed insert',
+  },
+  'commands/update.ts': {
+    calls: 2,
+    gate: 'enforcePermission() — requires data-admin before the typed update',
+  },
+  'commands/delete.ts': {
+    calls: 2,
+    gate: 'explicit data-admin check in the command before the typed delete',
   },
   'commands/query.ts': {
     calls: 3,

--- a/tests/unit/core/read-only-proof.test.ts
+++ b/tests/unit/core/read-only-proof.test.ts
@@ -59,11 +59,12 @@ describe('a single connection proves statements read-only too', () => {
     })
   }
 
-  test('the permission tier of the hidden write still applies', () => {
+  test('a statement that claims to read and does not is admin-only', () => {
     const deleting = 'WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone'
-    // DELETE needs data-admin, so read-write is not enough and admin is.
+    // Judged by the tier of the keyword found, this was laundered twice: by a
+    // harmless leading write, and by the exceptions needed to rank `INTO`.
     expect(checkPermission(deleting, 'read-write', 'postgresql').allowed).toBe(false)
-    expect(checkPermission(deleting, 'data-admin', 'postgresql').allowed).toBe(true)
+    expect(checkPermission(deleting, 'data-admin', 'postgresql').allowed).toBe(false)
     expect(checkPermission(deleting, 'admin', 'postgresql').allowed).toBe(true)
   })
 
@@ -82,14 +83,15 @@ describe('a single connection proves statements read-only too', () => {
   })
 })
 
-describe('the escalated tier is the strictest write present', () => {
+describe('no ordering of keywords launders a hidden write', () => {
   test('a harmless leading write does not launder a stricter one', () => {
     // Taking the leftmost keyword let read-write run a DELETE by putting an
     // INSERT in front of it.
     const smuggled =
       'WITH a AS (INSERT INTO t VALUES (1) RETURNING *), b AS (DELETE FROM users RETURNING *) SELECT 1'
     expect(checkPermission(smuggled, 'read-write', 'postgresql').allowed).toBe(false)
-    expect(checkPermission(smuggled, 'data-admin', 'postgresql').allowed).toBe(true)
+    expect(checkPermission(smuggled, 'data-admin', 'postgresql').allowed).toBe(false)
+    expect(checkPermission(smuggled, 'admin', 'postgresql').allowed).toBe(true)
   })
 
   test('a leading write does not launder a table creation', () => {
@@ -135,4 +137,29 @@ describe('DESCRIBE is EXPLAIN on MySQL and MariaDB', () => {
   test('a plain DESCRIBE is still a read', () => {
     expect(checkPermission('DESCRIBE users', 'query-only', 'mysql').allowed).toBe(true)
   })
+})
+
+/**
+ * Two textual exceptions — rewriting `INSERT INTO` to drop the `INTO`, and
+ * treating a keyword followed by whitespace and `(` as a function call —
+ * combined to erase the write entirely: stripping a quoted identifier leaves
+ * `INSERT` next to `(`.
+ */
+describe('a hidden write cannot be spelled away', () => {
+  const hidden = [
+    ['a quoted target table', `WITH x AS (INSERT INTO "users" (name) VALUES ('evil') RETURNING *) SELECT * FROM x`, 'postgresql'],
+    ['a backtick target table', 'WITH x AS (INSERT INTO `users` (name) VALUES (1) RETURNING *) SELECT * FROM x', 'mysql'],
+    ['no space before the column list', `WITH x AS (INSERT INTO "users"(name) VALUES ('e') RETURNING *) SELECT * FROM x`, 'postgresql'],
+    ['an alias that spells a verb', 'SELECT 1 AS insert INTO evil_copy FROM users', 'postgresql'],
+  ] as const
+
+  for (const [description, sql, dialect] of hidden) {
+    test(`query-only refuses ${description}`, () => {
+      expect(checkPermission(sql, 'query-only', dialect).allowed).toBe(false)
+    })
+
+    test(`read-write refuses ${description}`, () => {
+      expect(checkPermission(sql, 'read-write', dialect).allowed).toBe(false)
+    })
+  }
 })

--- a/tests/unit/core/read-only-proof.test.ts
+++ b/tests/unit/core/read-only-proof.test.ts
@@ -81,3 +81,58 @@ describe('a single connection proves statements read-only too', () => {
     }
   })
 })
+
+describe('the escalated tier is the strictest write present', () => {
+  test('a harmless leading write does not launder a stricter one', () => {
+    // Taking the leftmost keyword let read-write run a DELETE by putting an
+    // INSERT in front of it.
+    const smuggled =
+      'WITH a AS (INSERT INTO t VALUES (1) RETURNING *), b AS (DELETE FROM users RETURNING *) SELECT 1'
+    expect(checkPermission(smuggled, 'read-write', 'postgresql').allowed).toBe(false)
+    expect(checkPermission(smuggled, 'data-admin', 'postgresql').allowed).toBe(true)
+  })
+
+  test('a leading write does not launder a table creation', () => {
+    const smuggled =
+      'WITH a AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * INTO evil_copy FROM users'
+    expect(checkPermission(smuggled, 'read-write', 'postgresql').allowed).toBe(false)
+    expect(checkPermission(smuggled, 'data-admin', 'postgresql').allowed).toBe(false)
+    expect(checkPermission(smuggled, 'admin', 'postgresql').allowed).toBe(true)
+  })
+})
+
+describe('a function is not a statement', () => {
+  const reads = [
+    ["SELECT replace(name, 'a', 'b') FROM users", 'postgresql'],
+    ['SELECT TRUNCATE(1.234, 2) AS t', 'mysql'],
+    ["SELECT INSERT('abcd', 2, 1, 'X') AS s", 'mysql'],
+    ["SELECT regexp_replace(name, 'a', 'b') FROM users", 'postgresql'],
+    ['SELECT replace (name, 1, 2) FROM users', 'postgresql'],
+  ] as const
+
+  for (const [sql, dialect] of reads) {
+    test(`query-only allows ${sql}`, () => {
+      expect(checkPermission(sql, 'query-only', dialect).allowed).toBe(true)
+    })
+  }
+
+  test('the statement forms are still writes', () => {
+    expect(checkPermission('INSERT INTO t (a) VALUES (1)', 'query-only', 'postgresql').allowed).toBe(
+      false
+    )
+    expect(checkPermission("REPLACE INTO t VALUES (1)", 'query-only', 'mysql').allowed).toBe(false)
+    expect(checkPermission('TRUNCATE TABLE users', 'query-only', 'postgresql').allowed).toBe(false)
+  })
+})
+
+describe('DESCRIBE is EXPLAIN on MySQL and MariaDB', () => {
+  test('DESCRIBE ANALYZE of a write is refused', () => {
+    expect(checkPermission('DESCRIBE ANALYZE DELETE FROM users', 'query-only', 'mysql').allowed).toBe(
+      false
+    )
+  })
+
+  test('a plain DESCRIBE is still a read', () => {
+    expect(checkPermission('DESCRIBE users', 'query-only', 'mysql').allowed).toBe(true)
+  })
+})

--- a/tests/unit/core/read-only-proof.test.ts
+++ b/tests/unit/core/read-only-proof.test.ts
@@ -163,3 +163,29 @@ describe('a hidden write cannot be spelled away', () => {
     })
   }
 })
+
+describe('the refusal says what actually happened', () => {
+  const sql = 'WITH x AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM x'
+
+  for (const permission of ['query-only', 'read-write', 'data-admin'] as const) {
+    test(`${permission} names the hidden write and the tier that would allow it`, () => {
+      const { allowed, reason } = checkPermission(sql, permission, 'postgresql')
+      expect(allowed).toBe(false)
+      // The keyword that was found, so the user can see what triggered it.
+      expect(reason).toMatch(/INSERT/)
+      // The tier that actually allows it — earlier messages pointed at tiers
+      // that refuse the statement too.
+      expect(reason).toMatch(/admin/)
+      expect(reason).not.toMatch(/requires read-write/)
+      expect(reason).not.toMatch(/requires data-admin or admin/)
+      // It is recognised; telling the user to report it as unrecognised is wrong.
+      expect(reason).not.toMatch(/Unrecognised|open an issue/i)
+    })
+  }
+
+  test('a genuinely unrecognised statement still reads as unrecognised', () => {
+    const { allowed, reason } = checkPermission('VACUUM FULL users', 'query-only', 'postgresql')
+    expect(allowed).toBe(false)
+    expect(reason).toMatch(/Unrecognised/i)
+  })
+})

--- a/tests/unit/core/read-only-proof.test.ts
+++ b/tests/unit/core/read-only-proof.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The read-only proof — reject a statement whose leading keyword reads but
+ * whose body writes — existed only behind `if (multiConnection)`. A single
+ * connection was judged by `checkPermission`, which classifies on the first
+ * keyword alone, so `dbcli query` executed data-modifying CTEs, `SELECT … INTO`
+ * and `EXPLAIN ANALYZE <write>` under `permission: query-only`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { checkPermission } from '@/core/permission-guard'
+import { QueryExecutor } from '@/core/query-executor'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function makeSpyAdapter(): { adapter: DatabaseAdapter; calls: () => string[] } {
+  const captured: string[] = []
+  const adapter: DatabaseAdapter = {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>(sql: string) => {
+      captured.push(sql)
+      return { rows: [] as T[], affectedRows: 0 }
+    },
+    listTables: async () => [],
+    getTableSchema: async () => ({
+      name: '',
+      columns: [],
+      rowCount: 0,
+      primaryKey: undefined,
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+  return { adapter, calls: () => captured }
+}
+
+const WRITES_BEHIND_A_READ = [
+  ['a CTE that deletes', 'WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone'],
+  ['a CTE that updates', 'WITH b AS (UPDATE users SET n = n + 1 RETURNING *) SELECT * FROM b'],
+  ['a CTE that inserts', 'WITH a AS (INSERT INTO users (n) VALUES (1) RETURNING *) SELECT * FROM a'],
+  ['SELECT … INTO', 'SELECT * INTO evil_copy FROM users'],
+  ['EXPLAIN ANALYZE of a delete', 'EXPLAIN ANALYZE DELETE FROM users'],
+  ['EXPLAIN ANALYZE of an insert', 'EXPLAIN ANALYZE INSERT INTO users (a) VALUES (1)'],
+] as const
+
+describe('a single connection proves statements read-only too', () => {
+  for (const [description, sql] of WRITES_BEHIND_A_READ) {
+    test(`query-only refuses ${description}`, () => {
+      expect(checkPermission(sql, 'query-only', 'postgresql').allowed).toBe(false)
+    })
+
+    test(`nothing reaches the adapter for ${description}`, async () => {
+      const { adapter, calls } = makeSpyAdapter()
+      const executor = new QueryExecutor(adapter, 'query-only', undefined, undefined, {
+        dialect: 'postgresql',
+      })
+      await expect(executor.execute(sql)).rejects.toThrow()
+      expect(calls()).toEqual([])
+    })
+  }
+
+  test('the permission tier of the hidden write still applies', () => {
+    const deleting = 'WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone'
+    // DELETE needs data-admin, so read-write is not enough and admin is.
+    expect(checkPermission(deleting, 'read-write', 'postgresql').allowed).toBe(false)
+    expect(checkPermission(deleting, 'data-admin', 'postgresql').allowed).toBe(true)
+    expect(checkPermission(deleting, 'admin', 'postgresql').allowed).toBe(true)
+  })
+
+  test('ordinary reads are unaffected', () => {
+    for (const sql of [
+      'SELECT * FROM users',
+      'WITH recent AS (SELECT * FROM users) SELECT * FROM recent',
+      'SELECT create_date, update_count FROM audit_log',
+      "SELECT * FROM audit WHERE action = 'DELETE'",
+      'SELECT * FROM users FOR UPDATE',
+      'EXPLAIN SELECT * FROM users',
+      'SHOW TABLES',
+    ]) {
+      expect(checkPermission(sql, 'query-only', 'postgresql').allowed).toBe(true)
+    }
+  })
+})

--- a/tests/unit/core/saved-queries/parser.test.ts
+++ b/tests/unit/core/saved-queries/parser.test.ts
@@ -217,3 +217,30 @@ describe('validateBody — data-modifying CTEs', () => {
     expect(() => validateBody("SELECT * FROM logs WHERE action = 'DELETE'", input)).not.toThrow()
   })
 })
+
+describe('verify.query must be read-only', () => {
+  const withVerify = (verifyQuery: string) =>
+    parseSavedQuery({
+      key: '@t',
+      file: 't.sql',
+      source: 'shared',
+      text: wrap(
+        'SELECT * FROM users',
+        [
+          '-- name: t',
+          '-- engine: postgres',
+          '-- verify:',
+          `--   query: "${verifyQuery}"`,
+          '--   expects: "count > 0"',
+        ].join('\n')
+      ),
+    })
+
+  test('rejects a verification query that deletes rows', () => {
+    expect(() => withVerify('DELETE FROM users')).toThrow(/read-only|DELETE/i)
+  })
+
+  test('accepts an ordinary verification count', () => {
+    expect(() => withVerify('SELECT count(*) AS count FROM users')).not.toThrow()
+  })
+})

--- a/tests/unit/core/saved-queries/parser.test.ts
+++ b/tests/unit/core/saved-queries/parser.test.ts
@@ -244,3 +244,53 @@ describe('verify.query must be read-only', () => {
     expect(() => withVerify('SELECT count(*) AS count FROM users')).not.toThrow()
   })
 })
+
+describe('validateBody — read-only proof does not over-block', () => {
+  const input = (engine?: string) =>
+    ({ key: '@t', file: 't.sql', engine: engine ? [engine] : undefined }) as any
+
+  test('accepts a locking read (FOR UPDATE takes a lock, it does not write)', () => {
+    expect(() =>
+      validateBody('SELECT * FROM users WHERE id = :id FOR UPDATE', input('postgres'))
+    ).not.toThrow()
+  })
+
+  test('accepts FOR NO KEY UPDATE and FOR SHARE', () => {
+    expect(() =>
+      validateBody('SELECT * FROM users FOR NO KEY UPDATE', input('postgres'))
+    ).not.toThrow()
+    expect(() => validateBody('SELECT * FROM users FOR SHARE', input('postgres'))).not.toThrow()
+  })
+
+  test('accepts backtick-quoted identifiers that spell keywords', () => {
+    expect(() =>
+      validateBody('SELECT `update`, `create` FROM `orders`', input('mysql'))
+    ).not.toThrow()
+  })
+
+  test('accepts a MySQL # comment mentioning a keyword', () => {
+    expect(() =>
+      validateBody('SELECT id FROM users # drop this column later\n', input('mysql'))
+    ).not.toThrow()
+  })
+
+  test('accepts a dotted column whose name spells a keyword', () => {
+    expect(() => validateBody('SELECT a.create FROM a', input('postgres'))).not.toThrow()
+  })
+
+  test('still rejects a real write hiding behind a lock clause', () => {
+    expect(() =>
+      validateBody(
+        'WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone FOR UPDATE',
+        input('postgres')
+      )
+    ).toThrow(/read-only|DELETE/i)
+  })
+
+  test('still rejects a write keyword that a different dialect would execute', () => {
+    // Backticks are not string quoting in PostgreSQL, so this is executable there.
+    expect(() => validateBody('SELECT `x`; DROP TABLE t', input('postgres'))).toThrow(
+      /read-only|DROP/i
+    )
+  })
+})

--- a/tests/unit/core/saved-queries/parser.test.ts
+++ b/tests/unit/core/saved-queries/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { parseSavedQuery } from '@/core/saved-queries/parser'
+import { parseSavedQuery, validateBody } from '@/core/saved-queries/parser'
 import { SavedQueryError } from '@/core/saved-queries/types'
 
 const wrap = (sql: string, fm = ''): string => (fm ? `-- ---\n${fm}\n-- ---\n\n${sql}` : sql)
@@ -183,5 +183,37 @@ describe('parseSavedQuery — intent', () => {
     expect(() => parseSavedQuery({ key: '@x', file: 'x.sql', source: 'builtin', text })).toThrow(
       /invalid intent/
     )
+  })
+})
+
+describe('validateBody — data-modifying CTEs', () => {
+  const input = { key: '@t', file: '/tmp/t.sql' } as any
+
+  test('rejects a WITH clause whose CTE deletes rows', () => {
+    expect(() =>
+      validateBody('WITH gone AS (DELETE FROM users WHERE id = 1 RETURNING *) SELECT * FROM gone', input)
+    ).toThrow(/read-only|DELETE/i)
+  })
+
+  test('rejects a WITH clause whose CTE updates rows', () => {
+    expect(() =>
+      validateBody('WITH bumped AS (UPDATE users SET n = n + 1 RETURNING *) SELECT * FROM bumped', input)
+    ).toThrow(/read-only|UPDATE/i)
+  })
+
+  test('rejects a WITH clause whose CTE inserts rows', () => {
+    expect(() =>
+      validateBody('WITH added AS (INSERT INTO users (n) VALUES (1) RETURNING *) SELECT * FROM added', input)
+    ).toThrow(/read-only|INSERT/i)
+  })
+
+  test('still accepts an ordinary read-only CTE', () => {
+    expect(() =>
+      validateBody('WITH recent AS (SELECT * FROM users ORDER BY created_at DESC) SELECT * FROM recent', input)
+    ).not.toThrow()
+  })
+
+  test('does not reject a literal that merely mentions delete', () => {
+    expect(() => validateBody("SELECT * FROM logs WHERE action = 'DELETE'", input)).not.toThrow()
   })
 })

--- a/tests/unit/core/saved-queries/strategies/mongodb.test.ts
+++ b/tests/unit/core/saved-queries/strategies/mongodb.test.ts
@@ -149,3 +149,35 @@ describe('mongoStrategy.prepare', () => {
     ).toThrow(SavedQueryError)
   })
 })
+
+describe('mongoStrategy.validateBody — write stages', () => {
+  test('rejects an aggregate pipeline containing $out', () => {
+    expect(() =>
+      mongoStrategy.validateBody(
+        '[{"$match":{}},{"$out":"users_copy"}]',
+        meta({ operation: 'aggregate' }),
+        '/tmp/t.mongodb.sql'
+      )
+    ).toThrow(SavedQueryError)
+  })
+
+  test('rejects an aggregate pipeline containing $merge', () => {
+    expect(() =>
+      mongoStrategy.validateBody(
+        '[{"$merge":{"into":"users_copy"}}]',
+        meta({ operation: 'aggregate' }),
+        '/tmp/t.mongodb.sql'
+      )
+    ).toThrow(/\$merge/)
+  })
+
+  test('still accepts a read-only aggregate pipeline', () => {
+    expect(() =>
+      mongoStrategy.validateBody(
+        '[{"$match":{"status":"active"}},{"$group":{"_id":"$city"}}]',
+        meta({ operation: 'aggregate' }),
+        '/tmp/t.mongodb.sql'
+      )
+    ).not.toThrow()
+  })
+})

--- a/tests/unit/core/stacked-statement-guard.test.ts
+++ b/tests/unit/core/stacked-statement-guard.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, test, expect } from 'bun:test'
 import { QueryExecutor } from '@/core/query-executor'
-import { checkPermission, containsMultipleStatements } from '@/core/permission-guard'
+import {
+  checkPermission,
+  containsMultipleStatements,
+  findWriteKeyword,
+} from '@/core/permission-guard'
 import type { DatabaseAdapter } from '@/adapters/types'
 
 function makeSpyAdapter(): { adapter: DatabaseAdapter; calls: () => string[] } {
@@ -112,5 +116,50 @@ describe('stacking cannot be hidden from the guard', () => {
   test('an unknown dialect fails closed', () => {
     // With no dialect to judge by, any reading that sees a separator wins.
     expect(containsMultipleStatements('SELECT data #> \'{a}\' FROM t; DELETE FROM users')).toBe(true)
+  })
+})
+
+/**
+ * PostgreSQL identifiers may contain `$` after the first character, so `a$q$`
+ * is one identifier — not `a` followed by a dollar-quoted string. Reading it as
+ * a quote let everything up to the next `$q$` disappear from the guard while
+ * the server still executed it.
+ */
+describe('a $ inside an identifier does not open a dollar-quoted string', () => {
+  const payload = 'SELECT 1 AS a$q$ LIMIT 1; DELETE FROM users; SELECT 1 AS b$q$'
+
+  test('the statement is still seen as stacked under PostgreSQL', () => {
+    expect(containsMultipleStatements(payload, 'postgresql')).toBe(true)
+    expect(checkPermission(payload, 'query-only', 'postgresql').allowed).toBe(false)
+  })
+
+  test('nothing reaches the adapter', async () => {
+    const { adapter, calls } = makeSpyAdapter()
+    const executor = new QueryExecutor(adapter, 'query-only', undefined, undefined, {
+      dialect: 'postgresql',
+    })
+    await expect(executor.execute(payload)).rejects.toThrow(/multiple statements/i)
+    expect(calls()).toEqual([])
+  })
+
+  test('a genuine dollar-quoted string is still a string', () => {
+    expect(containsMultipleStatements('SELECT $q$a;b$q$ AS v', 'postgresql')).toBe(false)
+    expect(containsMultipleStatements('SELECT $$a;b$$ AS v', 'postgresql')).toBe(false)
+    // A dollar-quote may follow an operator or an open paren, not only whitespace.
+    expect(containsMultipleStatements('SELECT ($$a;b$$) AS v', 'postgresql')).toBe(false)
+  })
+
+  test('a write hidden the same way is still found in a snippet', () => {
+    const body =
+      'WITH t AS (SELECT 1 AS a$q$), d AS (DELETE FROM users RETURNING 1 AS b$q$) SELECT * FROM d'
+    expect(findWriteKeyword(body, ['postgresql'])).toBe('DELETE')
+  })
+})
+
+describe('PostgreSQL block comments nest', () => {
+  test('a nested comment containing a semicolon is one statement', () => {
+    expect(
+      containsMultipleStatements('SELECT 1 /* outer /* inner */ ; still comment */ FROM t', 'postgresql')
+    ).toBe(false)
   })
 })

--- a/tests/unit/core/stacked-statement-guard.test.ts
+++ b/tests/unit/core/stacked-statement-guard.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression guard: permission classification reads only the first keyword of a
+ * statement, while the PostgreSQL adapter forwards raw SQL through the simple
+ * query protocol, which executes every semicolon-separated statement. A stacked
+ * statement therefore classified as SELECT and ran a trailing write under
+ * `permission: query-only`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { QueryExecutor } from '@/core/query-executor'
+import { checkPermission } from '@/core/permission-guard'
+import type { DatabaseAdapter } from '@/adapters/types'
+
+function makeSpyAdapter(): { adapter: DatabaseAdapter; calls: () => string[] } {
+  const captured: string[] = []
+  const adapter: DatabaseAdapter = {
+    connect: async () => {},
+    disconnect: async () => {},
+    execute: async <T = Record<string, unknown>>(sql: string) => {
+      captured.push(sql)
+      return { rows: [] as T[], affectedRows: 0 }
+    },
+    listTables: async () => [],
+    getTableSchema: async () => ({
+      name: '',
+      columns: [],
+      rowCount: 0,
+      primaryKey: undefined,
+      foreignKeys: [],
+    }),
+    testConnection: async () => true,
+    getServerVersion: async () => 'test',
+  }
+  return { adapter, calls: () => captured }
+}
+
+describe('stacked statements are refused before reaching the adapter', () => {
+  test('query-only rejects a SELECT that carries a trailing DELETE', async () => {
+    const { adapter, calls } = makeSpyAdapter()
+    const executor = new QueryExecutor(adapter, 'query-only')
+
+    await expect(
+      executor.execute('SELECT 1 LIMIT 1; DELETE FROM users')
+    ).rejects.toThrow(/multiple statements|multi-statement/i)
+    expect(calls()).toEqual([])
+  })
+
+  test('data-admin rejects a stacked DDL that its permission level forbids', async () => {
+    const { adapter, calls } = makeSpyAdapter()
+    const executor = new QueryExecutor(adapter, 'data-admin')
+
+    await expect(
+      executor.execute('SELECT 1 LIMIT 1; DROP TABLE users')
+    ).rejects.toThrow(/multiple statements|multi-statement/i)
+    expect(calls()).toEqual([])
+  })
+
+  test('a trailing semicolon is still a single statement', async () => {
+    const { adapter, calls } = makeSpyAdapter()
+    const executor = new QueryExecutor(adapter, 'query-only')
+
+    await executor.execute('SELECT * FROM users;')
+    expect(calls()).toHaveLength(1)
+  })
+
+  test('a semicolon inside a string literal is not a statement separator', async () => {
+    const { adapter, calls } = makeSpyAdapter()
+    const executor = new QueryExecutor(adapter, 'query-only')
+
+    await executor.execute("SELECT * FROM users WHERE note = 'a;b'")
+    expect(calls()).toHaveLength(1)
+  })
+
+  test('classification refuses to label a stacked statement as a plain SELECT', () => {
+    const result = checkPermission('SELECT 1; DELETE FROM users', 'query-only')
+    expect(result.allowed).toBe(false)
+  })
+})

--- a/tests/unit/core/stacked-statement-guard.test.ts
+++ b/tests/unit/core/stacked-statement-guard.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, test, expect } from 'bun:test'
 import { QueryExecutor } from '@/core/query-executor'
-import { checkPermission } from '@/core/permission-guard'
+import { checkPermission, containsMultipleStatements } from '@/core/permission-guard'
 import type { DatabaseAdapter } from '@/adapters/types'
 
 function makeSpyAdapter(): { adapter: DatabaseAdapter; calls: () => string[] } {
@@ -74,5 +74,43 @@ describe('stacked statements are refused before reaching the adapter', () => {
   test('classification refuses to label a stacked statement as a plain SELECT', () => {
     const result = checkPermission('SELECT 1; DELETE FROM users', 'query-only')
     expect(result.allowed).toBe(false)
+  })
+})
+
+/**
+ * The first version of this guard stripped comments with a string-blind regex
+ * before the dialect-aware pass, and treated "every dialect agrees" as the test
+ * for a separator. Both were fail-open: a `--` inside a literal deleted the rest
+ * of the string before it was examined, and `#` is a comment in MySQL but an
+ * operator in PostgreSQL, so one `#` silenced the check for a Postgres query.
+ */
+describe('stacking cannot be hidden from the guard', () => {
+  const stacked = [
+    ['a dash-dash sequence inside a string literal', "SELECT 'x--' AS a LIMIT 1;\nDELETE FROM users;\n"],
+    ['a block-comment opener inside a string literal', "SELECT 'a/*' AS a LIMIT 1; DELETE FROM users; SELECT '*/' AS b"],
+    ['a # operator that only MySQL reads as a comment', "SELECT data #> '{a}' FROM t LIMIT 1; DELETE FROM users"],
+  ] as const
+
+  for (const [description, sql] of stacked) {
+    test(`refuses ${description}`, async () => {
+      const { adapter, calls } = makeSpyAdapter()
+      const executor = new QueryExecutor(adapter, 'query-only', undefined, undefined, {
+        dialect: 'postgresql',
+      })
+
+      await expect(executor.execute(sql)).rejects.toThrow(/multiple statements|multi-statement/i)
+      expect(calls()).toEqual([])
+    })
+  }
+
+  test('a dialect-specific literal is still not a separator', () => {
+    // $$…$$ is a string in PostgreSQL; backticks quote an identifier in MySQL.
+    expect(containsMultipleStatements('SELECT $$a;b$$ AS v', 'postgresql')).toBe(false)
+    expect(containsMultipleStatements('SELECT 1 AS `a;DELETE`', 'mysql')).toBe(false)
+  })
+
+  test('an unknown dialect fails closed', () => {
+    // With no dialect to judge by, any reading that sees a separator wins.
+    expect(containsMultipleStatements('SELECT data #> \'{a}\' FROM t; DELETE FROM users')).toBe(true)
   })
 })

--- a/tests/unit/core/stacked-statement-guard.test.ts
+++ b/tests/unit/core/stacked-statement-guard.test.ts
@@ -163,3 +163,39 @@ describe('PostgreSQL block comments nest', () => {
     ).toBe(false)
   })
 })
+
+/**
+ * PostgreSQL identifiers are not ASCII-only: its lexer accepts any high byte as
+ * an identifier character, so `café$q$` and `名前$q$` are single identifiers.
+ * An ASCII-only token-boundary test reopened the bypass above for them.
+ */
+describe('a non-ASCII identifier is still an identifier', () => {
+  const payloads = [
+    'SELECT 1 AS café$q$ LIMIT 1; DELETE FROM users; SELECT 1 AS b$q$',
+    'SELECT 1 AS 名前$q$ LIMIT 1; DROP TABLE users; SELECT 1 AS b$q$',
+  ]
+
+  for (const payload of payloads) {
+    test(`refuses ${payload.slice(0, 28)}…`, async () => {
+      expect(containsMultipleStatements(payload, 'postgresql')).toBe(true)
+
+      const { adapter, calls } = makeSpyAdapter()
+      const executor = new QueryExecutor(adapter, 'query-only', undefined, undefined, {
+        dialect: 'postgresql',
+      })
+      await expect(executor.execute(payload)).rejects.toThrow(/multiple statements/i)
+      expect(calls()).toEqual([])
+    })
+  }
+
+  test('a write hidden behind a non-ASCII identifier is still found in a snippet', () => {
+    const body =
+      'WITH t AS (SELECT 1 AS café$q$), d AS (DELETE FROM users RETURNING 1 AS b$q$) SELECT * FROM d'
+    expect(findWriteKeyword(body, ['postgresql'])).toBe('DELETE')
+  })
+
+  test('a dollar-quote still opens after a non-identifier character', () => {
+    expect(containsMultipleStatements('SELECT ($$a;b$$) AS v', 'postgresql')).toBe(false)
+    expect(containsMultipleStatements('SELECT $$a;b$$ AS v', 'postgresql')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes six ways a read-looking operation executed a write while bypassing the connection's configured `permission`. All six ship in 1.47.0 and earlier.

**A security advisory covering these is being prepared. This branch's commit messages contain full exploit detail.**

## The bypasses

| # | Bypass | Engines |
|---|---|---|
| 1 | MongoDB `$out` / `$merge` rejected only on multi-connection fan-out — single-connection `query`, saved snippets and `export` executed them at every tier. `--dry-run` previewed them as safe. | MongoDB |
| 2 | **The read-only proof itself ran only behind `if (multiConnection)`.** `dbcli query "WITH gone AS (DELETE … RETURNING *) SELECT * FROM gone"` deleted rows under `query-only`; the same SQL with `--use a,b` was refused. No unusual syntax required. | PostgreSQL, MariaDB |
| 3 | Statement stacking: classification reads the first keyword, the simple query protocol executes them all. | PostgreSQL |
| 4 | Snippets required a `SELECT`/`WITH` opening but allowed a data-modifying CTE and `SELECT … INTO`. | PostgreSQL, MariaDB |
| 5 | `verify.query` in snippet frontmatter was validated as a non-empty string and executed verbatim by `q --verify`. | all SQL |
| 6 | PostgreSQL identifiers may contain `$` after the first character, so `a$q$` is one identifier. Reading it as a dollar-quote hid the rest of the statement from every check. Defeated the fan-out proof in 1.47.0. | PostgreSQL |

Not one is a missing mechanism. Every one is a mechanism that did not reach a path.

## What changed

- Statements are proven read-only rather than assumed, on every path. A read-led statement containing an executable write is admin-only, and the refusal names the keyword found.
- What counts as a statement separator is judged under the connection's actual dialect (`$$…$$` quotes only in PostgreSQL, backticks only in MySQL/MariaDB, `#` opens a comment only in MySQL/MariaDB); an unknown dialect fails closed.
- MongoDB write stages require `data-admin` on `query` and are refused outright in snippets, `export` and fan-out.
- Snippet bodies and `verify.query` are proven read-only at parse time, under the dialects their declared engine implies.
- An unparseable snippet is skipped with a warning instead of breaking every `q` command; `queries check` still reports it and exits 1.

## ⚠️ Breaking behavior change

These now require `admin`: a writable CTE, `EXPLAIN`/`DESCRIBE ANALYZE` of a write, and MySQL's read-only `SELECT … INTO @variable`. The last is a genuine false positive, kept deliberately — the two attempts to except it are what produced two further bypasses (see the commit history).

## Structural guard

`tests/unit/core/execution-path-contract.test.ts` registers every path from a command to an adapter against the gate it relies on. A new path fails the suite until it declares one. Two of the six bypasses were found only by that enumeration, after four independent audits of the individual commands missed them.

## Review

Seven rounds of adversarial review. Rounds two through six each found a defect in the fix produced by the round before — twice in exceptions added only to stop a guard from rejecting legitimate queries. The seventh found nothing.

## Verification

3781 pass / 0 fail · `tsc --noEmit` clean · eslint clean · `plugin:check` 10/10 · six version manifests aligned at 1.47.1

Decision record: `docs/adr/0004-database-access-stays-a-cli-surface.md`

## Follow-ups, not in this branch

- Blacklist keys on the first table name only, so a `JOIN`ed or `UNION`ed table is neither blocked nor redacted — read-side disclosure, no interaction with the write-side bypasses here.
- `--recovery` silently writes no envelope for a multi-connection request, untested.