### PR TITLE
fix: [ ci ] 修掉 Windows runner 上的路徑與 CRLF 假設

### DIFF
--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -99,7 +99,7 @@ impactCommand
         throw new Error('Choose exactly one of --against-cache or --against-orm')
       }
 
-      const workspaceRoot = process.cwd()
+      const workspaceRoot = await realpath(process.cwd())
       const spec = await loadDesignSpec(String(options.design))
       const review = reviewDesign(spec)
       if (review.summary.errors > 0) throw new Error('design contains validation errors')

--- a/tests/integration/evidence-command.test.ts
+++ b/tests/integration/evidence-command.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { spawn } from 'node:child_process'
 import { mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { buildEvidenceReceipt } from '@/core/evidence-receipt'
 
 const CLI = resolve(import.meta.dir, '../../src/cli.ts')
@@ -170,7 +170,7 @@ describe('dbcli evidence (CLI)', () => {
 
     expect(compose.code).toBe(0)
     const composed = JSON.parse(compose.stdout)
-    expect(composed.path).toEndWith('/.dbcli/evidence/pack.json')
+    expect(composed.path).toEndWith(`${sep}.dbcli${sep}evidence${sep}pack.json`)
 
     const persisted = await Bun.file(join(work, '.dbcli/evidence/pack.json')).json()
     expect(JSON.stringify(persisted)).not.toContain('sensitive_users')

--- a/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
+++ b/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import {
   buildEvidenceReceipt,
   canonicalizeEvidenceReceiptCommand,
@@ -87,7 +87,7 @@ describe('evidence receipt', () => {
         verdict: { pass: true, checks: [{ pass: true }] },
       })
       const path = await writeEvidenceReceipt(workspace, 'evidence/assert.json', receipt)
-      expect(path).toEndWith('/evidence/assert.json')
+      expect(path).toEndWith(`${sep}evidence${sep}assert.json`)
       await expect(
         writeEvidenceReceipt(workspace, 'evidence/assert.json', receipt)
       ).rejects.toThrow('already exists')

--- a/tests/unit/skill-assets/reference-index.test.ts
+++ b/tests/unit/skill-assets/reference-index.test.ts
@@ -21,7 +21,7 @@ const source = await Bun.file('assets/reference.md').text()
 function headingAnchors(markdown: string): Set<string> {
   const anchors = new Set<string>()
   let inFence = false
-  for (const line of markdown.split('\n')) {
+  for (const line of markdown.split(/\r?\n/)) {
     if (/^```/.test(line)) {
       inFence = !inFence
       continue


### PR DESCRIPTION
修掉 run [31662091492](https://github.com/CarlLee1983/dbcli/actions/runs/31662091492) 在 `test (windows-latest, 1.3.3)` 與 `test (windows-latest, latest)` 的四個失敗。其他平台（ubuntu / macOS）全綠，所以問題全部出在測試與程式碼對路徑、換行的平台假設。

## 一個產品 bug

`src/commands/impact.ts` 的 `workspaceRoot` 取 `process.cwd()`，但 `resolveOutput()` 回傳的是 realpath 之後的絕對路徑。Windows 的 tmpdir 是 8.3 短檔名（`C:\Users\RUNNERA~1\...`），realpath 會展開成 `runneradmin`，於是 `relative(workspaceRoot, output)` 吐出：

```
..\..\..\..\..\runneradmin\AppData\Local\Temp\dbcli-impact-command-xAqgZH\impact.json
```

macOS 沒中，是因為 `chdir` 本身就會解 symlink，cwd 早就是 real path。

同一個落差還讓 `impact.ts:165` 的「design 與 output 路徑不得相同」防護在短檔名或 symlink 路徑下靜默失效——兩邊比較基準不一致，永遠不會相等。改成一開始就 `realpath(process.cwd())`，一行同時修掉兩者。

## 三個測試側的平台假設

`tests/unit/skill-assets/reference-index.test.ts` 用 `split('\n')` 切行，CRLF checkout 下每行尾端留著 `\r`。JS 正則的 `.` **不**匹配 `\r`（它是 line terminator），所以 `/^#{1,6}\s+(.*)$/` 一個標題都對不上，anchors 集合是空的，128 個 anchor 全部消失、68 個 in-page 連結被判為壞掉。改用 `split(/\r?\n/)`。

這裡刻意**不**加 `.gitattributes` 強制 `eol=lf`——那是把 CRLF 問題藏起來而不是修掉，方向也和 bae88b84（讓 frontmatter 剝除支援 CRLF 來源檔）不一致。

另外兩處 evidence 測試用 `toEndWith('/evidence/assert.json')` 斷言 POSIX 分隔符，但 `writeEvidenceReceipt()` 和 evidence compose 回傳的都是 OS 原生絕對路徑。改用 `path.sep` 組字串。

## Test plan

- [x] `SKIP_INTEGRATION_TESTS=true bun run test` → **4990 pass / 26 skip / 0 fail**，473 檔、95 秒
- [x] `bun run format` → 全部 unchanged
- [x] CRLF 那條另外拿一份 CRLF 副本跑過解析邏輯：從「0 anchors、68 broken」變成「128 anchors、0 broken」
- [ ] Windows 的 8.3 短檔名情境**沒辦法在 macOS 上實測**（`chdir` 會解 symlink），該項屬推論，要靠這個 PR 的 windows-latest job 確認

🤖 Generated with Claude Code