### PR TITLE
fix: [ security ] 黑名單的父欄位要涵蓋攤平後的子欄位

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **黑名單指定父欄位時，攤平後的子欄位未被遮蔽，而且不發通知。** Elasticsearch adapter 會把 `_source` 遞迴攤平成帶點的頂層鍵（`{profile:{ssn}}` → 鍵 `profile.ssn`，文件裡根本沒有 `profile`），而遮蔽判斷是以欄位名等值比對，因此把 `profile` 列入欄位黑名單完全沒有作用：資料原樣回傳，且因為「已遮蔽欄位」清單是空的，連安全通知都不會發出 —— 使用者不會知道有東西本來該被藏起來。影響 `query` / `q` / `export` 三條 Elasticsearch 路徑。現在任何位於黑名單祖先之下的欄位都會被遮蔽（`profiles`、`profile_name` 這類僅前綴相似的欄位不受影響）。已知天花板（規則指定葉節點名、或祖先不從路徑開頭起算）記於 `docs/security-threat-model.md`。
+
 ### Performance
 
 - **欄位遮罩對每一列的每一個欄位各複製一次整列。** `omitFieldPaths` 逐一路徑呼叫 `omitPath`，而後者每次都重建整個 record，因此成本是 O(列數 × 遮罩欄位數) 次完整複製 —— 100 列對上 50 個遮罩欄位就是 5000 次。沒有點的路徑只會刪掉一個頂層鍵，而欄位黑名單絕大多數就是這種名稱，現在合併成一趟處理，只有真正的巢狀路徑才遞迴。輸出完全相同，實測 30.37ms → 1.73ms。任何回傳大量資料又設有欄位黑名單的查詢或匯出都會受益。

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -113,6 +113,18 @@ and credentials must be protected from the agent's writable workspace.
      knowledge dbcli does not have, and `GET /_cat/aliases` reveals the mapping.
      Blacklist the alias as well, or rely on the Elasticsearch role.
 
+   - **A column rule naming a leaf, against a flattened source.** The Elasticsearch
+     adapter flattens `_source`, so `{profile:{ssn}}` arrives as the single key
+     `profile.ssn` and there is no `profile` key at all. A rule for `profile` does
+     cover it — every column under a blacklisted ancestor is withheld — but a rule
+     for `ssn` alone does not, and neither does `profile` against
+     `data.profile.ssn`. Matching any segment would close this, at the price of a
+     rule for `id` hiding `user.id`, `order.id`, and every other qualified column;
+     the trade was made in favour of the narrower rule. `dbcli schema` reports
+     Elasticsearch fields under their dotted names, so blacklisting what `schema`
+     shows is the workflow that holds. Pinned by the `KNOWN CEILING` tests in
+     `tests/unit/core/blacklist-validator.test.ts`.
+
    The blacklist withholds objects and columns from ordinary reads. It is not a
    proof that a value cannot be reconstructed. An account that must not read a
    column needs a database grant that says so.

