### PR TITLE
test: [ ci ] 把測試預算調到 Windows runner 的實際速度

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Via `bun run` so the timeout lives in one place (package.json). Bun's 5s
+      # default is too tight for windows-latest, where spawning a process costs
+      # seconds; `[test] timeout` in bunfig.toml is documented but not honoured by
+      # Bun 1.3.x, so the flag has to ride on the command.
       - name: Test
-        run: bun test
+        run: bun run test
         env:
           SKIP_INTEGRATION_TESTS: 'true'
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "release:check": "bash scripts/release-check.sh",
     "plugin:sync": "bun run scripts/sync-plugin-assets.ts --write",
     "plugin:check": "bun run scripts/sync-plugin-assets.ts",
-    "test": "bun test",
+    "test": "bun test --timeout 30000",
     "test:unit": "bun test tests/unit tests/core",
     "test:integration": "bun test tests/integration",
     "test:docker": "docker compose -f docker-compose.test.yml up -d --wait && bun test tests/integration/adapters; docker compose -f docker-compose.test.yml down",

--- a/tests/unit/commands/completion.test.ts
+++ b/tests/unit/commands/completion.test.ts
@@ -107,7 +107,12 @@ async function runBashCompletion(script: string, words: readonly string[]): Prom
     '_dbcli_completions',
     'printf "%s\\n" "${COMPREPLY[@]}"',
   ].join('; ')
-  const output = await Bun.$`bash -lc ${command}`.text()
+  // Not a login shell: `command` only sources the script under test and calls bash
+  // builtins, so profile startup buys nothing — and on Windows, Git Bash's
+  // /etc/profile is expensive enough that these three tests were the slowest in the
+  // suite (2.5s+, one of them tipping past the old 5s budget). It also makes the
+  // result independent of whatever a machine's profile puts in the environment.
+  const output = await Bun.$`bash -c ${command}`.text()
   return output.trim().split('\n').filter(Boolean)
 }
 


### PR DESCRIPTION
## 起因

main 連兩次紅燈是同一回事，只是換了測試。#26 修的是 `stdout-pipe` 的 hook，[run 31022942758](https://github.com/CarlLee1983/dbcli/actions/runs/31022942758) 換成 `completion.test.ts`：

```
(fail) generateBashCompletion > keeps nested option completion after option values [5011.98ms]
  ^ this test timed out after 5000ms.
```

又是 Bun 的 5s 預設。所以這次不再一個一個補 —— 先量清楚還有幾顆地雷。掃 Windows job 的 log，列出所有 ≥1500ms 的測試：

| 耗時 | 測試 |
| --- | --- |
| 5012ms **fail** | `generateBashCompletion > keeps nested option completion…` |
| 4589ms pass | `lint subprocess safety and redaction > lint suggests analyze only…` |
| 4439ms pass | `dbcli recover --apply verify (P4) > SCHEMA_CACHE_MISSING…` |
| 4428ms pass | `dbcli recover --apply --write-verification-artifact…` |
| 4357ms pass | `dbcli recover --apply verify (P4) > runs verify after success…` |
| 4338ms pass | `dbcli recover --apply happy path > runs all readonly steps…` |
| 4163ms pass | `lint subprocess safety and redaction > explain --analyze rejects…` |
| 2776ms pass | `config binding layout > reads and writes config…` |

一個 job 裡 **8 個測試在 3s 以上**，另一個 job 有 6 個（其中兩個到 5.1–5.3s）。這些測試沒有卡死，只是 windows-latest 生一個 process 就要好幾秒。繼續逐一補 timeout，下週還會有下一個。

## 做法

`bun test --timeout 30000`，寫在 `package.json` 的 `test` script，`ci.yml` 改用 `bun run test`，避免兩邊各維護一份。

**原本想放 `bunfig.toml` 的 `[test] timeout`** —— Bun 自己的文件（`node_modules/bun-types/docs/test/configuration.mdx:155`）明寫支援。實測 1.3.10 不吃：

```
# bunfig.toml 只有 [test] timeout = 30000
bun test p.test.ts            → 0 pass 1 fail   (timed out after 5000ms)
bun test --timeout 30000 …    → 1 pass 0 fail   [6.01s]
```

同一個探針、同一個檔案，差別只在旗標。文件是錯的，所以旗標只能掛在指令上。這件事我是先探針證實才改的，不是照文件寫。

**代價**：真的卡死的測試現在要 30s 才失敗，不是 5s。在 Windows 上本來就跑 5–6 分鐘的 suite 裡可以接受，但這是取捨、不是純好處。

**另外**：`completion.test.ts` 的 `bash -lc` → `bash -c`。那段指令只 source 受測腳本再呼叫 bash builtin，login profile 什麼也沒提供；而 Windows 上 Git Bash 的 `/etc/profile` 貴到讓這三個測試成為整個 suite 最慢的（2.5s+，一個翻過 5s）。順帶讓結果不再受各機器 profile 內容影響 —— 這是正確性的改善，不只是速度。

## 測試計畫

- 探針證實 `bun run test` 現在吃得下 6s 的測試（見上）
- `completion.test.ts` 20 pass，本機 569ms → **381ms**（`-l` 在 macOS 上也不是免費的）
- `SKIP_INTEGRATION_TESTS=true bun run test`：**4624 pass / 26 skip / 0 fail**
- `typecheck` / `lint` / `prettier --check` 全綠

## 已知限制

`--timeout` 只在 `bun run test` 生效；直接打 `bun test` 仍是 5s 預設。CI 走的是前者，本機隨手跑後者不會拿到新預算 —— 這是 Bun 不支援設定檔造成的，等它修好可以搬回 `bunfig.toml`。