### PR TITLE
fix: skill frontmatter 剝除支援 CRLF 來源檔 (#52 B-1)

### DIFF
--- a/src/core/skill-install/platform-format.ts
+++ b/src/core/skill-install/platform-format.ts
@@ -31,7 +31,11 @@ interface ParsedSkill {
 }
 
 function parseSkill(source: string): ParsedSkill {
-  const match = /^---\n([\s\S]*?)\n---\n?/.exec(source)
+  // `\r?\n`，不是 `\n`：來源檔可能是 CRLF（Windows 上 git autocrlf 的 checkout，
+  // 或使用者自己用 CRLF 編輯 assets/SKILL.md）。只認 LF 時整段比對不到，
+  // frontmatter 原封不動留在輸出裡——而 Windsurf 不解析 frontmatter，那 900
+  // 字的 Claude 標頭會變成寫給錯誤讀者的正文（ADR 0006）。
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source)
   if (!match) return { frontmatter: '', body: source }
   return { frontmatter: match[1]!, body: source.slice(match[0].length) }
 }
@@ -61,7 +65,7 @@ export function formatForPlatform(platform: string, skillMarkdown: string): stri
 
   const { frontmatter, body } = parseSkill(skillMarkdown)
   const description = frontmatterValue(frontmatter, 'description')
-  const repointedBody = repointReference(body.replace(/^\n+/, ''), referencePath)
+  const repointedBody = repointReference(body.replace(/^[\r\n]+/, ''), referencePath)
 
   if (platform.toLowerCase() === 'cursor') {
     const header = [

--- a/tests/unit/skill-assets/platform-format.test.ts
+++ b/tests/unit/skill-assets/platform-format.test.ts
@@ -92,3 +92,33 @@ Full flags live in reference.md, and the \`reference.md\` Redis section covers R
     expect(formatForPlatform('cursor', once)).toBe(once)
   })
 })
+
+// ── CRLF 來源檔（#52 B-1） ─────────────────────────────────────────────────
+//
+// Windows 上 git autocrlf 的 checkout 會把 assets/SKILL.md 變成 CRLF，使用者
+// 自己用 CRLF 編輯也一樣。frontmatter 的比對只認 LF 時整段剝不掉，Windsurf
+// 版就會帶著它不會解析的 YAML 標頭出貨——CI 上表現為 Windows job 紅燈。
+
+describe('formatForPlatform with CRLF source', () => {
+  const CRLF_SKILL = SKILL.replace(/\n/g, '\r\n')
+
+  test('windsurf 仍然剝掉 frontmatter', () => {
+    const out = formatForPlatform('windsurf', CRLF_SKILL)
+    expect(out).not.toContain('name: dbcli')
+    expect(out).not.toContain('---')
+    expect(out).toContain('# dbcli')
+  })
+
+  test('windsurf 仍然把 description 提為開頭段落並重指 reference', () => {
+    const out = formatForPlatform('windsurf', CRLF_SKILL)
+    expect(out.startsWith('Database CLI for AI agents.')).toBe(true)
+    expect(out).toContain('.windsurf/skills/dbcli/reference.md')
+  })
+
+  test('cursor 仍然換成自己的 rule 欄位', () => {
+    const out = formatForPlatform('cursor', CRLF_SKILL)
+    expect(out).not.toContain('name: dbcli')
+    expect(out).toContain('alwaysApply: false')
+    expect(out).toContain('description: Database CLI for AI agents.')
+  })
+})


### PR DESCRIPTION
#52 的 B-1。這條不只是 Windows CI 的測試問題，是實際會出貨錯誤內容的產品 bug。

## 問題

`parseSkill()`（`src/core/skill-install/platform-format.ts`）的 frontmatter 比對只認 LF：

```ts
const match = /^---\n([\s\S]*?)\n---\n?/.exec(source)
```

來源檔是 CRLF 時整段比對不到，frontmatter 原封不動留在輸出裡。Windsurf 不解析 frontmatter，那約 900 字的 Claude 標頭於是變成寫給錯誤讀者的正文——正是 ADR 0006 要避免的情況。

觸發條件不限於 CI：Windows 上 git autocrlf 的 checkout 會這樣，使用者自己用 CRLF 編輯 `assets/SKILL.md` 也會，且在任何平台都會中。

## 修法

- regex 改為容忍 `\r?\n`；body 前導空行的清理一併處理 `\r`
- 新增以 CRLF 輸入覆蓋 windsurf 與 cursor 兩條轉換路徑的測試

## Test plan

- 新測試在修正前紅、修正後綠（3 條）
- `bun run test:unit` 4204 pass / 0 fail
- `typecheck` / `lint` / `plugin:check` / `skill:check` 通過
- Windows CI 上 `skill --install windsurf preserves an existing user .windsurfrules` 應轉綠；同票其餘四條（A / B-2 / C）不在這個 PR 範圍

Refs #52