--- a/src/core/blacklist-validator.ts
+++ b/src/core/blacklist-validator.ts
@@ -253,9 +253,53 @@ export class BlacklistValidator {
     // SQL adapters normally return a uniform top-level column set, but JSON
     // columns can contain nested records. Treat an exact dotted path as
     // protected too, so projecting its parent cannot recover the child.
-    const omittedColumns = blacklistedColumns.filter(
-      (path) => columnList.includes(path) || rows.some((row) => hasFieldPath(row, path))
-    )
+    //
+    // The other direction has to hold as well: an adapter may flatten instead of
+    // nest. `elasticsearch-adapter.ts` walks `_source` recursively and emits
+    // `profile.email` as a top-level key with no `profile` key anywhere, so a
+    // blacklist entry naming the parent matched nothing — the rows were returned
+    // whole and, because the omitted list was empty, without a notification either.
+    // Every present column under the parent is therefore omitted by name.
+    // Sparse documents mean a protected field can appear only in a later row, so
+    // the column set is taken from the rows as well as the declared column list.
+    // A null row is an adapter edge case, not a reason to throw from the masker.
+    const presentColumns = new Set(columnList)
+    for (const row of rows) {
+      if (row === null || typeof row !== 'object') continue
+      for (const key of Object.keys(row)) presentColumns.add(key)
+    }
+
+    const protectedPaths = new Set(blacklistedColumns)
+
+    const omitted = new Set<string>()
+    for (const path of blacklistedColumns) {
+      // `presentColumns` first: it is a Set lookup, while the nested probe walks
+      // every row. The fail-safe branch above can hand this loop the whole rule set
+      // with almost nothing matching, which is exactly the shape that probe is worst at.
+      if (presentColumns.has(path) || rows.some((row) => hasFieldPath(row, path))) {
+        omitted.add(path)
+      }
+    }
+    // Walk each column up to its ancestors rather than testing every rule against
+    // every column: `a.b.c` only has to ask about `a` and `a.b`. The other direction
+    // is O(columns × rules), which on a wide sparse result set with a large blacklist
+    // measured 26ms where this measures 6.7ms. Ancestor matching also means a merely
+    // similar name — `profiles`, `profile_name` — is never mistaken for a child.
+    for (const column of presentColumns) {
+      // `dot >= 0` continues the walk; `dot > 0` decides a match. Conflating the two
+      // meant a column whose name starts with a dot — Elasticsearch permits it, and
+      // `flattenSource` concatenates it verbatim — exited before testing a single
+      // ancestor, so a rule for `.profile` never reached `.profile.ssn`.
+      let dot = column.indexOf('.')
+      while (dot >= 0) {
+        if (dot > 0 && protectedPaths.has(column.slice(0, dot))) {
+          omitted.add(column)
+          break
+        }
+        dot = column.indexOf('.', dot + 1)
+      }
+    }
+    const omittedColumns = Array.from(omitted)
 
     if (omittedColumns.length === 0) {
       return { filteredRows: rows, omittedColumns: [] }

--- a/src/core/field-projection.ts
+++ b/src/core/field-projection.ts
@@ -71,20 +71,38 @@ export function omitFieldPaths(
   // blacklist is overwhelmingly such names, so those are collected into one pass
   // and only genuinely nested paths still recurse. Same output, ~50x faster.
   //
-  // Ceiling: dotted paths keep the old cost. A blacklist of N dotted JSON paths is
-  // still N rebuilds per row — measured at 2.6ms for 5 paths over 100 rows, and it
-  // grows linearly in N. `blacklist-validator.ts` admits dotted paths deliberately,
-  // so if a config ever carries dozens of them, this branch is what to optimise next.
-  const topLevel = new Set<string>()
-  const nested: string[] = []
-  for (const path of paths) {
-    if (path.includes('.')) nested.push(path)
-    else topLevel.add(path)
-  }
+  // A dotted path has two jobs: delete a literal key of that exact name, and walk
+  // into a nested record of the same head. The first is what `omitPath`'s
+  // `key === exactPath` branch does, and the skip-set does it just as well — so
+  // every path joins the skip-set, and the expensive recursion is reserved for the
+  // rows that actually hold an object at the head. That distinction matters because
+  // the Elasticsearch adapter flattens `_source`: its rows are *all* dotted keys and
+  // no nested records, so masking them used to pay a full rebuild per path for
+  // traversal that could never match. Measured on 1000 flattened docs with 6
+  // protected fields: 10.9ms with the recursion, 2.0ms without.
+  //
+  // The decision is per row, not per result set. A single document whose `profile`
+  // is an array (Elasticsearch does not flatten arrays) would otherwise put all
+  // thousand rows back on the slow path — measured at 8.4ms for one nested row in
+  // a thousand, over the benchmark's budget, for traversal 999 rows cannot use.
+  //
+  // Ceiling: a genuinely nested row still costs one rebuild per path that reaches it.
+  const topLevel = new Set<string>(paths)
+  const dotted = paths
+    .filter((path) => path.includes('.'))
+    .map((path) => ({ head: path.slice(0, path.indexOf('.')), segments: path.split('.') }))
 
   return rows.map((row) => {
+    // A null/non-record row carries no field to mask. Returning it untouched only
+    // moved the throw downstream (`query-executor` indexes into every row), and the
+    // declared return type says these are records — so it becomes an empty one. Row
+    // count and ordering are preserved, which is what callers actually index by.
+    if (row === null || typeof row !== 'object') return {}
     let projected: unknown = cloneRecord(row, topLevel)
-    for (const path of nested) projected = omitPath(projected, path.split('.'))
+    for (const { head, segments } of dotted) {
+      const value = row[head]
+      if (value !== null && typeof value === 'object') projected = omitPath(projected, segments)
+    }
     return projected as Record<string, unknown>
   })
 }

--- a/tests/perf/blacklist-performance.bench.ts
+++ b/tests/perf/blacklist-performance.bench.ts
@@ -227,14 +227,13 @@ describe('Blacklist Performance Benchmarks', () => {
       () => validator.filterColumns('logs', docs, columnList).filteredRows
     )
 
-    // PROVISIONAL budget. Locally this measures ~1.8ms and the regression it guards
-    // against (deciding the nested recursion per result set instead of per row)
-    // measures ~8.7ms, so the discriminating ceiling is around 4ms — but the ratio
-    // between this machine and a CI runner is not known for this shape yet, and the
-    // sibling case scales 0.65ms → 3.66ms on windows-latest. Tightened from the CI
-    // numbers this benchmark prints, not from a dev machine.
-    report('Column filtering (1000 flattened docs)', elapsed, 16)
-    expect(elapsed).toBeLessThan(16)
+    // Budget set from CI, not from a dev machine: measured 2.59–5.53ms across the
+    // six matrix jobs (worst windows-latest, bun 1.3.3), against 1.83ms locally — so
+    // a runner costs about 3x here. The regression this guards against measures
+    // 8.7ms locally, i.e. roughly 26ms on that runner, so 12ms both clears the worst
+    // real measurement by 2.2x and fails loudly if the per-row decision is undone.
+    report('Column filtering (1000 flattened docs)', elapsed, 12)
+    expect(elapsed).toBeLessThan(12)
   })
 
   it('Config loading - typical blacklist: < 5ms', () => {

--- a/tests/perf/blacklist-performance.bench.ts
+++ b/tests/perf/blacklist-performance.bench.ts
@@ -194,6 +194,49 @@ describe('Blacklist Performance Benchmarks', () => {
     expect(elapsed).toBeLessThan(10)
   })
 
+  it('Column filtering (1000 flattened docs, 3 parent rules): < 8ms per call', () => {
+    // The shape the Elasticsearch adapter actually produces: `_source` flattened
+    // into dotted top-level keys with no nested records anywhere. Nothing here
+    // covered it, which is how a 70x masking regression on real ES results passed
+    // CI once — the other cases mask by plain column name and never exercise the
+    // dotted branch on a wide result set.
+    const docs = Array.from({ length: 1000 }, (_, i) => {
+      const row: Record<string, unknown> = { id: i }
+      for (let j = 0; j < 16; j++) row[`f${j}`] = j
+      row['profile.email'] = `e${i}`
+      row['profile.ssn'] = `s${i}`
+      row['payment.card'] = `c${i}`
+      row['payment.cvv'] = '123'
+      row['meta.a'] = 1
+      row['meta.b'] = 2
+      return row
+    })
+    // Elasticsearch does not flatten arrays, so one document out of a thousand can
+    // legitimately carry a nested `profile`. When the recursion decision was made
+    // once for the whole result set instead of per row, this single document put the
+    // other 999 back on the slow path and pushed this case over budget.
+    docs[500] = { id: 500, profile: [{ email: 'nested' }], 'payment.card': 'c' }
+    const config = {
+      ...baseConfig,
+      blacklist: { tables: [], columns: { logs: ['profile', 'payment', 'meta'] } },
+    }
+    const validator = new BlacklistValidator(new BlacklistManager(config as any))
+    const columnList = Object.keys(docs[0] ?? {})
+
+    const elapsed = medianElapsed(
+      () => validator.filterColumns('logs', docs, columnList).filteredRows
+    )
+
+    // PROVISIONAL budget. Locally this measures ~1.8ms and the regression it guards
+    // against (deciding the nested recursion per result set instead of per row)
+    // measures ~8.7ms, so the discriminating ceiling is around 4ms — but the ratio
+    // between this machine and a CI runner is not known for this shape yet, and the
+    // sibling case scales 0.65ms → 3.66ms on windows-latest. Tightened from the CI
+    // numbers this benchmark prints, not from a dev machine.
+    report('Column filtering (1000 flattened docs)', elapsed, 16)
+    expect(elapsed).toBeLessThan(16)
+  })
+
   it('Config loading - typical blacklist: < 5ms', () => {
     const elapsed = medianElapsed(() => new BlacklistManager(typicalConfig as any))
 

--- a/tests/unit/core/blacklist-validator.test.ts
+++ b/tests/unit/core/blacklist-validator.test.ts
@@ -239,6 +239,153 @@ describe('BlacklistValidator', () => {
       expect(notification).not.toBe('security.columns_omitted')
     })
   })
+  describe('filterColumns() against a flattened result set', () => {
+    // The Elasticsearch adapter flattens `_source` recursively
+    // (`elasticsearch-adapter.ts:72`), so a document `{ profile: { email, ssn } }`
+    // reaches the validator as the keys `profile.email` and `profile.ssn` — there is
+    // no `profile` key at all. Blacklisting the parent has to still protect them.
+    const flattenedRows = [
+      { id: 1, 'profile.email': 'a@example.com', 'profile.ssn': '123', keep: 'ok' },
+    ]
+    const flattenedColumns = ['id', 'profile.email', 'profile.ssn', 'keep']
+
+    it('omits flattened children when the parent column is blacklisted', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+
+      const result = validator.filterColumns('logs', flattenedRows, flattenedColumns)
+
+      expect(result.omittedColumns.sort()).toEqual(['profile.email', 'profile.ssn'])
+      expect(result.filteredRows[0]).toEqual({ id: 1, keep: 'ok' })
+    })
+
+    it('reports the omission so the security notification is not silent', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+
+      const result = validator.filterColumns('logs', flattenedRows, flattenedColumns)
+
+      // An empty list means no notification is emitted — the data would leave
+      // without the caller ever being told something was supposed to be hidden.
+      expect(result.omittedColumns.length).toBeGreaterThan(0)
+      expect(validator.buildSecurityNotification('logs', result.omittedColumns)).not.toBe('')
+    })
+
+    it('does not treat a merely prefixed column name as a child', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+      const rows = [{ profileId: 7, profile_name: 'x', profiles: 'y' }]
+
+      const result = validator.filterColumns('logs', rows, [
+        'profileId',
+        'profile_name',
+        'profiles',
+      ])
+
+      expect(result.omittedColumns).toEqual([])
+      expect(result.filteredRows[0]).toEqual({ profileId: 7, profile_name: 'x', profiles: 'y' })
+    })
+
+    it('finds a protected field that appears only in a later row', () => {
+      // Elasticsearch documents are sparse and `columnList` is usually taken from
+      // the first row, so a field that shows up further down must still be caught.
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+      const rows = [{ id: 1 }, { id: 2 }, { id: 3, 'profile.ssn': '123' }]
+
+      const result = validator.filterColumns('logs', rows, ['id'])
+
+      expect(result.omittedColumns).toEqual(['profile.ssn'])
+      expect(result.filteredRows[2]).toEqual({ id: 3 })
+    })
+
+    it('works with an empty column list', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+
+      const result = validator.filterColumns('logs', [{ 'profile.ssn': '123' }], [])
+
+      expect(result.omittedColumns).toEqual(['profile.ssn'])
+      expect(result.filteredRows[0]).toEqual({})
+    })
+
+    it('matches at every ancestor depth', () => {
+      const rows = [{ 'a.b.c': 'secret', 'a.x': 'also secret', keep: 1 }]
+      const columns = ['a.b.c', 'a.x', 'keep']
+
+      const byRoot = makeValidator({ tables: [], columns: { logs: ['a'] } })
+      expect(byRoot.filterColumns('logs', rows, columns).filteredRows[0]).toEqual({ keep: 1 })
+
+      const byMiddle = makeValidator({ tables: [], columns: { logs: ['a.b'] } })
+      expect(byMiddle.filterColumns('logs', rows, columns).filteredRows[0]).toEqual({
+        'a.x': 'also secret',
+        keep: 1,
+      })
+    })
+
+    it('normalises a null row instead of throwing or passing null downstream', () => {
+      // Passing the row through only moved the throw: callers index into every row.
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+      const rows = [null as any, { 'profile.ssn': '1', keep: 2 }]
+
+      const result = validator.filterColumns('logs', rows, [])
+
+      expect(result.filteredRows).toEqual([{}, { keep: 2 }])
+      expect(result.filteredRows[0]).not.toBeNull()
+    })
+
+    it('an empty blacklist entry does not swallow dot-prefixed columns', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['', 'a'] } })
+
+      const result = validator.filterColumns('logs', [{ '.x': 1, 'a.b': 2, keep: 3 }], [])
+
+      expect(result.omittedColumns).toEqual(['a.b'])
+      expect(result.filteredRows[0]).toEqual({ '.x': 1, keep: 3 })
+    })
+
+    it('matches ancestors of a column name that starts with a dot', () => {
+      // Elasticsearch permits a leading dot in a field name and `flattenSource`
+      // concatenates it verbatim, so `.profile.ssn` is a reachable column name.
+      const validator = makeValidator({ tables: [], columns: { logs: ['.profile'] } })
+
+      const result = validator.filterColumns('logs', [{ '.profile.ssn': 'S', keep: 1 }], [])
+
+      expect(result.omittedColumns).toEqual(['.profile.ssn'])
+      expect(result.filteredRows[0]).toEqual({ keep: 1 })
+    })
+
+    it('KNOWN CEILING: a rule naming a leaf does not match it inside a flattened path', () => {
+      // Blacklisting `ssn` does NOT protect a flattened `profile.ssn`. Matching any
+      // segment would close it, but it would also mean a rule for `id` hides
+      // `user.id`, `order.id`, and every other qualified column — over-blocking wide
+      // enough to make the feature unusable. `dbcli schema` reports Elasticsearch
+      // fields with their dotted names, so the documented workflow yields the path
+      // that does work. Pinned so the trade-off is a decision, not a surprise.
+      const validator = makeValidator({ tables: [], columns: { logs: ['ssn'] } })
+
+      const result = validator.filterColumns(
+        'logs',
+        [{ id: 1, 'profile.ssn': 'S' }],
+        ['id', 'profile.ssn']
+      )
+
+      expect(result.omittedColumns).toEqual([])
+    })
+
+    it('KNOWN CEILING: a rule matches ancestors only from the start of the path', () => {
+      // `profile` does not reach `data.profile.ssn` — same trade-off as above.
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+
+      const result = validator.filterColumns('logs', [{ 'data.profile.ssn': 'S' }], [])
+
+      expect(result.omittedColumns).toEqual([])
+    })
+
+    it('still omits the nested representation when both forms are present', () => {
+      const validator = makeValidator({ tables: [], columns: { logs: ['profile'] } })
+      const rows = [{ id: 1, 'profile.email': 'flat', profile: { email: 'nested' } }]
+
+      const result = validator.filterColumns('logs', rows, ['id', 'profile.email', 'profile'])
+
+      expect(result.filteredRows[0]).toEqual({ id: 1 })
+    })
+  })
+
   describe('checkTablesBlacklist / filterColumnsForTables (issue #23)', () => {
     it('blocks when any table in the list is blacklisted', () => {
       const validator = makeValidator({ tables: ['users'], columns: {} })

--- a/tests/unit/core/field-projection.test.ts
+++ b/tests/unit/core/field-projection.test.ts
@@ -160,6 +160,18 @@ describe('projectRows', () => {
     expect(projected.rows).toEqual([{ id: 1 }])
   })
 
+  test('exclusion never emits a non-record row for callers to index into', () => {
+    // Include mode already coerces a null row into a normalised record; exclusion
+    // used to be the one path that leaked `null` into a Record<string, unknown>[].
+    const projected = projectRows([null as any, { a: 1, b: 2 }], {
+      mode: 'exclude',
+      paths: ['b'],
+    })
+
+    expect(projected.rows).toEqual([{ a: null }, { a: 1 }])
+    expect(projected.columnNames).toEqual(['a'])
+  })
+
   test('normalizes sparse inclusion keys for JSON and preserves non-plain values', () => {
     const date = new Date('2026-08-01T00:00:00Z')
     const projected = projectRows([{ id: 1, date }, { id: 2 }], {


### PR DESCRIPTION
## 漏洞

`elasticsearch-adapter.ts:72` 的 `flattenSource()` 會遞迴走 `_source`，把 `{profile:{ssn}}` 攤平成單一鍵 `profile.ssn` —— **文件裡根本沒有 `profile` 這個鍵**。而遮蔽是以欄位名等值比對決定的：

```
columnList.includes('profile')                → false
rows.some(r => hasFieldPath(r, 'profile'))    → false
→ omittedColumns 為空 → 資料原樣回傳
```

所以在 ES index 上把 `profile` 列入欄位黑名單**完全沒有作用**。而且因為 `omittedColumns` 是空的，`buildSecurityNotification` 也不會發出通知 —— 使用者連「有東西本來該被藏起來」都不會知道。**靜默洩漏**，影響 `query` / `q` / `export` 三條 ES 路徑。

三條路徑都走 `filterColumnsForIndexExpression` → 委派給 `filterColumnsForTables`，所以一處修好全部覆蓋。`flattenSource` 也只存在於 ES adapter，MongoDB 回傳巢狀文件不受影響。

## 修法

每個欄位往上拆自己的祖先去比對黑名單（`a.b.c` 只需問 `a`、`a.b`），任何位於黑名單祖先之下的欄位都會被遮蔽。

方向是刻意選的：反過來「每條規則掃描所有欄位」是 O(欄位 × 規則)，在稀疏寬文件上量到 **26ms**；祖先走訪是 O(欄位 × 深度)，量到 **7.9ms**。

`profiles` / `profile_name` / `profileId` 這類僅前綴相似的欄位不受影響（有測試釘住）。

## 順帶修掉一個我自己造的 70 倍退化

第一版把 child 名稱丟進 `omittedColumns`，而它們帶點，於是全部走 `omitPath` 的整筆 rebuild —— **正是 PR #28 註解裡標為天花板的那條路徑**，只是這次由資料自動生成，一般設定就會踩到。而現有基準沒有任何攤平形狀的資料，所以 CI 攔不到，退化只會出現在使用者身上。

拆法：dotted path 的兩件工作分開。刪掉字面鍵由 `cloneRecord` 的 skip-set 做（那正是 `omitPath` 的 `key === exactPath` 分支），遞迴只保留給「該列真的在 head 上放了物件」。

判斷還必須**下放到每列** —— ES 遇到陣列不攤平，1000 份文件裡只要有 1 份的 `profile` 是陣列，全域述詞就會讓其餘 999 列全部回到舊成本：

| 形狀 | 修復前 | 第一版 | 全域述詞 | 現在 |
| --- | --- | --- | --- | --- |
| 真實 ES 1000×22 | 0.15ms* | 10.88ms | 2.15ms | **2.15ms** |
| 1 份 profile 是陣列 | — | — | 4.07ms | **1.66ms** |
| 1 份三個父層都巢狀 | — | — | **8.36ms（超預算）** | **1.52ms** |
| 稀疏 1000×50 | 6.67ms | 26.44ms | — | **7.86ms** |

\* 「修復前」的 0.15ms 是**什麼都沒遮蔽就早退**的成本，也就是這次要修的洩漏本身，不是合理對照。

**新增攤平形狀的基準**（含第 500 份是巢狀文件的 seed）—— 就是這個缺口讓 70 倍退化溜過 CI 的。

## 審查

三輪。第一輪**擋下**（70 倍退化 + 掃描方向），第二輪擋下兩個我重寫時新開的 MEDIUM，第三輪判定可合併並指出兩個 delta 新開的 WARNING，都已修：

- **欄位名以點開頭時祖先走訪一次都不跑** —— `while (dot > 0)` 讓 `dot > 0` 同時當迴圈條件與空前綴排除，欄位名開頭是點時 `indexOf` 回傳 0 直接不進迴圈。ES 允許這種欄位名，所以 `.profile` 比不到 `.profile.ssn`。已拆成 `dot >= 0` 走訪、`dot > 0` 判定。
- **null 列的守衛只是把例外往後挪兩個函式** —— 現在正規化成空 record，與 include 模式一致，不再把 `null` 送進宣告為 `Record<string, unknown>[]` 的陣列。測試也從「不 throw」改成斷言實際輸出。
- **一段我寫錯的註解** —— 它宣稱空字串 filter 與 `dot > 0` 是兩道刻意的守衛，實際上前者不可達。已移除死碼；留著只會讓日後的人以為死的那行是 load-bearing。

第三輪以 **20 萬次差分 fuzz** 確認 per-row 述詞與舊行為零差異，並驗證「把迴圈改回 `dot > 0` 就會有測試失敗」。

## 刻意未收的天花板

規則寫葉節點名（`ssn`）比不到 `profile.ssn`，`profile` 也比不到 `data.profile.ssn`。收掉要比對任一 segment，代價是 `id` 這條規則會藏起 `user.id`、`order.id` 與所有帶限定的欄位 —— 過度攔截到讓功能不可用。

`dbcli schema` 對 ES 回報的是帶點的完整欄位名，所以文件所述的工作流（照 `schema` 顯示的名稱設黑名單）會落在有效的分支上。以兩條 `KNOWN CEILING` 測試把現況釘死，並寫進 `docs/security-threat-model.md` —— 讓它是一個看得見的取捨，不是「以為已經全覆蓋」。

## 測試計畫

- 新增 12 條測試：攤平子欄位、安全通知不再靜默、僅前綴相似不誤殺、稀疏列（欄位只出現在第 3 列）、空 columnList、多層深度、以點開頭的欄位名、null 列、空黑名單項、兩條 KNOWN CEILING
- `SKIP_INTEGRATION_TESTS=true bun run test`：**4641 pass / 26 skip / 0 fail**
- `typecheck` / `lint` / `prettier` / `docs:check` 全綠

## 待這個 PR 的 CI 回報後再收的一件事

新基準的預算**暫定 16ms**。本機量到 1.83ms、它要防的退化量到 8.66ms，所以有區辨力的天花板大約在 4ms —— 但這個形狀在 CI runner 上的縮放比還不知道（同檔的另一條是本機 0.65ms → windows-latest 3.66ms，約 5.6 倍）。等這個 PR 印出 Windows 的數字再收緊，不從本機猜。