### PR TITLE
perf: [ blacklist ] 欄位遮罩每列只複製一次，不是每個路徑一次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+
+- **欄位遮罩對每一列的每一個欄位各複製一次整列。** `omitFieldPaths` 逐一路徑呼叫 `omitPath`，而後者每次都重建整個 record，因此成本是 O(列數 × 遮罩欄位數) 次完整複製 —— 100 列對上 50 個遮罩欄位就是 5000 次。沒有點的路徑只會刪掉一個頂層鍵，而欄位黑名單絕大多數就是這種名稱，現在合併成一趟處理，只有真正的巢狀路徑才遞迴。輸出完全相同，實測 30.37ms → 1.73ms。任何回傳大量資料又設有欄位黑名單的查詢或匯出都會受益。
+
+### Fixed
+
+- **兩條效能基準自 2026-03-26 加入起就沒通過過。** 它們被 `ci.yml` 的 `continue-on-error: true` 蓋住，所以 CI 從未因此變紅，超標 6 倍也沒人看見。門檻本身是合理的（修正後餘裕 3 倍），問題在上面那條實作。基準也改為取多次量測的中位數並印出實測值：單次 `performance.now()` 加硬門檻約每三次就會誤報一次，當不了 gate。
+
 ## [1.48.0] - 2026-08-05 - blacklist 涵蓋語句中的每一張表，以及所有執行路徑（安全性修復）
 
 對應 issue [#23](https://github.com/CarlLee1983/dbcli/issues/23)。與 1.47.1 修掉的六個繞過不同，這一批洩漏的是**讀取內容**，不是寫入能力。

--- a/src/core/field-projection.ts
+++ b/src/core/field-projection.ts
@@ -64,9 +64,27 @@ export function omitFieldPaths(
   rows: readonly Record<string, unknown>[],
   paths: readonly string[]
 ): Record<string, unknown>[] {
+  // `omitPath` rebuilds the whole record, so running it once per path made this
+  // O(rows × paths) full copies — 100 rows against a 50-column blacklist cost 5000
+  // rebuilds and ~35ms, which is why the masking benchmark had never met its 5ms
+  // budget. A path without a dot only ever deletes one top-level key, and a column
+  // blacklist is overwhelmingly such names, so those are collected into one pass
+  // and only genuinely nested paths still recurse. Same output, ~50x faster.
+  //
+  // Ceiling: dotted paths keep the old cost. A blacklist of N dotted JSON paths is
+  // still N rebuilds per row — measured at 2.6ms for 5 paths over 100 rows, and it
+  // grows linearly in N. `blacklist-validator.ts` admits dotted paths deliberately,
+  // so if a config ever carries dozens of them, this branch is what to optimise next.
+  const topLevel = new Set<string>()
+  const nested: string[] = []
+  for (const path of paths) {
+    if (path.includes('.')) nested.push(path)
+    else topLevel.add(path)
+  }
+
   return rows.map((row) => {
-    let projected: unknown = cloneRecord(row)
-    for (const path of paths) projected = omitPath(projected, path.split('.'))
+    let projected: unknown = cloneRecord(row, topLevel)
+    for (const path of nested) projected = omitPath(projected, path.split('.'))
     return projected as Record<string, unknown>
   })
 }
@@ -132,10 +150,15 @@ function omitPath(value: unknown, segments: readonly string[]): unknown {
   return out
 }
 
-function cloneRecord(value: Record<string, unknown>, omittedKey?: string): Record<string, unknown> {
+// `omittedKeys` is required rather than optional: for a masking helper, the
+// fail-open direction of a forgotten argument (keep every key) is the wrong default.
+function cloneRecord(
+  value: Record<string, unknown>,
+  omittedKeys: ReadonlySet<string>
+): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [key, child] of Object.entries(value)) {
-    if (key !== omittedKey) defineData(out, key, child)
+    if (!omittedKeys.has(key)) defineData(out, key, child)
   }
   return out
 }

--- a/tests/perf/blacklist-performance.bench.ts
+++ b/tests/perf/blacklist-performance.bench.ts
@@ -68,6 +68,36 @@ const typicalRows = Array.from({ length: 1000 }, (_, i) => ({
 }))
 const typicalColumnList = Object.keys(typicalRows[0] ?? {})
 
