### PR TITLE
fix: [ test ] 只在 dist 過期時重建測試產物，並修好 CI matrix 的連坐取消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      # One slow runner must not cancel the others: a macOS failure used to
+      # leave both Windows jobs "cancelled" with no result of their own.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         bun-version: ['1.3.3', 'latest']

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/.build-stamp",
     "assets/",
     "plugins/",
     "skills/",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,8 +3,31 @@
  * Bundles src/cli.ts → dist/cli.mjs with shebang prepended.
  */
 import { $ } from 'bun'
+import { rmSync } from 'node:fs'
 
 const outfile = 'dist/cli.mjs'
+
+// 0. Build stamp: tests/helpers/ensure-dist.ts reads it to decide whether dist is
+// stale. `startedAt` is recorded *before* the first output is written, so a source
+// edited while the build runs reads as newer than the stamp and forces another
+// build. The stamp is removed up front and rewritten only on success, so a build
+// that dies partway (as the macOS CI runner did) leaves no stamp at all.
+const stampFile = 'dist/.build-stamp'
+const startedAt = Date.now()
+rmSync(stampFile, { force: true })
+
+// Every file this script produces. Their hashes go into the stamp because mtime
+// alone cannot see a git checkout rewriting a tracked output (assets/ui-template.html
+// is tracked) — a restore stamps mtime as "now" while changing the content.
+const artifacts = [
+  'dist/cli.mjs',
+  'dist/core.mjs',
+  'dist/core.d.ts',
+  'dist/agent-core.mjs',
+  'dist/agent-core.d.ts',
+  'dist/ui-style.css',
+  'assets/ui-template.html',
+]
 
 // 1. Bundle
 await $`bun build ./src/cli.ts --outfile ${outfile} --target bun --external pg --external mysql2 --external mongodb --external open`
