### PR TITLE
test: [ ci ] 給 stdout-pipe 的檔案系統工作一個明確預算

### DIFF
--- a/tests/integration/stdout-pipe.test.ts
+++ b/tests/integration/stdout-pipe.test.ts
@@ -6,6 +6,15 @@ import { join, resolve } from 'node:path'
 const CLI = resolve(import.meta.dir, '../../src/cli.ts')
 const LARGE_DESCRIPTION = 'x'.repeat(400)
 
+// The 500 snippets below are what pushes the CLI's output past the pipe buffer, so
+// the count is load-bearing and must not shrink — but it makes every hook and the
+// test itself filesystem-bound, and on windows-latest each write goes through
+// Defender. Measured on that runner: ~1s for the whole file when healthy, but the
+// beforeAll hook blew past Bun's 5s default on run 31019607734. The test body was
+// 680ms on a healthy run, which leaves too little room for the same >5x spike, so it
+// gets a budget too rather than being left one bad runner away from the same failure.
+const SLOW_FS_TIMEOUT_MS = 60_000
+
 let workspace: string
 let consumerPath: string
 
@@ -46,58 +55,62 @@ beforeAll(async () => {
       'await Bun.write(Bun.stdout, JSON.stringify(summary))',
     ].join('\n')
   )
-})
+}, SLOW_FS_TIMEOUT_MS)
 
 afterAll(async () => {
   await rm(workspace, { recursive: true, force: true })
-})
+}, SLOW_FS_TIMEOUT_MS)
 
 describe('CLI stdout piping', () => {
-  test('flushes JSON output larger than the pipe buffer before exiting', async () => {
-    const pipeline =
-      '"$DBCLI_TEST_BUN" run "$DBCLI_TEST_CLI" queries list --format json | "$DBCLI_TEST_BUN" "$DBCLI_TEST_CONSUMER"'
-    const windowsPipelinePath = join(workspace, 'stdout-pipeline.cmd')
-    if (process.platform === 'win32') {
-      await Bun.write(
-        windowsPipelinePath,
-        '@echo off\r\n"%DBCLI_TEST_BUN%" run "%DBCLI_TEST_CLI%" queries list --format json | "%DBCLI_TEST_BUN%" "%DBCLI_TEST_CONSUMER%"\r\n'
-      )
-    }
-    const child = Bun.spawn({
-      cmd:
-        process.platform === 'win32'
-          ? ['cmd.exe', '/d', '/s', '/c', windowsPipelinePath]
-          : ['/bin/sh', '-c', pipeline],
-      cwd: workspace,
-      env: {
-        ...process.env,
-        NODE_ENV: 'test',
-        DBCLI_NO_UPDATE_CHECK: '1',
-        DBCLI_TEST_BUN: process.execPath,
-        DBCLI_TEST_CLI: CLI,
-        DBCLI_TEST_CONSUMER: consumerPath,
-      },
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
+  test(
+    'flushes JSON output larger than the pipe buffer before exiting',
+    async () => {
+      const pipeline =
+        '"$DBCLI_TEST_BUN" run "$DBCLI_TEST_CLI" queries list --format json | "$DBCLI_TEST_BUN" "$DBCLI_TEST_CONSUMER"'
+      const windowsPipelinePath = join(workspace, 'stdout-pipeline.cmd')
+      if (process.platform === 'win32') {
+        await Bun.write(
+          windowsPipelinePath,
+          '@echo off\r\n"%DBCLI_TEST_BUN%" run "%DBCLI_TEST_CLI%" queries list --format json | "%DBCLI_TEST_BUN%" "%DBCLI_TEST_CONSUMER%"\r\n'
+        )
+      }
+      const child = Bun.spawn({
+        cmd:
+          process.platform === 'win32'
+            ? ['cmd.exe', '/d', '/s', '/c', windowsPipelinePath]
+            : ['/bin/sh', '-c', pipeline],
+        cwd: workspace,
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          DBCLI_NO_UPDATE_CHECK: '1',
+          DBCLI_TEST_BUN: process.execPath,
+          DBCLI_TEST_CLI: CLI,
+          DBCLI_TEST_CONSUMER: consumerPath,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
 
-    const [stdout, stderr, code] = await Promise.all([
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-      child.exited,
-    ])
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ])
 
-    expect(stderr).toBe('')
-    expect(code).toBe(0)
-    const summary = JSON.parse(stdout) as {
-      valid: boolean
-      count?: number
-      description?: string
-      bytes?: number
-    }
-    expect(summary.valid).toBe(true)
-    expect(summary.bytes).toBeGreaterThan(64 * 1024)
-    expect(summary.count).toBe(500)
-    expect(summary.description).toBe(LARGE_DESCRIPTION)
-  })
+      expect(stderr).toBe('')
+      expect(code).toBe(0)
+      const summary = JSON.parse(stdout) as {
+        valid: boolean
+        count?: number
+        description?: string
+        bytes?: number
+      }
+      expect(summary.valid).toBe(true)
+      expect(summary.bytes).toBeGreaterThan(64 * 1024)
+      expect(summary.count).toBe(500)
+      expect(summary.description).toBe(LARGE_DESCRIPTION)
+    },
+    SLOW_FS_TIMEOUT_MS
+  )
 })


### PR DESCRIPTION
## 起因

合併 #24 之後 main 的 CI 紅了（[run 31019607734](https://github.com/CarlLee1983/dbcli/actions/runs/31019607734)），但**不是 #24 或 #25 造成的**：

```
##[group]tests\integration\stdout-pipe.test.ts:
  (fail) (unnamed) [5000.88ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

`5000.88ms` 就是 Bun 的預設 hook 預算 —— 那個 `beforeAll` 從來沒指定過 timeout。它會在 temp 目錄寫 **500 個 snippet 檔**，而 windows-latest 上每一次寫入都要經過 Defender。

證據：

- 該檔最後一次改動是 2026-08-02（`b6d6a24`），比 #24 早三天，不在 #24 的 commit 裡 → 先前就存在
- 同一個 job 在 #25 上是 pass 的 → flake，不是穩定壞掉
- 本機 macOS 整個檔案 559ms；[健康的 Windows run](https://github.com/CarlLee1983/dbcli/actions/runs/31017069945/job/92343787780) 上 test 本體 679.99ms，整組約 1s

順帶一提，`fail-fast: false`（#25 剛加的）在這次立刻回本：只有 `windows-latest, latest` 掛，另外 6 個 job 全部跑完並通過，一眼就看得出範圍。換作以前會有一批顯示 cancelled。

## 做法

給 `beforeAll` / `afterAll` / `test` 各一個明確的 60s 預算。

**不減少 500 這個數字** —— 它正是讓 CLI 輸出撐爆 pipe buffer 的原因，也就是這條測試要守的東西（`expect(summary.bytes).toBeGreaterThan(64 * 1024)`）。減量等於弱化回歸防護，所以改的是預算不是負載。

`test` 本體也給預算的理由：健康的 Windows run 上它是 680ms，但這次 hook 的尖峰超過 5 倍，剩下的餘裕不足以再撐一次同樣的尖峰 —— 它跟 hook 一樣是檔案系統綁定的（CLI 要讀那 500 個檔）。

⚠️ 加 `test` 的 timeout 讓 prettier 重新縮排了整個 test 主體。diff 裡那 47 行是排版，不是邏輯變更。

## 掃描

掃過 `tests/` 其餘所有 hook，找「做大量工作但沒有明確 timeout」的。唯一另一個命中是 `redis-parity.test.ts` 的 2000 筆 —— 那是 Redis 指令而非檔案系統，而且 Redis 不可達時直接 early-return（CI 上正是如此），不受影響。真正需要修的只有這一處。

## 測試計畫

- `SKIP_INTEGRATION_TESTS=true bun test`：**4624 pass / 26 skip / 0 fail**
- `typecheck` / `lint` / `prettier --check` 全綠
- 真正的驗證在 Windows CI —— 本機無法重現這個逾時