### PR TITLE
test: [ ci ] 讓 lock 逾時測試不再靠牆鐘僥倖通過

### DIFF
--- a/tests/unit/core/concurrent-lock.test.ts
+++ b/tests/unit/core/concurrent-lock.test.ts
@@ -82,22 +82,35 @@ test('ConcurrentLockManager - timeout on lock acquisition', async () => {
   const testDir = join(tmpdir(), `lock-timeout-${Date.now()}`)
   await mkdir(testDir, { recursive: true })
 
-  const manager1 = new ConcurrentLockManager(testDir, 100) // Very short timeout
-  const manager2 = new ConcurrentLockManager(testDir, 100)
+  // Only the contender's acquisition is under test, so only it gets a short budget.
+  // Sharing a 100ms budget made this flaky on Windows: every acquisition attempt
+  // shells out to `mv` (and `rm`) via `Bun.spawn`, which on a loaded runner costs
+  // more than the whole budget — so the holder could time out taking an *uncontended*
+  // lock and fail the test on line one, before the assertion was ever reached. The
+  // failing run took 547ms for a test whose nominal cost is ~220ms.
+  const holder = new ConcurrentLockManager(testDir)
+  // 1000ms, not 100ms, for a second reason: `tryAcquireLock` treats a lock older than
+  // 3x the timeout as stale and *deletes* it. The elapsed check runs at the top of the
+  // loop and the staleness check inside the attempt, so an attempt that stalls longer
+  // than 3x the budget makes the contender steal the lock and succeed — turning a
+  // 300ms hiccup into a red build. At 1000ms that race needs a 3s stall inside a
+  // single attempt. The assertions below are what make the test pass or fail; the
+  // budget only decides how long it waits to find out.
+  const contender = new ConcurrentLockManager(testDir, 1000)
 
-  // Manager1 acquires lock
-  await manager1.acquireLock('operation1')
-
-  // Manager2 tries to acquire with short timeout
   try {
-    await manager2.acquireLock('operation2')
-    expect(true).toBe(false) // Should timeout
-  } catch (error) {
-    expect(error instanceof Error).toBe(true)
-    expect((error as Error).message).toContain('timeout')
-  }
+    await holder.acquireLock('operation1')
 
-  // Cleanup
-  await manager1.releaseLock()
-  await rm(testDir, { recursive: true, force: true })
+    await expect(contender.acquireLock('operation2')).rejects.toThrow(/timeout/)
+
+    // The lock is still the holder's. Without this, the stale-lock race above would
+    // read as a pass on the day it fires: `rejects.toThrow` is the only other
+    // assertion, and a contender that stole the lock would simply not throw.
+    const lock = await Bun.file(join(testDir, 'schema.lock')).json()
+    expect(lock.operation).toBe('operation1')
+    expect(holder.isLockHeld()).toBe(true)
+  } finally {
+    await holder.releaseLock()
+    await rm(testDir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
`ConcurrentLockManager - timeout on lock acquisition` 在 windows-latest / bun 1.3.3 上偶發紅（#31 的 CI 就中了一次，該次耗時 **547ms**，名目成本約 220ms；重跑即綠）。實作沒壞，是測試把自己綁在牆鐘上，而且有兩個**獨立**的 flake 來源。

## ① 持鎖端與競爭端共用 100ms 預算

每次取鎖都會 `Bun.spawn` 一個 `mv`（釋放時還有 `rm`）。在忙碌的 runner 上單次 spawn 就超過整個預算，於是**持鎖端會在取一個沒有人競爭的鎖時逾時丟出例外** —— 測試在第一行就死了，底下的斷言根本沒跑到。

只有競爭端的取鎖行為是這條測試的主題，所以現在只有它拿短預算，持鎖端用預設值。

## ② stale-lock race：卡 300ms 就會翻紅

`tryAcquireLock` 會把「比逾時久 3 倍」的鎖視為 stale 並**直接刪掉**。elapsed 檢查在迴圈頂端、staleness 檢查在嘗試裡面，所以只要單次嘗試卡超過 3 倍預算，競爭端就會搶走鎖並**成功取得** —— 在 100ms 預算下，一個 300ms 的 hiccup 就足夠。改成 1000ms 後，這個 race 需要單次嘗試卡滿 3 秒。

預算只決定「等多久才知道結果」，決定成敗的是斷言。

## 斷言也補強了

- `expect(true).toBe(false)` → `rejects.toThrow(/timeout/)`
- 新增「鎖仍然屬於持鎖端」的斷言。這是必要的：② 真的發生時，競爭端是**成功**而不是丟例外，原本的寫法會安靜地通過 —— 一條偶爾什麼都不驗的測試，比偶爾翻紅更糟
- 清理移進 `finally`，失敗時不再留下 temp 目錄

兩條斷言都以突變驗證過確實會失敗（改壞 `lock.operation` 的期望值 → 紅；把 `/timeout/` 換成不匹配的字串 → 紅），不是空跑。

## 沒有動的部分

實作本身兩個味道留著，供後續決定：

- 每次取鎖嘗試都 `Bun.spawn` 一個 `mv` / `rm`：慢，而且相依於 PATH 上有 Unix 工具（Windows runner 是靠 Git 附的 `usr/bin` 才過的）
- stale 判定與逾時綁成 3 倍，使得**競爭端可能刪掉一個還活著的鎖**。這是 ② 的成因，測試只是不再踩它，並不是它不存在了

## Test plan

- `bun run test:unit` — 3996 pass / 0 fail
- `bun test ./tests/unit/core/concurrent-lock.test.ts` 連跑三次 — 4 pass / 0 fail
- `bun run typecheck` / `bun run lint` — 綠