@@ -73,3 +96,15 @@ html = html.replace('/*DBCLI_JS*/', () => jsCode.replace(/<\/script>/gi, '<\\/sc
 await Bun.write('assets/ui-template.html', html)
 
 console.log('UI template built successfully: assets/ui-template.html')
+
+// 5. Everything above succeeded — record when this build started, which Bun built
+// it (a toolchain upgrade changes the output with no input file changing), and what
+// each artifact hashes to.
+const outputs: Record<string, string> = {}
+for (const rel of artifacts) {
+  outputs[rel] = Bun.hash(await Bun.file(rel).bytes()).toString(16)
+}
+await Bun.write(
+  stampFile,
+  `${JSON.stringify({ startedAt, bunVersion: Bun.version, outputs }, null, 2)}\n`
+)

--- a/tests/helpers/ensure-dist.ts
+++ b/tests/helpers/ensure-dist.ts
@@ -1,0 +1,176 @@
+/**
+ * Rebuild `dist/` for tests that import the published artifacts — but only when
+ * it is actually stale.
+ *
+ * `bun run build` costs ~15s on a fast laptop and has been measured past 60s on
+ * a contended macOS CI runner, where it was killed mid dts-bundle-generator and
+ * failed the run. CI already builds in its own step before `bun test`, so the
+ * rebuild inside a test hook is pure duplication there.
+ *
+ * Freshness is decided against `dist/.build-stamp`, which `scripts/build.ts`
+ * writes on success. Two independent checks have to agree:
+ *
+ * 1. Inputs are older than the moment the build *started* (not than the output
+ *    mtimes). That ordering is what makes a source edited mid-build, a build
+ *    killed halfway, and a coarse-granularity filesystem all read as stale.
+ * 2. Every artifact still hashes to what the build produced. mtime cannot see a
+ *    git checkout rewriting `assets/ui-template.html`, which is tracked — a
+ *    restore sets mtime to "now" while changing the content.
+ *
+ * Known blind spots, all requiring an mtime-preserving mutation of an *input*:
+ * `node_modules` edited without touching `bun.lock` (`bun link`, patch-package),
+ * and archive extraction that restores timestamps (`tar -x`, `rsync -a`). The
+ * build's own toolchain is covered by recording `Bun.version` in the stamp.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const ROOT = resolve(import.meta.dir, '..', '..')
+
+/** Headroom for the slowest observed CI build; the freshness check means we rarely pay it. */
+export const BUILD_TIMEOUT_MS = 180_000
+
+/**
+ * Budget for a `beforeAll` that calls {@link ensureDistBuilt}. Deliberately larger
+ * than {@link BUILD_TIMEOUT_MS}: if the two deadlines coincided, Bun's hook timeout
+ * could fire first and the build's own diagnosis would never be printed.
+ */
+export const BUILD_HOOK_TIMEOUT_MS = BUILD_TIMEOUT_MS + 30_000
+
+/** Written by `scripts/build.ts` only after every output lands. */
+export const BUILD_STAMP = 'dist/.build-stamp'
+
+/**
+ * Everything the build reads. `package.json` is inlined into the bundle (version
+ * string), `tsconfig.json` drives dts-bundle-generator, and `bun.lock` changes
+ * whenever a bundled dependency does — none of them touch `src/`.
+ */
+export const BUILD_INPUTS = [
+  'src',
+  'scripts/build.ts',
+  'tsconfig.json',
+  'package.json',
+  'bun.lock',
+  'bunfig.toml',
+] as const
+
+/** Everything the build writes. All must exist, or the last build did not finish. */
+export const BUILD_OUTPUTS = [
+  'dist/cli.mjs',
+  'dist/core.mjs',
+  'dist/core.d.ts',
+  'dist/agent-core.mjs',
+  'dist/agent-core.d.ts',
+  'dist/ui-style.css',
+  'assets/ui-template.html',
+] as const
+
+/** Must match how `scripts/build.ts` hashes each artifact. */
+export function hashArtifact(path: string): string | null {
+  try {
+    return Bun.hash(readFileSync(path)).toString(16)
+  } catch {
+    return null
+  }
+}
+
+function newestMtimeUnder(path: string): number {
+  let stat
+  try {
+    stat = statSync(path)
+  } catch {
+    // A vanished input cannot prove freshness — force a rebuild.
+    return Number.POSITIVE_INFINITY
+  }
+  if (!stat.isDirectory()) return stat.mtimeMs
+
+  let newest = stat.mtimeMs
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    newest = Math.max(newest, newestMtimeUnder(join(path, entry.name)))
+  }
+  return newest
+}
+
+interface BuildStamp {
+  startedAt: number
+  bunVersion: string
+  outputs: Record<string, string>
+}
+
+function readStamp(root: string): BuildStamp | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(root, BUILD_STAMP), 'utf8')) as BuildStamp
+    if (!Number.isFinite(parsed?.startedAt)) return null
+    if (typeof parsed?.bunVersion !== 'string') return null
+    if (!parsed?.outputs || typeof parsed.outputs !== 'object') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/** True when a completed build started after every input changed and its artifacts are intact. */
+export function isDistFresh(root: string = ROOT): boolean {
+  const stamp = readStamp(root)
+  if (stamp === null) return false
+  if (stamp.bunVersion !== Bun.version) return false
+
+  // Every artifact the tests rely on must be one this build recorded...
+  for (const rel of BUILD_OUTPUTS) {
+    if (!(rel in stamp.outputs)) return false
+  }
+  // ...and must still hold the bytes it wrote.
+  for (const [rel, hash] of Object.entries(stamp.outputs)) {
+    if (hashArtifact(join(root, rel)) !== hash) return false
+  }
+
+  // Strict `>`: a tie means the edit and the build start share a timestamp, which
+  // on a coarse-granularity filesystem cannot be ordered — rebuild rather than guess.
+  return BUILD_INPUTS.every((rel) => stamp.startedAt > newestMtimeUnder(join(root, rel)))
+}
+
+interface BuildResult {
+  status: number | null
+  signal: NodeJS.Signals | string | null
+  error?: Error
+  stdout: string | null
+  stderr: string | null
+}
+
+/**
+ * Turn a finished `bun run build` into an error, or null when it succeeded.
+ *
+ * Branch order matters. On a timeout Bun sets `error` (ETIMEDOUT) *and* `signal`,
+ * and the timeout is the exact failure this helper exists to explain — routing it
+ * through the generic `error` branch would report it as "could not run bun" and
+ * drop the build log that says how far the build got.
+ */
+export function buildFailure(build: BuildResult, timeoutMs = BUILD_TIMEOUT_MS): Error | null {
+  const log = `\n${build.stdout ?? ''}\n${build.stderr ?? ''}`
+
+  if (build.signal) {
+    return new Error(
+      `bun run build was killed by ${build.signal} after ${timeoutMs}ms:${log}`,
+      build.error ? { cause: build.error } : undefined
+    )
+  }
+  if (build.error) {
+    return new Error(`could not run bun run build: ${build.error.message}`, { cause: build.error })
+  }
+  if (build.status !== 0) {
+    return new Error(`bun run build failed:${log}`)
+  }
+  return null
+}
+
+/** Build `dist/` if stale. Throws with the build's own output when it fails. */
+export function ensureDistBuilt(root: string = ROOT): void {
+  if (isDistFresh(root)) return
+
+  const failure = buildFailure(
+    spawnSync('bun', ['run', 'build'], { cwd: root, encoding: 'utf8', timeout: BUILD_TIMEOUT_MS })
+  )
+  if (failure) throw failure
+}

