### PR TITLE
chore: [ release ] 1.49.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.49.0] - 2026-08-06 - 欄位遮罩涵蓋攤平與陣列列，且不再為每條規則掃過整個結果集
+
+延續 1.48.0 的 blacklist 主題：那一版修的是「哪些物件受保護」，這一版修的是「受保護的欄位到底有沒有真的被遮掉」，以及遮罩本身的成本。兩條安全性修復都屬於 fail-open —— 資料原樣回傳，其中一條連安全通知都不會發。
 
 ### Added
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/src/core/blacklist-validator.ts
+++ b/src/core/blacklist-validator.ts
@@ -28,7 +28,8 @@ function flattenArrayRow(row: readonly unknown[]): Record<string, unknown>[] {
   const records: Record<string, unknown>[] = []
   for (const item of row) {
     if (Array.isArray(item)) records.push(...flattenArrayRow(item))
-    else if (item !== null && typeof item === 'object') records.push(item as Record<string, unknown>)
+    else if (item !== null && typeof item === 'object')
+      records.push(item as Record<string, unknown>)
   }
   return records
 }

--- a/src/core/field-projection.ts
+++ b/src/core/field-projection.ts
@@ -60,10 +60,7 @@ export function projectRows(
 // for the same path pays `split` once instead of once per row: the masker's fail-safe
 // branch applies every rule in the config, so "many paths, almost no matches" is its
 // normal shape, and the splitting alone measured a third of that branch's cost.
-export function hasFieldPath(
-  row: Record<string, unknown>,
-  segments: readonly string[]
-): boolean {
+export function hasFieldPath(row: Record<string, unknown>, segments: readonly string[]): boolean {
   return readPath(row, segments).found
 }
 

--- a/tests/unit/core/blacklist-validator.test.ts
+++ b/tests/unit/core/blacklist-validator.test.ts
@@ -517,10 +517,11 @@ describe('BlacklistValidator', () => {
     it('does not omit a dotted rule whose head is a scalar in every row', () => {
       const validator = makeValidator({ tables: [], columns: { orders: ['profile.ssn'] } })
 
-      const result = validator.filterColumns('orders', [{ id: 1, profile: 'plain' }], [
-        'id',
-        'profile',
-      ])
+      const result = validator.filterColumns(
+        'orders',
+        [{ id: 1, profile: 'plain' }],
+        ['id', 'profile']
+      )
 
       expect(result.omittedColumns).toEqual([])
       expect(result.filteredRows[0]).toEqual({ id: 1, profile: 'plain' })

--- a/tests/unit/proxy/analyze.test.ts
+++ b/tests/unit/proxy/analyze.test.ts
@@ -199,11 +199,7 @@ describe('buildErrors', () => {
       }),
     ])
     expect(g!.tables).toEqual(['a', 'b', 'c', 'd'])
-    expect(g!.suggestedCommands).toEqual([
-      'dbcli schema a',
-      'dbcli schema b',
-      'dbcli schema c',
-    ])
+    expect(g!.suggestedCommands).toEqual(['dbcli schema a', 'dbcli schema b', 'dbcli schema c'])
   })
 
   it('always emits a hint and omits suggestedCommands when no tables are known', () => {


### PR DESCRIPTION
版本發布：**1.49.0**（minor）。npm publish 由使用者手動執行，本 PR 只處理版號、CHANGELOG 定版與 tag 前的驗證。

## 為什麼是 minor 而非 patch

`### Added` 有新功能（#33 救回的 proxy analyze errors / repetition 行動化建議）。其餘是安全性與效能修復。沒有破壞性變更 —— 陣列列那條雖是行為變更（輸出從原樣變成真的遮掉），但目前沒有任何 adapter 會產生陣列列。

## 這一版的內容（1.48.0 之後合併的四個 PR）

| PR | 內容 |
| --- | --- |
| #30 | **Security** — 黑名單指定父欄位時，ES 攤平後的子欄位未被遮蔽，且不發安全通知 |
| #31 | **Security** — 陣列列只發通知不拿掉資料；**Performance** — 遮罩層不再為每條規則掃過整個結果集（12.10ms → 0.70ms） |
| #32 | lock 逾時測試去 flake（Windows 偶發紅） |
| #33 | **Added** — proxy analyze 的 errors / repetition 帶可執行的 `suggestedCommands` 與 `hints` |

延續 1.48.0 的 blacklist 主題：那一版修的是「哪些物件受保護」，這一版修的是「受保護的欄位到底有沒有真的被遮掉」，以及遮罩本身的成本。兩條 Security 都屬於 fail-open。

## 變更內容

- 六份 manifest 對齊 1.49.0：`package.json`、`gemini-extension.json`、`.cursor-plugin`、`.claude-plugin`、`.codex-plugin`、`plugins/dbcli-agent/.codex-plugin`（`plugin:sync` 不同步版號，必須手動）
- CHANGELOG 的 `[Unreleased]` 定版為 `## [1.49.0] - 2026-08-06`
- 附帶一個 `style:` commit 補跑 prettier：四個檔案在 main 上帶著格式漂移，因為 **CI 不跑 prettier**，只有 `release:check` 的第 2 步會擋，所以合併時沒人看見。純格式，無行為變更

## Test plan

- `bun run release:check` — **9/9 通過**（audit / prettier / agent-core purity / typecheck / lint / test / build / dist smoke / doc-presence）
- 測試 **4010 pass / 0 fail**
- 六個 parity check 全綠，CLI contract 對齊 90 個指令路徑與 165 個長旗標
