### PR TITLE
ci: [ format ] prettier 進 CI，不再只由發布前那一步把關

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,23 @@ jobs:
       - name: Run performance benchmarks
         run: bun run test:perf
 
+  format:
+    # Formatting is platform-independent, so this runs once rather than per matrix
+    # entry. It exists because `release:check` was the only thing enforcing prettier:
+    # four unformatted files reached main through green CI and were caught minutes
+    # before a release. Scope is deliberately the same TS glob release:check uses —
+    # a whole-repo check currently fails on 86 files (docs, generated HTML, fixtures)
+    # and reformatting those is its own change, not a side effect of adding a gate.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - name: Prettier
+        run: bun run format:check
+
   docs-parity:
     # Drift guards: fail the build when the CLI, SKILL.md, reference.md, managed
     # platform copies, or user docs fall out of sync. Runs once (not per matrix).

--- a/package.json
+++ b/package.json
@@ -81,8 +81,9 @@
     "typecheck": "tsc --noEmit --pretty false",
     "test:perf": "bun test ./tests/perf/*.bench.ts",
     "lint": "eslint src tests scripts --ext .ts --max-warnings=0",
-    "lint:fix": "eslint src tests scripts --ext .ts --fix --max-warnings=0",
-    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\""
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint:fix": "eslint src tests scripts --ext .ts --fix --max-warnings=0"
   },
   "dependencies": {
     "cli-table3": "^0.6.5",

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -8,8 +8,11 @@ step() { printf '\n\033[1;34m▶ %s\033[0m\n' "$*"; }
 step '1/9 bun audit'
 bun audit
 
+# Via `bun run` so the glob lives in one place (package.json) and CI's `format`
+# job checks exactly what this checks — the two drifting apart is how unformatted
+# files reached main in the first place.
 step '2/9 prettier --check'
-bunx prettier --check "src/**/*.ts" "tests/**/*.ts" "scripts/**/*.ts"
+bun run format:check
 
 step '3/9 agent-core purity'
 bun run agent-core:check


### PR DESCRIPTION
發布 1.49.0 時撞到的：`release:check` 的第 2 步是**唯一**在跑 prettier 的地方，於是四個未格式化的檔案（都是我這兩天合併的）一路綠燈進了 main，直到打 tag 前幾分鐘才被擋下來。CI 綠不代表發得出去，這個落差自己就是缺陷。

## 做法

- 新增一個只跑一次的 `format` job。格式與平台無關，不需要跟著 6 格矩陣跑
- glob 收進 `package.json` 的 `format:check` / `format`，`release:check` 第 2 步改成 `bun run format:check` —— **兩邊定義漂開正是當初漏掉的原因**，現在只有一處

## 範圍為什麼不是全 repo

刻意維持 `release:check` 既有的 TS glob（`src` / `tests` / `scripts`）。全 repo 檢查目前有 **86 個檔案**不合格（docs、產生的 HTML、fixtures），重新格式化那些是另一件事，不該當成加 gate 的副作用；而且其中數個檔案有內容契約測試在盯（`assets/SKILL.md`、`docs/user/**` 的 parity check）。

要收那 86 個檔案的話，值得單獨開一個 PR，讓 diff 的性質清楚。

## Test plan

- `bun run format:check` 在乾淨的 main 上通過
- 故意在 `src/core/field-projection.ts` 尾端加一行未格式化的程式碼 → gate 擋下（驗過它不是空跑）
- workflow YAML 解析正常，jobs = `test` / `format` / `docs-parity`