--- a/tests/integration/core-dist-import.test.ts
+++ b/tests/integration/core-dist-import.test.ts
@@ -1,26 +1,16 @@
 import { test, expect, beforeAll } from 'bun:test'
-import { spawnSync } from 'node:child_process'
 import { resolve, join } from 'node:path'
 
+import { BUILD_HOOK_TIMEOUT_MS, ensureDistBuilt } from '../helpers/ensure-dist'
+
 // 此測試驗證「對外發布的產物」可被 import，等同外部消費者的視角。
-// beforeAll 會重新 build，確保測的是當前原始碼（mirrors dist-smoke.test.ts）。
+// beforeAll 確保測的是當前原始碼；產物已是最新時不會重 build（mirrors dist-smoke.test.ts）。
 
 const ROOT = resolve(import.meta.dir, '..', '..')
 
-// bun run build now runs dts-bundle-generator (~5–6s); raise the hook timeout well above Bun's 5s default.
-const BUILD_TIMEOUT_MS = 60_000
-
 beforeAll(() => {
-  // Rebuild dist so we test current source, not a stale artifact (mirrors dist-smoke.test.ts).
-  const build = spawnSync('bun', ['run', 'build'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-    timeout: BUILD_TIMEOUT_MS,
-  })
-  if (build.status !== 0) {
-    throw new Error(`bun run build failed:\n${build.stdout}\n${build.stderr}`)
-  }
-}, BUILD_TIMEOUT_MS)
+  ensureDistBuilt(ROOT)
+}, BUILD_HOOK_TIMEOUT_MS)
 
 test('dist/core.mjs 暴露 engine 進入點', async () => {
   const core = await import(join(ROOT, 'dist', 'core.mjs'))

--- a/tests/integration/dist-smoke.test.ts
+++ b/tests/integration/dist-smoke.test.ts
@@ -13,11 +13,10 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
+import { BUILD_HOOK_TIMEOUT_MS, ensureDistBuilt } from '../helpers/ensure-dist'
+
 const ROOT = resolve(import.meta.dir, '..', '..')
 const DIST = join(ROOT, 'dist', 'cli.mjs')
-
-// bun run build now runs dts-bundle-generator (~5–6s); raise the hook timeout well above Bun's 5s default.
-const BUILD_TIMEOUT_MS = 60_000
 
 function run(args: string[], cwd: string) {
   return spawnSync('bun', [DIST, ...args], {
@@ -32,15 +31,8 @@ describe('dist/packaged binary — runs from outside the dev tree', () => {
   let failingMongoConfig = ''
 
   beforeAll(() => {
-    // Rebuild dist so we test the current source, not a stale artifact.
-    const build = spawnSync('bun', ['run', 'build'], {
-      cwd: ROOT,
-      encoding: 'utf8',
-      timeout: BUILD_TIMEOUT_MS,
-    })
-    if (build.status !== 0) {
-      throw new Error(`bun run build failed:\n${build.stdout}\n${build.stderr}`)
-    }
+    // Test the current source, not a stale artifact — rebuilds only when dist is stale.
+    ensureDistBuilt(ROOT)
     workdir = mkdtempSync(join(tmpdir(), 'dbcli-dist-smoke-'))
     mkdirSync(workdir, { recursive: true })
     failingMongoConfig = join(workdir, 'failing-mongo.json')
@@ -61,7 +53,7 @@ describe('dist/packaged binary — runs from outside the dev tree', () => {
         audit: { enabled: false },
       })
     )
-  }, BUILD_TIMEOUT_MS)
+  }, BUILD_HOOK_TIMEOUT_MS)
 
   test('--version succeeds (sanity)', () => {
     const r = run(['--version'], workdir)

--- a/tests/unit/ensure-dist.test.ts
+++ b/tests/unit/ensure-dist.test.ts
@@ -1,0 +1,282 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+  utimesSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import {
+  BUILD_INPUTS,
+  BUILD_OUTPUTS,
+  BUILD_STAMP,
+  buildFailure,
+  isDistFresh,
+} from '../helpers/ensure-dist'
+
+// The freshness predicate is what lets CI skip a duplicate `bun run build` inside
+// test hooks, so its failure mode has to be "rebuild anyway", never "silently test
+// a stale artifact". The fixtures below spell out paths literally rather than
+// deriving them from BUILD_INPUTS/BUILD_OUTPUTS — a fixture built from the lists
+// under test cannot fail when the lists are the thing that is wrong.
+
+const ROOT = resolve(import.meta.dir, '..', '..')
+
+const BUILD_STARTED_S = 1_700_000_001
+const BEFORE_BUILD_S = 1_700_000_000
+const AFTER_BUILD_S = 1_700_000_002
+
+const SOURCE_FILES = [
+  'src/cli.ts',
+  'src/deep/nested/mod.ts',
+  'scripts/build.ts',
+  'tsconfig.json',
+  'package.json',
+  'bun.lock',
+  'bunfig.toml',
+]
+
+const ARTIFACTS = [
+  'dist/cli.mjs',
+  'dist/core.mjs',
+  'dist/core.d.ts',
+  'dist/agent-core.mjs',
+  'dist/agent-core.d.ts',
+  'dist/ui-style.css',
+  'assets/ui-template.html',
+]
+
+function write(path: string, content: string, epochSeconds: number): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+  utimesSync(path, epochSeconds, epochSeconds)
+}
+
+/**
+ * Directory mtimes count as inputs — adding or deleting a source file moves them
+ * and nothing else — so a fixture that leaves them at "now" reads as stale for the
+ * wrong reason. Age them to match the files they hold.
+ */
+function ageDirectories(dir: string, epochSeconds: number): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) ageDirectories(join(dir, entry.name), epochSeconds)
+  }
+  utimesSync(dir, epochSeconds, epochSeconds)
+}
+
+describe('isDistFresh', () => {
+  let root = ''
+
+  function writeStamp(overrides: Record<string, unknown> = {}): void {
+    const outputs: Record<string, string> = {}
+    for (const rel of ARTIFACTS) {
+      outputs[rel] = Bun.hash(readFileSync(join(root, rel))).toString(16)
+    }
+    writeFileSync(
+      join(root, BUILD_STAMP),
+      JSON.stringify({
+        startedAt: BUILD_STARTED_S * 1000,
+        bunVersion: Bun.version,
+        outputs,
+        ...overrides,
+      })
+    )
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dbcli-ensure-dist-'))
+    for (const rel of [...SOURCE_FILES, ...ARTIFACTS]) {
+      write(join(root, rel), `content of ${rel}`, BEFORE_BUILD_S)
+    }
+    writeStamp()
+    ageDirectories(root, BEFORE_BUILD_S)
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test('a completed build newer than every input is fresh', () => {
+    expect(isDistFresh(root)).toBe(true)
+  })
+
+  for (const rel of SOURCE_FILES) {
+    test(`editing ${rel} after the build makes dist stale`, () => {
+      write(join(root, rel), 'edited', AFTER_BUILD_S)
+      expect(isDistFresh(root)).toBe(false)
+    })
+  }
+
+  for (const rel of ARTIFACTS) {
+    test(`a build that never wrote ${rel} is stale`, () => {
+      rmSync(join(root, rel))
+      expect(isDistFresh(root)).toBe(false)
+    })
+  }
+
+  for (const rel of ARTIFACTS) {
+    test(`${rel} rewritten behind the build's back is stale`, () => {
+      // A git checkout, stash pop, or rebase restores a tracked artifact with an
+      // mtime of "now" — later than the stamp — so only content can catch it.
+      write(join(root, rel), 'restored from another revision', AFTER_BUILD_S)
+      expect(isDistFresh(root)).toBe(false)
+    })
+  }
+
+  test('an artifact truncated in place is stale', () => {
+    write(join(root, 'dist/cli.mjs'), '', BEFORE_BUILD_S)
+    expect(isDistFresh(root)).toBe(false)
+  })
+
+  test('a stamp that never recorded a required artifact is stale', () => {
+    const outputs: Record<string, string> = {}
+    for (const rel of ARTIFACTS.slice(1)) {
+      outputs[rel] = Bun.hash(readFileSync(join(root, rel))).toString(16)
+    }
+    writeStamp({ outputs })
+    expect(isDistFresh(root)).toBe(false)
+  })
+
+  test('a build made by a different Bun is stale', () => {
+    // A toolchain upgrade changes bundler output with no input file changing.
+    writeStamp({ bunVersion: '0.0.0-not-this-one' })
+    expect(isDistFresh(root)).toBe(false)
+  })
+
+  test('no stamp at all is stale — a build that died halfway leaves none', () => {
+    rmSync(join(root, BUILD_STAMP))
+    expect(isDistFresh(root)).toBe(false)
+  })
+
+  for (const [label, body] of [
+    ['unparseable', 'not-json'],
+    ['missing startedAt', JSON.stringify({ bunVersion: Bun.version, outputs: {} })],
+    ['missing bunVersion', JSON.stringify({ startedAt: 1, outputs: {} })],
+    ['missing outputs', JSON.stringify({ startedAt: 1, bunVersion: Bun.version })],
+  ] as const) {
+    test(`a stamp that is ${label} is stale rather than throwing`, () => {
+      writeFileSync(join(root, BUILD_STAMP), body)
+      expect(isDistFresh(root)).toBe(false)
+    })
+  }
+
+  test('an input touched in the same instant the build started is stale', () => {
+    // A tie cannot be ordered on a coarse-mtime filesystem, so it must not read fresh.
+    write(join(root, 'src/cli.ts'), 'content of src/cli.ts', BUILD_STARTED_S)
+    expect(isDistFresh(root)).toBe(false)
+  })
+
+  test('a vanished input is stale rather than silently fresh', () => {
+    rmSync(join(root, 'tsconfig.json'))
+    expect(isDistFresh(root)).toBe(false)
+  })
+})
+
+describe('buildFailure', () => {
+  // The shapes below are what Bun actually returns; the timeout one was observed
+  // with spawnSync('sleep', ['5'], { timeout: 300 }) — signal AND error together.
+  const TIMED_OUT = {
+    status: null,
+    signal: 'SIGTERM',
+    error: Object.assign(new Error('spawnSync bun ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+    stdout: 'Bundled 473 modules\nProcessing src/core/public.ts',
+    stderr: '',
+  }
+
+  test('a timeout is reported as a kill, keeping the build log', () => {
+    const error = buildFailure(TIMED_OUT, 180_000)
+    expect(error?.message).toContain('killed by SIGTERM after 180000ms')
+    // Losing this is what made the original CI failure hard to read.
+    expect(error?.message).toContain('Processing src/core/public.ts')
+    expect(error?.message).not.toContain('could not run')
+    expect(error?.cause).toBe(TIMED_OUT.error)
+  })
+
+  test('a missing bun binary is reported as unrunnable', () => {
+    const cause = Object.assign(new Error('spawnSync bun ENOENT'), { code: 'ENOENT' })
+    const error = buildFailure({
+      status: null,
+      signal: null,
+      error: cause,
+      stdout: null,
+      stderr: null,
+    })
+    expect(error?.message).toContain('could not run bun run build')
+    expect(error?.message).not.toContain('null')
+    expect(error?.cause).toBe(cause)
+  })
+
+  test('a non-zero exit carries the build output', () => {
+    const error = buildFailure({ status: 1, signal: null, stdout: 'out', stderr: 'boom' })
+    expect(error?.message).toContain('bun run build failed')
+    expect(error?.message).toContain('boom')
+  })
+
+  test('a clean exit is not a failure', () => {
+    expect(buildFailure({ status: 0, signal: null, stdout: '', stderr: '' })).toBeNull()
+  })
+})
+
+describe('BUILD_INPUTS / BUILD_OUTPUTS cover what scripts/build.ts actually touches', () => {
+  // The lists are hand-maintained; this reads the build script and fails when a
+  // path it reads or writes is not accounted for. Without it, adding an output to
+  // the build silently widens the window in which a stale dist reads as fresh.
+  //
+  // Known limit: coverage cannot tell a read from a write, so a build step that
+  // wrote *under* `src/` would pass as "covered" by the input entry.
+  const declared: string[] = [...BUILD_INPUTS, ...BUILD_OUTPUTS, BUILD_STAMP]
+
+  function isCovered(path: string): boolean {
+    return declared.some((entry) => path === entry || path.startsWith(`${entry}/`))
+  }
+
+  /** Path-shaped tokens, from code only — a path named in a comment proves nothing. */
+  function repoPathsIn(source: string): string[] {
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ')
+    const tokens = code.split(/[\s'"`(),;{}[\]]+/)
+    const paths = tokens
+      .map((token) => token.replace(/^\.\//, ''))
+      .filter((token) => /^[\w.-]+(\/[\w.-]+)+$/.test(token))
+    return [...new Set(paths)]
+  }
+
+  test('every repo path in scripts/build.ts is covered', () => {
+    const paths = repoPathsIn(readFileSync(join(ROOT, 'scripts', 'build.ts'), 'utf8'))
+
+    expect(paths.length).toBeGreaterThan(5)
+    expect(paths.filter((p) => !isCovered(p))).toEqual([])
+  })
+
+  test('the scraper is not silently matching nothing', () => {
+    // Guards the regex itself: a shape it cannot see is a build output it cannot guard.
+    expect(repoPathsIn(`await Bun.write('resources/x.json', y)`)).toEqual(['resources/x.json'])
+    expect(repoPathsIn(`await $\`cp a b/c.txt\``)).toEqual(['b/c.txt'])
+    expect(repoPathsIn(`// writes lib/ignored.mjs`)).toEqual([])
+  })
+
+  test('tsconfig.json is declared, since dts-bundle-generator is driven by it', () => {
+    const source = readFileSync(join(ROOT, 'scripts', 'build.ts'), 'utf8')
+    expect(source).toContain('tsconfig.json')
+    expect(isCovered('tsconfig.json')).toBe(true)
+  })
+
+  test('the build script scraped above is the one `bun run build` executes', () => {
+    // Coverage means nothing if `build` starts chaining a second script.
+    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+    expect(pkg.scripts.build).toBe('bun run scripts/build.ts')
+  })
+
+  test('the declared outputs all exist in a built tree', () => {
+    // Guards against a typo in BUILD_OUTPUTS, which would make dist permanently
+    // stale. Only meaningful once something has built; skipped on a bare checkout.
+    if (Bun.file(join(ROOT, 'dist', 'cli.mjs')).size === 0) return
+    for (const rel of BUILD_OUTPUTS) {
+      expect(Bun.file(join(ROOT, rel)).size).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## 起因

PR #24 的 `test (macos-latest, 1.3.3)` 掛掉（[run 31012986823](https://github.com/CarlLee1983/dbcli/actions/runs/31012986823)），但**同一顆 commit** 的 pull_request run 全綠 —— 是 flake，不是那個 PR 的程式碼問題。

```
##[group]tests/integration/core-dist-import.test.ts:
  (fail) (unnamed) [60016.63ms]
  ^ a beforeEach/afterEach hook timed out for this test.
error: bun run build failed:
  Bundled 473 modules … core.mjs 1.16 MB
  Compiling input files...
  Processing src/core/public.ts      ← 卡在這裡被 60s timeout 砍掉
```

`core-dist-import.test.ts` 與 `dist-smoke.test.ts` 的 `beforeAll` 各自無條件重跑一次 `bun run build`。但 `ci.yml` 的 `Build` step 已經在 `bun test` 之前建過了，所以那是純重複工 —— 而且在負載中的 macOS runner 上，它被砍在 `dts-bundle-generator`。本機 M4 全建置 15s，60s 的預算在 CI 上不夠。

同一個根因也在本機咬過 `release:check`（dist-smoke build SIGTERM）。

## 做法

新增 `tests/helpers/ensure-dist.ts`，dist 還新鮮就跳過重建。判斷條件刻意設計成**只會往「重建」的方向出錯**：

1. **比對 build 開始的時間，不比對產物 mtime。** `scripts/build.ts` 在寫出任何產物之前記下 `Date.now()`，開頭先刪掉 stamp、成功後才寫入。於是「build 途中被存檔的原始碼」「中途被砍的 build」「粗粒度 mtime 的檔案系統」全都判為過期。
2. **比對每個產物的 hash。** 時間戳看不到 `git checkout` 重寫 `assets/ui-template.html`（它是 git 追蹤的產物），因為 restore 會把 mtime 設成「現在」卻換掉內容。stamp 另記 `Bun.version`，因為工具鏈升級也不會動到任何輸入檔。

`BUILD_INPUTS` 涵蓋 `src`、`scripts/build.ts`、`tsconfig.json`、`package.json`（版號會被 inline 進 bundle）、`bun.lock`、`bunfig.toml`。剩餘盲點（`bun link` 改 `node_modules` 而不動 lock、`tar -x` 保留時間戳）在 header 註解裡寫明，不做過度宣稱。

**逾時的錯誤分類也修了**：Bun 逾時時會同時設定 `error`(ETIMEDOUT) 與 `signal`，原本 `error` 分支在前，會把「build 逾時」報成「跑不起來 bun」而且丟掉 build log —— 正好是本次事故本身最需要的證據。分類抽成 `buildFailure()` 並以測試釘住。hook 預算改為比 spawn 逾時多 30s，避免兩個 deadline 撞在一起。

第二個 commit 是獨立的：matrix 加 `fail-fast: false`，否則 macOS 一掛，兩個 Windows job 只會顯示 cancelled、看不到自己的結果。

## 測試計畫

真實 repo 實測（不是 fixture），下列每一種情況都正確判為過期並觸發重建：

| 情況 | `isDistFresh()` |
| --- | --- |
| clean build 之後 | `true` |
| `touch package.json` / `tsconfig.json` / `bun.lock` | `false` |
| 刪掉 `dist/ui-style.css`（半成品 build） | `false` |
| 刪掉 stamp（build 中途死掉） | `false` |
| `assets/ui-template.html` 被改寫（git checkout 情境） | `false` |
| `dist/cli.mjs` 截斷成 0 bytes | `false` |
| 內容還原成 build 寫出的位元組 | `true` |

- `tests/unit/ensure-dist.test.ts` 41 個測試。fixture 的路徑是**字面列出**的，不從受測的清單推導 —— 清單本身就是可能出錯的東西。另有契約測試會剝掉註解後掃描 `scripts/build.ts` 的路徑，任何新的 build 產物沒被納入就會失敗。
- `SKIP_INTEGRATION_TESTS=true bun test`：**4624 pass / 26 skip / 0 fail**
- `typecheck` / `lint` / `prettier --check` 全綠
- dist 新鮮時兩個整合測試 **30s → 4.8s**；`touch src/cli.ts` 後仍照常重建（14.9s）
- `npm pack --dry-run` 確認 `dist/.build-stamp` 不會進 tarball（`files` 加了排除）

經過兩輪 code review：第一輪擋下原本用產物 mtime 的設計（`package.json`/`tsconfig.json` 未涵蓋、半成品 build 會被永久當成新鮮），第二輪擋下產物只驗存在不驗內容、以及逾時走錯分支。兩輪的 CRITICAL/HIGH 都已修並實測。