+/**
+ * Median of `sampleCount` runs, after one discarded warm-up run.
+ *
+ * A single `performance.now()` around one call is not a threshold a CI job can be
+ * held to: one GC pause or a descheduled slice and it reads several times high. On
+ * this machine the same masking call medians at ~1.3ms, yet three consecutive
+ * single-shot runs of the old benchmark produced one reading past the 5ms budget
+ * (n=3 — enough to show the gate was unreliable, not enough to put a rate on it).
+ * The median is what makes this assertion a gate rather than a coin flip.
+ */
+function medianElapsed(run: () => unknown, sampleCount = 9): number {
+  const samples: number[] = []
+  let sink = 0
+  for (let i = 0; i <= sampleCount; i++) {
+    const start = performance.now()
+    const result = run()
+    const elapsed = performance.now() - start
+    // Consume the result so the JIT cannot elide the call it is timing.
+    sink += Array.isArray(result) ? result.length : 1
+    if (i > 0) samples.push(elapsed)
+  }
+  if (samples.length === 0 || sink === 0) {
+    // Failing open here would let `expect(0).toBeLessThan(5)` certify a gate that
+    // measured nothing at all.
+    throw new Error('medianElapsed measured no samples')
+  }
+  samples.sort((a, b) => a - b)
+  return samples[Math.floor(samples.length / 2)]!
+}
+
 describe('Blacklist Performance Benchmarks', () => {
   it('Table lookup (1000 tables): 1000 lookups in < 10ms', () => {
     const largeManager = new BlacklistManager(largeConfig as any)
@@ -96,27 +126,61 @@ describe('Blacklist Performance Benchmarks', () => {
     expect(elapsed / 1000).toBeLessThan(1) // avg < 1ms
   })
 
-  it('Column filtering (100 rows x 50 cols, omit 5): < 5ms per call', () => {
+  it('Column filtering (100 rows x 50 cols, omits 50): < 5ms per call', () => {
     const largeManager = new BlacklistManager(largeConfig as any)
     const largeValidator = new BlacklistValidator(largeManager)
     const columnList = Object.keys(largeRows[0] ?? {})
 
-    // Warm up JIT
-    largeValidator.filterColumns('table_0', largeRows.slice(0, 5), columnList)
+    const elapsed = medianElapsed(
+      () => largeValidator.filterColumns('table_0', largeRows, columnList).filteredRows
+    )
 
-    const start = performance.now()
-    largeValidator.filterColumns('table_0', largeRows, columnList)
-    const elapsed = performance.now() - start
-
-    expect(elapsed).toBeLessThan(5) // < 5ms for 100 rows (first call may include JIT warmup)
+    // Printed so a passing CI run still shows the margin — without it there is no
+    // way to tell whether this budget is comfortable on a runner or one GC away.
+    console.log(`Column filtering (100 rows x 50 cols) = ${elapsed.toFixed(2)}ms (budget 5ms)`)
+    expect(elapsed).toBeLessThan(5)
   })
 
-  it('Column filtering (1000 rows x 7 cols, omit 3): < 5ms per call', () => {
-    const start = performance.now()
-    typicalValidator.filterColumns('users', typicalRows, typicalColumnList)
-    const elapsed = performance.now() - start
+  it('Column filtering (1000 rows x 7 cols, omits 3): < 5ms per call', () => {
+    const elapsed = medianElapsed(
+      () => typicalValidator.filterColumns('users', typicalRows, typicalColumnList).filteredRows
+    )
 
-    expect(elapsed).toBeLessThan(5) // < 5ms for 1000 rows
+    console.log(`Column filtering (1000 rows x 7 cols) = ${elapsed.toFixed(2)}ms (budget 5ms)`)
+    expect(elapsed).toBeLessThan(5)
+  })
+
+  it('Column filtering (100 rows, 5 dotted JSON paths): < 10ms per call', () => {
+    // The single-pass optimisation covers dotless paths only; a dotted path still
+    // rebuilds the whole record once per path. Nothing guarded that half, so this
+    // pins it. The budget is deliberately looser than the dotless cases because
+    // this is the O(rows × paths) branch — it is a ceiling, not a target.
+    const jsonRows = Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      name: `n${i}`,
+      profile: { email: `e${i}`, ssn: `s${i}`, phone: `p${i}`, city: 'Taipei', note: 'x' },
+      payment: { card: `c${i}`, cvv: '123' },
+    }))
+    const jsonConfig = {
+      ...baseConfig,
+      blacklist: {
+        tables: [],
+        columns: {
+          orders: ['profile.email', 'profile.ssn', 'profile.phone', 'payment.card', 'payment.cvv'],
+        },
+      },
+    }
+    const validator = new BlacklistValidator(new BlacklistManager(jsonConfig as any))
+    const columnList = Object.keys(jsonRows[0] ?? {})
+
+    const elapsed = medianElapsed(
+      () => validator.filterColumns('orders', jsonRows, columnList).filteredRows
+    )
+
+    console.log(
+      `Column filtering (100 rows, 5 dotted paths) = ${elapsed.toFixed(2)}ms (budget 10ms)`
+    )
+    expect(elapsed).toBeLessThan(10)
   })
 
   it('Config loading - typical blacklist: < 5ms', () => {

--- a/tests/unit/core/field-projection.test.ts
+++ b/tests/unit/core/field-projection.test.ts
@@ -87,6 +87,79 @@ describe('projectRows', () => {
     ])
   })
 
+  test('excludes a mix of top-level, dotted, and array-nested paths in one pass', () => {
+    // omitFieldPaths splits paths into top-level and dotted so it can rebuild a row
+    // once instead of once per path. This pins the semantics that split must keep:
+    // plain names, a literal dotted key, traversal into a nested record, and
+    // traversal through an array all have to survive being handled together.
+    const rows = [
+      {
+        id: 1,
+        secret: 'top-level',
+        'profile.email': 'literal dotted key',
+        profile: { email: 'nested', city: 'Taipei' },
+        orders: [
+          { total: 10, card: 'a' },
+          { total: 20, card: 'b' },
+        ],
+      },
+    ]
+
+    const projected = projectRows(rows, {
+      mode: 'exclude',
+      paths: ['secret', 'profile.email', 'orders.card', 'absent', 'nope.here'],
+    })
+
+    expect(projected.rows).toEqual([
+      {
+        id: 1,
+        profile: { city: 'Taipei' },
+        orders: [{ total: 10 }, { total: 20 }],
+      },
+    ])
+    expect(projected.columnNames).toEqual(['id', 'profile', 'orders'])
+    // Input untouched — the projection must copy, never mutate.
+    expect(rows[0]!.secret).toBe('top-level')
+    expect(rows[0]!['profile.email']).toBe('literal dotted key')
+    expect(rows[0]!.orders).toEqual([
+      { total: 10, card: 'a' },
+      { total: 20, card: 'b' },
+    ])
+  })
+
+  test('excluding a parent and its child is order-independent across the split', () => {
+    // A top-level path and a dotted path sharing a head land in different buckets,
+    // so the split changes the order they are applied in. That is only safe because
+    // omission never creates a key; both orders must still collapse the whole parent.
+    const rows = [{ id: 1, profile: { email: 'a@example.com', city: 'Taipei' } }]
+
+    for (const paths of [
+      ['profile', 'profile.email'],
+      ['profile.email', 'profile'],
+    ]) {
+      const projected = projectRows(rows, { mode: 'exclude', paths })
+      expect(projected.rows).toEqual([{ id: 1 }])
+    }
+  })
+
+  test('excludes a prototype-polluting key without touching Object.prototype', () => {
+    const rows = [Object.assign(Object.create(null), { __proto__: 'x', safe: 1 })]
+
+    const projected = projectRows(rows, { mode: 'exclude', paths: ['__proto__'] })
+
+    expect(projected.rows).toEqual([{ safe: 1 }])
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype)
+    expect((Object.prototype as Record<string, unknown>).safe).toBeUndefined()
+  })
+
+  test('an empty-string path excludes the empty-string key and nothing else', () => {
+    const rows = [{ '': 'blank', id: 1 }]
+
+    const projected = projectRows(rows, { mode: 'exclude', paths: [''] })
+
+    expect(projected.rows).toEqual([{ id: 1 }])
+  })
+
   test('normalizes sparse inclusion keys for JSON and preserves non-plain values', () => {
     const date = new Date('2026-08-01T00:00:00Z')
     const projected = projectRows([{ id: 1, date }, { id: 2 }], {


### PR DESCRIPTION
## 起因

`test:perf` 有兩條基準**自 2026-03-26 加入起就沒通過過**，超標 6 倍。沒人看見，因為 `ci.yml` 那個 step 有 `continue-on-error: true`。

第一個問題是：這是不是 #24 造成的退化？（#24 大改了 blacklist 欄位處理路徑，而 1.48.0 剛發出去。）

**不是。** 同一支基準跑在 #24 前後：

| | 100×50 中位數 |
| --- | --- |
| `4fbbf7e`（#24 之前） | 32.07ms |
| `1.48.0`（#24 之後） | 30.37ms |

#24 之後反而快了一點。門檻也不是不切實際 —— 修完之後餘裕 3 倍。問題一直在實作。

## 根因

量出來的，不是看程式碼猜的：

| 階段 | 耗時 |
| --- | --- |
| 找出要遮蔽的欄位 | 1.02ms |
| **`omitFieldPaths`** | **34.65ms（97%）** |

`omitPath` 每次呼叫都用 `Object.entries` 重建整個 record，而 `omitFieldPaths` 對**每一個路徑**各呼叫一次 → O(列數 × 路徑數) 次完整複製。100 列對 50 個遮罩欄位 = 5000 次。

## 做法

沒有點的路徑只會刪掉一個頂層鍵（`omitPath` 在 `segments.length === 1` 時三個分支都收斂成「刪掉這個鍵」），而欄位黑名單絕大多數就是這種名稱。把它們收進一個 Set 一趟處理，只有真正的巢狀路徑才遞迴。

**30.37ms → 1.73ms，輸出逐位元組相同。**

## 安全性等價

這是遮罩路徑 —— 少刪一個欄位就是洩漏。審查以**差分 fuzz 30 萬組隨機案例、零不一致**確認等價，比較用的序列化保留鍵順序、prototype 身分與例外訊息（不是 `toEqual`）。涵蓋 `""`、`"."`、`".."`、`"a."`、`".a"`、`"a..b"`、`__proto__`、`constructor`、null-prototype、class instance、三層巢狀與陣列。

順序可交換的理由：`omitPath` 只會複製 `Object.entries` 裡已存在的鍵，從不新建或改名，所以「先做全部頂層、再做巢狀」與逐一交錯的結果相同。

## 基準本身也是壞的

修完實作後，基準**三次仍會誤報一次** —— 它只量單一次 `performance.now()`，GC 一抖就超標。這種東西當不了 gate，也解釋了當初為什麼要加 `continue-on-error`。

- 改成取 9 次中位數（丟棄暖身那次）→ `test:perf` 連跑 **10/10 通過**
- 消費回傳值，避免 JIT 省略掉正在計時的呼叫
- 樣本為空時丟例外，而非回 `0` —— 原本 `expect(0).toBeLessThan(5)` 會讓一個什麼都沒量到的 gate 靜默通過
- 印出實測值，否則通過時看不到餘裕

新增**巢狀路徑基準**：單趟優化只涵蓋無點路徑，帶點的仍是 O(列 × 路徑)，原本沒有任何基準守這一半。上限（5 條點路徑 100 列 = 2.6ms，隨路徑數線性成長）與「下一個要優化的就是這裡」都寫進 `field-projection.ts` 的註解。

`cloneRecord` 的 `omittedKeys` 改為必填：對遮罩函式來說，漏傳參數的 fail-open 方向（保留所有鍵）是錯的預設。

## 測試計畫

CI log 現在會印：

```
Column filtering (100 rows x 50 cols) = 1.59ms (budget 5ms)
Column filtering (1000 rows x 7 cols) = 1.09ms (budget 5ms)
Column filtering (100 rows, 5 dotted paths) = 0.96ms (budget 10ms)
```

- `test:perf` 連跑 10 次：**10/10 通過**
- 新增 3 條語意守門測試，釘住 refactor 真正的風險點（父/子路徑跨兩桶且兩種順序、`__proto__` 作為黑名單項、空字串路徑）
- `SKIP_INTEGRATION_TESTS=true bun run test`：**4628 pass / 26 skip / 0 fail**
- `typecheck` / `lint` / `prettier` / `docs:check` / `skill:check` / `plugin:check` / `contract:check` 全綠

## 刻意沒做

**沒有拿掉 `continue-on-error: true`。** 本機餘裕 3 倍，但 Windows runner 在這個工作量上約慢 2 倍，會壓到 3.5ms 左右，太接近 5ms。等這個 PR 的 CI 印出 Windows 上的真實數字再決定 —— 那正是新增那幾行 `console.log` 的用途。

## 順帶發現（先前就存在，本 PR 未動）

若 adapter 把 JSON 欄位攤平成字面鍵 `profile.email` 而**不**同時回傳 `profile`，則黑名單寫 `profile` 保護不到它：`blacklist-validator.ts` 用 `hasFieldPath(row,'profile')` 判斷，回傳 `found: false`，於是 `omittedColumns` 為空、資料原樣回傳、**而且不會發出安全通知**。改動前後行為相同，屬於 blacklist 涵蓋範圍的 backlog。