### PR TITLE
perf: [ cli ] 子命令按需載入（closes #50）

### DIFF
--- a/docs/adr/0007-lazy-subcommand-registration-runs-beside-the-eager-tree.md
+++ b/docs/adr/0007-lazy-subcommand-registration-runs-beside-the-eager-tree.md
@@ -1,0 +1,111 @@
+---
+status: accepted
+date: 2026-08-13
+---
+
+# Lazy subcommand registration runs beside the eager tree, not instead of it
+
+`src/program.ts` statically imported about 40 command modules, so every CLI
+invocation paid for all of them. Issue #50 proposed fixing that by making
+subcommand registration lazy, and named two ways to do it: split each command
+into a declaration file and an implementation file, or keep one file per
+command and move the heavy dependencies into the action. Both change all ~40
+command modules.
+
+Neither was taken, because the constraint that decides this is not in the
+command modules at all.
+
+`buildProgram()` is **synchronous**, and three non-test callers plus eight test
+files walk the tree it returns in-process: `scripts/check-cli-contract.ts`
+verifies 115 command paths and 178 live long options against the shipped
+documentation, `buildCompletionTree()` derives shell completion from it, and
+`src/commands/shell.ts` rebuilds it per REPL session. Lazy loading is
+asynchronous. Making `buildProgram()` async to accommodate it would convert a
+performance change into a breaking change across eleven call sites, and any
+design that keeps it synchronous must keep its static imports — which is
+exactly the cost being removed.
+
+## Decision
+
+Two registration paths, sharing one set of declarations.
+
+`buildProgram()` in `src/program.ts` is untouched: synchronous, eager, same
+registration order, same signature. Every existing caller keeps working, and
+the CLI contract check keeps seeing the whole tree.
+
+`buildProgramFor(argv)` in `src/program-lazy.ts` is the path the real CLI entry
+uses. It reads argv, and when argv names exactly one known command it registers
+only that one, dynamically imported. Everything else — no command, `--help`, an
+unknown name, anything after a bare `--` — falls back to `buildProgram()`.
+Top-level help must list every command, so it is a fallback case by design, not
+an oversight.
+
+The two paths cannot drift in what they *declare*, because they do not each
+hold a declaration. The seven commands whose options are declared in
+`program.ts` moved to `src/commands/inline-registrars.ts` as functions taking
+their implementation as a parameter; the other ~33 were already `Command`
+objects exported by their own modules. Both paths call the same function or add
+the same object. What can drift is the *set* of names in `COMMAND_LOADERS`, and
+`tests/unit/program/lazy-registry.test.ts` pins that: the registry's keys must
+equal the eager tree's top-level names, and every lazily built command must
+deep-equal its eager twin down to option flags, defaults, parser presence,
+choices, and the full subcommand tree.
+
+`src/program-lazy.ts`, `src/program-root.ts` and
+`src/commands/inline-registrars.ts` must never statically import `./program` or
+any `./commands/*` module. One static edge makes the laziness a no-op, silently
+— the tests above would still pass, because behaviour would be unchanged.
+
+## Why record this
+
+The measured payoff is much smaller than the issue estimated, and a later
+reader looking at three extra files and a parallel registration path deserves
+the real number rather than the projection.
+
+Issue #50 estimated a 50ms saving from importing modules individually under
+`bun -e`. dbcli ships as a single-file bundle (`bun build --outfile`, no code
+splitting), where deferring a module defers its evaluation but not its parse.
+Measured on the shipped bundle under `bun`, interleaved A/B, 21 paired samples,
+median: `query --help` 72.1ms → 64.2ms, `list --help` 69.9ms → 62.1ms. The
+`--help` fallback is unchanged within noise (68.7ms → 71.8ms on one bundle
+pair, 72.9ms → 72.4ms on the other), which is what a path that loads the whole
+tree anyway should show. Bundle size rises about 22KB.
+
+So roughly 8ms, against an estimate of 50ms. That is worth having for a CLI
+agents invoke in a loop, and it is not worth a second one of these. The next
+such change should establish its ceiling on the shipped artifact before the
+design is chosen, not after — measuring the module graph under `bun -e` says
+almost nothing about a bundle with no code splitting.
+
+Getting that 8ms honestly took three attempts, which is itself worth recording.
+`bun run build` is **not deterministic**: successive builds of identical source
+alternate `dist/cli-runtime.mjs` between two sizes about 690KB apart, on this
+branch (1,913,004 / 2,604,444) and on `main` alike (1,891,038 / 2,582,505).
+Comparing a bundle from one side against the other variant from the other side
+produces a difference of ~13ms that has nothing to do with this change. Any
+future measurement here has to pin both sides to the same variant.
+
+One smaller consequence follows from the entry point rather than the registry.
+`src/cli-runtime.ts` imports `formatUpdateHint`, `formatSkillUpdateReminder`
+and `checkSkillUpdates` at the point of use; that shortens the static graph but
+does not show up in the numbers above. And `findCommandName()` derives the set
+of value-taking root options from `createRootProgram().options` rather than a
+hardcoded list, in both long and short spellings, and refuses to guess at
+optional-value options at all: mistaking an option's value for a command name
+would dispatch to the wrong command silently, where failing to recognise a
+command name merely falls back to eager.
+
+`dbcli completion <shell>` had to stop deriving the command tree from
+`completionCommand.parent`. Under the lazy path that parent holds one command,
+so the generated script listed only `completion` itself — and `--install`
+writes it into the user's shell rc, where it stays until reinstalled. It now
+builds the tree from `buildProgram()` the way `src/commands/shell.ts` already
+did. That failure is invisible to any test that constructs a program in-process,
+which is why `tests/integration/lazy-entry-path.test.ts` spawns the real CLI:
+the lazy path exists only at the process entry point, so only a real process
+exercises it.
+
+**Falsified if:** `buildProgram()` in `src/program.ts` becomes asynchronous, or
+`src/program-lazy.ts` statically imports `./program` or any `./commands/*`
+module, or `tests/unit/program/lazy-registry.test.ts` stops comparing the
+lazily built tree against the eager one.

--- a/src/cli-runtime.ts
+++ b/src/cli-runtime.ts
@@ -1,10 +1,9 @@
 // Full command runtime. Keep the lightweight process entry point in cli.ts so
 // standalone version checks do not parse database drivers and every command.
+import type { Command } from 'commander'
 import pkg from '../package.json'
 import { createLogger, setGlobalLogger, LogLevel } from './utils/logger'
-import { formatUpdateHint, formatSkillUpdateReminder } from './commands/upgrade'
 import { checkForUpdate, type VersionCheckCache } from './utils/version-check'
-import { checkSkillUpdates } from './commands/skill'
 import { setGlobalConnectionName } from './core/config'
 import { setGlobalConnectionTimeout, setGlobalStatementTimeout } from './utils/connection-timeout'
 import { resolveConnectionSelector } from './core/connection-selector'
@@ -12,7 +11,7 @@ import { resolveConfigPath } from './utils/config-path'
 import { isMachineReadableCommand } from './utils/cli-output'
 import { claimUpdateHint, defaultCliSessionKey } from './utils/update-hint-state'
 import { readSkillCheckCache, writeSkillCheckCache } from './utils/skill-check-cache'
-import { buildProgram } from './program'
+import { buildProgramFor } from './program-lazy'
 import { presentCliError } from './utils/cli-error'
 import { join } from 'path'
 import { writeSync } from 'node:fs'
@@ -86,7 +85,22 @@ function shouldSkipBackgroundChecks(): boolean {
 // `completion` is included because its stdout is eval'd at shell startup.
 const QUIET_OUTPUT_COMMANDS = new Set(['upgrade', 'completion'])
 
-const program = buildProgram()
+/**
+ * Building the program now involves a dynamic import per invocation (ADR 0007),
+ * so it can fail where the old static construction could not. Route that
+ * failure through the same presenter as every other CLI error instead of
+ * letting it surface as an unhandled rejection.
+ */
+async function buildProgramOrExit(): Promise<Command> {
+  try {
+    return await buildProgramFor(process.argv)
+  } catch (error) {
+    presentCliError(error)
+    process.exit(1)
+  }
+}
+
+const program = await buildProgramOrExit()
 
 function misplacedConnectionSelectorHint(): string | undefined {
   const rawArgs = process.argv.slice(2)
@@ -226,6 +240,7 @@ program.hook('postAction', async (thisCommand, actionCommand) => {
       _bgVersionCheckResult.latestVersion
     ))
   ) {
+    const { formatUpdateHint } = await import('./commands/upgrade')
     process.stderr.write(formatUpdateHint(_bgVersionCheckResult.latestVersion) + '\n')
   }
 
@@ -242,6 +257,7 @@ program.hook('postAction', async (thisCommand, actionCommand) => {
     const skillCacheKey = context?.configPath ?? resolveConfigPath(actionCommand)
     let outdatedSkills = await readSkillCheckCache(skillCacheKey, pkg.version)
     if (outdatedSkills === null) {
+      const { checkSkillUpdates } = await import('./commands/skill')
       outdatedSkills = await checkSkillUpdates()
       await writeSkillCheckCache(skillCacheKey, pkg.version, outdatedSkills)
     }
@@ -255,6 +271,7 @@ program.hook('postAction', async (thisCommand, actionCommand) => {
         outdatedSkills.slice().sort().join(',')
       ))
     ) {
+      const { formatSkillUpdateReminder } = await import('./commands/upgrade')
       process.stderr.write(formatSkillUpdateReminder(outdatedSkills) + '\n')
     }
   }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -360,13 +360,13 @@ export const completionCommand = new Command('completion')
   .argument('[shell]', 'Shell type: bash, zsh, fish')
   .option('--install [shell]', 'Auto-install completion to shell rc file')
   .action(async (shellArg: string | undefined, options: { install?: string | boolean }) => {
-    const parentProgram = completionCommand.parent
-    if (!parentProgram) {
-      console.error(colors.error('Error: completion command must be registered to a program'))
-      process.exit(1)
-    }
-
-    const root = buildCompletionTree(parentProgram)
+    // Build the tree from the eager program rather than from this command's
+    // parent: under the lazy entry path (see ADR 0007) the parent holds only
+    // the command argv named, which would emit a completion script listing
+    // `completion` and nothing else — and `--install` writes that into the
+    // user's shell rc, leaving tab completion dead until reinstalled.
+    const { buildProgram } = await import('@/program')
+    const root = buildCompletionTree(buildProgram())
 
     const installing = options.install !== undefined
     const shell = installing

--- a/src/commands/inline-registrars.ts
+++ b/src/commands/inline-registrars.ts
@@ -1,0 +1,244 @@
+import type { Command } from 'commander'
+import { t } from '../i18n/message-loader'
+import { printLocalizedCliError } from '../utils/cli-error'
+import {
+  createConnectionSelectorOption,
+  resolveConnectionSelector,
+} from '../core/connection-selector'
+import {
+  findLongOptionValue,
+  hasLongOption,
+  normalizeLimitFlags,
+  parsePositiveInteger,
+  parseSlowMs,
+} from '../program-root'
+
+/**
+ * Option declarations + action wiring for the seven commands that are
+ * registered inline in program.ts, extracted so both the eager tree
+ * (program.ts) and the lazy tree (program-lazy.ts) can build the identical
+ * command from the same source. Option order, defaults and parsers must stay
+ * byte-for-byte what buildProgram() used to declare inline — that shape is
+ * the --help contract.
+ */
+
+export function registerQueryCommand(
+  program: Command,
+  run: typeof import('./query').queryCommand
+): void {
+  program
+    .command('query [sql]')
+    .description(t('query.description'))
+    .option('-f, --query-file <path>', 'Read query text from a UTF-8 file, or - for stdin')
+    .option('--format <type>', 'Output format: table, json, csv, html', 'table')
+    .option('--ui', 'Show interactive dashboard in browser', false)
+    .option('--limit <number>', 'Limit result rows (overrides auto-limit)', parsePositiveInteger)
+    .option('--no-limit', 'Disable auto-limit in query-only mode')
+    .option('--collection <name>', 'MongoDB collection name; Elasticsearch index name')
+    .option('--index <name>', 'Elasticsearch index name (alias for --collection)')
+    .option('--fields <list>', 'Include fields, or exclude them with --fields=-field_a,-field_b')
+    .option(
+      '--truncate <number>',
+      'Limit serialized table cells to N Unicode characters',
+      parsePositiveInteger
+    )
+    .option('--no-truncate', 'Disable the default table-cell truncation')
+    .option(
+      '--slow-ms <number>',
+      'Emit a passive performance hint at or above this execution time; 0 disables it',
+      parseSlowMs,
+      1000
+    )
+    .addOption(createConnectionSelectorOption())
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .action(async (sql: string | undefined, options: Record<string, unknown>, command) => {
+      const rawArgs = command.parent?.rawArgs ?? []
+      const rawTruncate = findLongOptionValue(rawArgs, '--truncate')
+      const rootUse = command.parent?.opts().use as string | undefined
+      const commandUse = options.use as string | undefined
+      const connectionSelector =
+        rootUse !== undefined || commandUse !== undefined
+          ? resolveConnectionSelector({ root: rootUse, command: commandUse })
+          : undefined
+      await run(
+        sql,
+        {
+          ...normalizeLimitFlags(options),
+          connectionSelector,
+          truncate: rawTruncate === undefined ? undefined : parsePositiveInteger(rawTruncate),
+          noTruncate: hasLongOption(rawArgs, '--no-truncate'),
+        } as any,
+        command
+      )
+    })
+}
+
+export function registerPlanCommand(
+  program: Command,
+  run: typeof import('./plan').planCommand
+): void {
+  program
+    .command('plan <sql>')
+    .description('Analyze SQL risk without executing')
+    .option('--format <type>', 'Output format: text, json', 'text')
+    .action(async (sql: string, options: Record<string, unknown>, command) => {
+      await run(sql, options as never, command)
+    })
+}
+
+export function registerQCommand(program: Command, run: typeof import('./q').qCommand): void {
+  program
+    .command('q <name>')
+    .description(t('q.description'))
+    .option('--format <type>', 'Output format: table, json, csv, html', 'table')
+    .option('--ui', 'Show interactive dashboard in browser', false)
+    .option('--no-limit', 'Disable size guard wrap (LIMIT 1000)')
+    .option('--dry-run', 'Show final SQL + bind values; do not execute')
+    .option(
+      '--param <kv>',
+      'Pass parameter as key=value (repeatable)',
+      (val: string, prev: string[] = []) => prev.concat([val]),
+      [] as string[]
+    )
+    .option('--param-file <path>', 'JSON file containing param values')
+    .option(
+      '--slow-ms <number>',
+      'Emit a passive performance hint at or above this execution time; 0 disables it',
+      parseSlowMs,
+      1000
+    )
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .option('--verify', 'Run verification check after execution if defined', false)
+    .action(async (name: string, options: Record<string, unknown>, command) => {
+      await run(name, normalizeLimitFlags(options) as any, command)
+    })
+}
+
+export function registerInsertCommand(
+  program: Command,
+  run: typeof import('./insert').insertCommand
+): void {
+  program
+    .command('insert <table>')
+    .description(t('insert.description'))
+    .option('--data <json>', 'JSON object to insert')
+    .option('--dry-run', 'Show generated SQL without executing')
+    .option('--force', 'Skip confirmation prompt')
+    .option('--plan', 'Analyze risk without connecting or executing')
+    .option('--format <type>', 'Output format for --plan: text or json', 'text')
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .action(async (table: string, options: Record<string, unknown>, command) => {
+      try {
+        await run(table, options, command)
+      } catch (error) {
+        if (options.recovery === true) {
+          const { emitRecoveryEnvelope } = await import('../core/recovery')
+          emitRecoveryEnvelope(error, { operation: 'insert', table, writeOperation: 'INSERT' })
+        }
+        printLocalizedCliError((error as Error).message, error)
+        process.exit(1)
+      }
+    })
+}
+
+export function registerUpdateCommand(
+  program: Command,
+  run: typeof import('./update').updateCommand
+): void {
+  program
+    .command('update <table>')
+    .description(t('update.description'))
+    .option('--where <condition>', 'WHERE clause (required, e.g. "id=1")')
+    .option('--set <json>', 'JSON with fields to update (required, e.g. \'{"name":"Bob"}\')')
+    .option('--dry-run', 'Show generated SQL without executing')
+    .option('--force', 'Skip confirmation prompt')
+    .option('--plan', 'Analyze risk without connecting or executing')
+    .option('--format <type>', 'Output format for --plan: text or json', 'text')
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .action(async (table: string, options: Record<string, unknown>, command) => {
+      try {
+        await run(table, options as never, command)
+      } catch (error) {
+        if (options.recovery === true) {
+          const { emitRecoveryEnvelope } = await import('../core/recovery')
+          emitRecoveryEnvelope(error, { operation: 'update', table, writeOperation: 'UPDATE' })
+        }
+        printLocalizedCliError((error as Error).message, error)
+        process.exit(1)
+      }
+    })
+}
+
+export function registerDeleteCommand(
+  program: Command,
+  run: typeof import('./delete').deleteCommand
+): void {
+  program
+    .command('delete <table>')
+    .description(t('delete.description'))
+    .option('--where <condition>', 'WHERE clause (required, e.g. "id=1")')
+    .option('--dry-run', 'Show generated SQL without executing')
+    .option('--force', 'Skip confirmation prompt')
+    .option('--plan', 'Analyze risk without connecting or executing')
+    .option('--format <type>', 'Output format for --plan: text or json', 'text')
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .action(async (table: string, options: Record<string, unknown>, command) => {
+      try {
+        await run(table, options as never, command)
+      } catch (error) {
+        if (options.recovery === true) {
+          const { emitRecoveryEnvelope } = await import('../core/recovery')
+          emitRecoveryEnvelope(error, { operation: 'delete', table, writeOperation: 'DELETE' })
+        }
+        printLocalizedCliError((error as Error).message, error)
+        process.exit(1)
+      }
+    })
+}
+
+export function registerExportCommand(
+  program: Command,
+  run: typeof import('./export').exportCommand
+): void {
+  program
+    .command('export <sql>')
+    .description(t('export.description'))
+    .option('--format <format>', 'Output format: json, jsonl, csv, html', 'json')
+    .option('--output <path>', 'Output file path (if omitted, write to stdout)', undefined)
+    .option('--force', 'Skip overwrite confirmation', false)
+    .option('--collection <name>', 'MongoDB collection name; Elasticsearch index name')
+    .option('--index <name>', 'Elasticsearch index name (alias for --collection)')
+    .addOption(createConnectionSelectorOption())
+    .option('--limit <number>', 'Limit result rows (overrides auto-limit)', (val) =>
+      parseInt(val, 10)
+    )
+    .option('--no-limit', 'Disable auto-limit in query-only mode')
+    .option(
+      '--recovery',
+      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
+      false
+    )
+    .action(async (sql: string, options: Record<string, unknown>, command) => {
+      return await run(sql, normalizeLimitFlags(options) as never, command)
+    })
+}

--- a/src/program-lazy.ts
+++ b/src/program-lazy.ts
@@ -1,0 +1,352 @@
+import type { Command } from 'commander'
+import { createRootProgram } from './program-root'
+
+/**
+ * Contract between the two registration paths.
+ *
+ * buildProgram() (in ./program) stays eager — check-cli-contract.ts, the
+ * completion tree and a dozen tests walk the whole command tree in-process
+ * and must keep seeing it. buildProgramFor(argv) registers only the command
+ * argv actually names, so a real CLI invocation stops paying for the other
+ * ~40 command modules.
+ *
+ * Nothing in this file may statically import ./program or any ./commands/*
+ * module — that static edge is exactly what would make the laziness here a
+ * no-op, since Bun/Node resolve the whole static import graph up front.
+ */
+export const COMMAND_LOADERS: Record<string, () => Promise<(program: Command) => void>> = {
+  init: async () => {
+    const { initCommand } = await import('./commands/init')
+    return (program) => {
+      program.addCommand(initCommand)
+    }
+  },
+  list: async () => {
+    const { listCommand } = await import('./commands/list')
+    return (program) => {
+      program.addCommand(listCommand)
+    }
+  },
+  schema: async () => {
+    const { schemaCommand } = await import('./commands/schema')
+    return (program) => {
+      program.addCommand(schemaCommand)
+    }
+  },
+  query: async () => {
+    const { queryCommand } = await import('./commands/query')
+    const { registerQueryCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerQueryCommand(program, queryCommand)
+    }
+  },
+  plan: async () => {
+    const { planCommand } = await import('./commands/plan')
+    const { registerPlanCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerPlanCommand(program, planCommand)
+    }
+  },
+  q: async () => {
+    const { qCommand } = await import('./commands/q')
+    const { registerQCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerQCommand(program, qCommand)
+    }
+  },
+  insert: async () => {
+    const { insertCommand } = await import('./commands/insert')
+    const { registerInsertCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerInsertCommand(program, insertCommand)
+    }
+  },
+  update: async () => {
+    const { updateCommand } = await import('./commands/update')
+    const { registerUpdateCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerUpdateCommand(program, updateCommand)
+    }
+  },
+  delete: async () => {
+    const { deleteCommand } = await import('./commands/delete')
+    const { registerDeleteCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerDeleteCommand(program, deleteCommand)
+    }
+  },
+  export: async () => {
+    const { exportCommand } = await import('./commands/export')
+    const { registerExportCommand } = await import('./commands/inline-registrars')
+    return (program) => {
+      registerExportCommand(program, exportCommand)
+    }
+  },
+  skill: async () => {
+    const { registerSkillCommand } = await import('./commands/skill')
+    const { registerSkillTasksCommand } = await import('./commands/skill-tasks')
+    return (program) => {
+      registerSkillTasksCommand(registerSkillCommand(program))
+    }
+  },
+  blacklist: async () => {
+    const { blacklistCommand } = await import('./commands/blacklist')
+    return (program) => {
+      program.addCommand(blacklistCommand)
+    }
+  },
+  check: async () => {
+    const { checkCommand } = await import('./commands/check')
+    return (program) => {
+      program.addCommand(checkCommand)
+    }
+  },
+  diff: async () => {
+    const { diffCommand } = await import('./commands/diff')
+    return (program) => {
+      program.addCommand(diffCommand)
+    }
+  },
+  status: async () => {
+    const { statusCommand } = await import('./commands/status')
+    return (program) => {
+      program.addCommand(statusCommand)
+    }
+  },
+  inspect: async () => {
+    const { inspectCommand } = await import('./commands/inspect')
+    return (program) => {
+      program.addCommand(inspectCommand)
+    }
+  },
+  report: async () => {
+    const { reportCommand } = await import('./commands/report')
+    return (program) => {
+      program.addCommand(reportCommand)
+    }
+  },
+  guide: async () => {
+    const { guideCommand } = await import('./commands/guide')
+    const { registerMissingIndexCommand } = await import('./commands/guide-missing-index')
+    return (program) => {
+      program.addCommand(guideCommand)
+      registerMissingIndexCommand(guideCommand)
+    }
+  },
+  recovery: async () => {
+    const { recoveryCommand } = await import('./commands/recovery')
+    return (program) => {
+      program.addCommand(recoveryCommand)
+    }
+  },
+  recover: async () => {
+    const { recoverCommand } = await import('./commands/recover')
+    return (program) => {
+      program.addCommand(recoverCommand)
+    }
+  },
+  audit: async () => {
+    const { auditCommand } = await import('./commands/audit')
+    return (program) => {
+      program.addCommand(auditCommand)
+    }
+  },
+  doctor: async () => {
+    const { doctorCommand } = await import('./commands/doctor')
+    return (program) => {
+      program.addCommand(doctorCommand)
+    }
+  },
+  completion: async () => {
+    const { completionCommand } = await import('./commands/completion')
+    return (program) => {
+      program.addCommand(completionCommand)
+    }
+  },
+  upgrade: async () => {
+    const { upgradeCommand } = await import('./commands/upgrade')
+    return (program) => {
+      program.addCommand(upgradeCommand)
+    }
+  },
+  shell: async () => {
+    const { shellCommand } = await import('./commands/shell')
+    return (program) => {
+      program.addCommand(shellCommand)
+    }
+  },
+  migrate: async () => {
+    const { migrateCommand } = await import('./commands/migrate')
+    return (program) => {
+      program.addCommand(migrateCommand)
+    }
+  },
+  use: async () => {
+    const { useCommand } = await import('./commands/use')
+    return (program) => {
+      program.addCommand(useCommand)
+    }
+  },
+  queries: async () => {
+    const { queriesCommand } = await import('./commands/queries')
+    return (program) => {
+      program.addCommand(queriesCommand)
+    }
+  },
+  explain: async () => {
+    const { explainCommand } = await import('./commands/explain')
+    return (program) => {
+      program.addCommand(explainCommand)
+    }
+  },
+  lint: async () => {
+    const { lintCommand } = await import('./commands/lint')
+    return (program) => {
+      program.addCommand(lintCommand)
+    }
+  },
+  snapshot: async () => {
+    const { snapshotCommand } = await import('./commands/snapshot')
+    return (program) => {
+      program.addCommand(snapshotCommand)
+    }
+  },
+  assert: async () => {
+    const { assertCommand } = await import('./commands/assert')
+    return (program) => {
+      program.addCommand(assertCommand)
+    }
+  },
+  verification: async () => {
+    const { verificationCommand } = await import('./commands/verification')
+    return (program) => {
+      program.addCommand(verificationCommand)
+    }
+  },
+  verify: async () => {
+    const { verifyCommand } = await import('./commands/verify')
+    return (program) => {
+      program.addCommand(verifyCommand)
+    }
+  },
+  proxy: async () => {
+    const { proxyCommand } = await import('./commands/proxy')
+    return (program) => {
+      program.addCommand(proxyCommand)
+    }
+  },
+  semantic: async () => {
+    const { semanticCommand } = await import('./commands/semantic')
+    return (program) => {
+      program.addCommand(semanticCommand)
+    }
+  },
+  design: async () => {
+    const { designCommand } = await import('./commands/design')
+    return (program) => {
+      program.addCommand(designCommand)
+    }
+  },
+  backfill: async () => {
+    const { backfillCommand } = await import('./commands/backfill')
+    return (program) => {
+      program.addCommand(backfillCommand)
+    }
+  },
+  evidence: async () => {
+    const { evidenceCommand } = await import('./commands/evidence')
+    return (program) => {
+      program.addCommand(evidenceCommand)
+    }
+  },
+  contract: async () => {
+    const { contractCommand } = await import('./commands/contracts')
+    return (program) => {
+      program.addCommand(contractCommand)
+    }
+  },
+  impact: async () => {
+    const { impactCommand } = await import('./commands/impact')
+    return (program) => {
+      program.addCommand(impactCommand)
+    }
+  },
+}
+
+export const COMMAND_NAMES: readonly string[] = Object.keys(COMMAND_LOADERS)
+
+/**
+ * Root option flags, split by how they consume the token that follows.
+ *
+ * Both spellings are collected even though no root short option takes a value
+ * today: were one added, reading only the long form would make `dbcli -c query`
+ * dispatch to the `query` command instead of treating `query` as -c's value —
+ * a silent misdispatch, not merely a lost optimization.
+ *
+ * Optional-value options (`--foo [bar]`) are separated out rather than folded
+ * in, because Commander only swallows the next token when it doesn't look like
+ * an option. Guessing either way misreads some argv, so their presence sends
+ * the whole invocation to the eager path instead.
+ */
+function rootOptionFlags(options: Command['options']): {
+  consumesNext: ReadonlySet<string>
+  ambiguous: ReadonlySet<string>
+} {
+  const consumesNext = new Set<string>()
+  const ambiguous = new Set<string>()
+  for (const option of options) {
+    const target = option.required ? consumesNext : option.optional ? ambiguous : undefined
+    if (!target) continue
+    if (option.long) target.add(option.long)
+    if (option.short) target.add(option.short)
+  }
+  return { consumesNext, ambiguous }
+}
+
+/**
+ * Find the first argv token that names a command, applying the same placement
+ * rules Commander itself uses: `--` ends option/command parsing, any
+ * `-`-prefixed token is an option, and a root option taking a required value
+ * additionally consumes the token after it (unless given as `--opt=value`,
+ * which is self-contained).
+ *
+ * Returning undefined costs only the optimization — the caller falls back to
+ * the eager tree and the CLI behaves exactly as before. Returning the wrong
+ * name would dispatch the wrong command, so every uncertain shape returns
+ * undefined.
+ */
+function findCommandName(argv: readonly string[], options: Command['options']): string | undefined {
+  const { consumesNext, ambiguous } = rootOptionFlags(options)
+  const rawArgs = argv.slice(2)
+  for (let index = 0; index < rawArgs.length; index++) {
+    const token = rawArgs[index]!
+    if (token === '--') return undefined
+    if (token.startsWith('-')) {
+      const flag = token.split('=', 1)[0]!
+      if (ambiguous.has(flag)) return undefined
+      if (!token.includes('=') && consumesNext.has(flag)) index++
+      continue
+    }
+    return token
+  }
+  return undefined
+}
+
+/**
+ * Build a program containing only the command argv names, or the full eager
+ * tree when argv doesn't unambiguously name exactly one known command
+ * (no command, `--help`, an unknown name, or anything after a bare `--`).
+ */
+export async function buildProgramFor(argv: readonly string[]): Promise<Command> {
+  const program = createRootProgram()
+  const name = findCommandName(argv, program.options)
+  const loader = name === undefined ? undefined : COMMAND_LOADERS[name]
+  if (loader) {
+    const register = await loader()
+    register(program)
+    return program
+  }
+
+  const { buildProgram } = await import('./program')
+  return buildProgram()
+}

--- a/src/program-root.ts
+++ b/src/program-root.ts
@@ -1,0 +1,133 @@
+import { Command, InvalidArgumentError } from 'commander'
+import { createConnectionSelectorOption } from './core/connection-selector'
+import {
+  parseTimeoutOption,
+  parseStatementTimeoutOption,
+  MIN_CONNECTION_TIMEOUT_MS,
+  MAX_CONNECTION_TIMEOUT_MS,
+  MIN_STATEMENT_TIMEOUT_MS,
+  MAX_STATEMENT_TIMEOUT_MS,
+} from './utils/validation'
+import { parseSlowQueryThreshold } from './core/slow-query-advisory'
+import pkg from '../package.json'
+
+/**
+ * Commander-facing wrapper: same rule as the config schema, but reported the way
+ * Commander reports every other bad option value.
+ */
+export function parseConnectionTimeout(value: string): number {
+  try {
+    return parseTimeoutOption(value)
+  } catch {
+    throw new InvalidArgumentError(
+      `must be an integer between ${MIN_CONNECTION_TIMEOUT_MS} and ${MAX_CONNECTION_TIMEOUT_MS} milliseconds`
+    )
+  }
+}
+
+export function parseStatementTimeout(value: string): number {
+  try {
+    return parseStatementTimeoutOption(value)
+  } catch {
+    throw new InvalidArgumentError(
+      `must be an integer between ${MIN_STATEMENT_TIMEOUT_MS} and ${MAX_STATEMENT_TIMEOUT_MS} milliseconds (0 removes the limit)`
+    )
+  }
+}
+
+export function parsePositiveInteger(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError('must be a positive integer')
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('must be a positive integer')
+  }
+  return parsed
+}
+
+export function parseSlowMs(value: string): number {
+  try {
+    return parseSlowQueryThreshold(value)
+  } catch {
+    throw new InvalidArgumentError('must be a non-negative integer')
+  }
+}
+
+/**
+ * Commander folds a `--no-limit` flag into the `limit` attribute — `false` when
+ * passed, `true` when the flag stands alone and is omitted — and never produces
+ * `noLimit`. Commands read `noLimit`, so restore that shape here and keep
+ * `limit` holding only a real row count.
+ */
+export function normalizeLimitFlags<T extends Record<string, unknown>>(options: T): T {
+  const limit = options.limit
+  if (typeof limit === 'boolean') {
+    return { ...options, limit: undefined, noLimit: limit === false }
+  }
+  return { ...options, noLimit: false }
+}
+
+export function findLongOptionValue(
+  rawArgs: readonly string[],
+  option: string
+): string | undefined {
+  let value: string | undefined
+  for (let index = 0; index < rawArgs.length; index++) {
+    const token = rawArgs[index]!
+    if (token === '--') break
+    if (token === option) {
+      value = rawArgs[index + 1]
+      index++
+    } else if (token.startsWith(`${option}=`)) {
+      value = token.slice(option.length + 1)
+    }
+  }
+  return value
+}
+
+export function hasLongOption(rawArgs: readonly string[], option: string): boolean {
+  for (const token of rawArgs) {
+    if (token === '--') return false
+    if (token === option || token.startsWith(`${option}=`)) return true
+  }
+  return false
+}
+
+/**
+ * Build the root dbcli Commander program: name, description, version, and all
+ * root-level options. No subcommands are registered — callers attach those.
+ */
+export function createRootProgram(): Command {
+  return (
+    new Command()
+      .name('dbcli')
+      .description('Database CLI for AI agents')
+      .version(pkg.version)
+      .option('--no-color', 'Disable colored output')
+      .option(
+        '-v, --verbose',
+        'Increase verbosity (-v verbose, -vv debug)',
+        (_, prev) => prev + 1,
+        0
+      )
+      .option('-q, --quiet', 'Suppress non-essential output')
+      .option('--config <path>', 'Path to .dbcli config file', '.dbcli')
+      .option('--global', 'Use the user-global connection registry (~/.config/dbcli)', false)
+      .option(
+        '--timeout <ms>',
+        'Connection timeout in milliseconds; also caps statement time unless --statement-timeout is given (default 5000)',
+        parseConnectionTimeout
+      )
+      .option(
+        '--statement-timeout <ms>',
+        'Statement timeout in milliseconds, independent of the connection timeout (0 removes the limit; default: server setting)',
+        parseStatementTimeout
+      )
+      .addOption(createConnectionSelectorOption())
+      // Required so options after a sub-subcommand (e.g. `dbcli proxy analyze --events ...`)
+      // bind to the leaf command instead of being absorbed by an ancestor that shares the
+      // option name. Commander requires every ancestor in the chain to opt in.
+      .enablePositionalOptions()
+  )
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,5 +1,4 @@
-import { Command, InvalidArgumentError } from 'commander'
-import { t } from './i18n/message-loader'
+import type { Command } from 'commander'
 import { initCommand } from './commands/init'
 import { listCommand } from './commands/list'
 import { schemaCommand } from './commands/schema'
@@ -44,100 +43,17 @@ import { evidenceCommand } from './commands/evidence'
 import { contractCommand } from './commands/contracts'
 import { impactCommand } from './commands/impact'
 import {
-  createConnectionSelectorOption,
-  resolveConnectionSelector,
-} from './core/connection-selector'
-import { printLocalizedCliError } from './utils/cli-error'
-import {
-  parseTimeoutOption,
-  parseStatementTimeoutOption,
-  MIN_CONNECTION_TIMEOUT_MS,
-  MAX_CONNECTION_TIMEOUT_MS,
-  MIN_STATEMENT_TIMEOUT_MS,
-  MAX_STATEMENT_TIMEOUT_MS,
-} from './utils/validation'
-import { parseSlowQueryThreshold } from './core/slow-query-advisory'
-import pkg from '../package.json'
+  registerQueryCommand,
+  registerPlanCommand,
+  registerQCommand,
+  registerInsertCommand,
+  registerUpdateCommand,
+  registerDeleteCommand,
+  registerExportCommand,
+} from './commands/inline-registrars'
+import { createRootProgram } from './program-root'
 
-/**
- * Commander-facing wrapper: same rule as the config schema, but reported the way
- * Commander reports every other bad option value.
- */
-function parseConnectionTimeout(value: string): number {
-  try {
-    return parseTimeoutOption(value)
-  } catch {
-    throw new InvalidArgumentError(
-      `must be an integer between ${MIN_CONNECTION_TIMEOUT_MS} and ${MAX_CONNECTION_TIMEOUT_MS} milliseconds`
-    )
-  }
-}
-
-function parseStatementTimeout(value: string): number {
-  try {
-    return parseStatementTimeoutOption(value)
-  } catch {
-    throw new InvalidArgumentError(
-      `must be an integer between ${MIN_STATEMENT_TIMEOUT_MS} and ${MAX_STATEMENT_TIMEOUT_MS} milliseconds (0 removes the limit)`
-    )
-  }
-}
-
-function parsePositiveInteger(value: string): number {
-  if (!/^\d+$/.test(value)) {
-    throw new InvalidArgumentError('must be a positive integer')
-  }
-  const parsed = Number(value)
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new InvalidArgumentError('must be a positive integer')
-  }
-  return parsed
-}
-
-function parseSlowMs(value: string): number {
-  try {
-    return parseSlowQueryThreshold(value)
-  } catch {
-    throw new InvalidArgumentError('must be a non-negative integer')
-  }
-}
-
-/**
- * Commander folds a `--no-limit` flag into the `limit` attribute — `false` when
- * passed, `true` when the flag stands alone and is omitted — and never produces
- * `noLimit`. Commands read `noLimit`, so restore that shape here and keep
- * `limit` holding only a real row count.
- */
-export function normalizeLimitFlags<T extends Record<string, unknown>>(options: T): T {
-  const limit = options.limit
-  if (typeof limit === 'boolean') {
-    return { ...options, limit: undefined, noLimit: limit === false }
-  }
-  return { ...options, noLimit: false }
-}
-
-function findLongOptionValue(rawArgs: readonly string[], option: string): string | undefined {
-  let value: string | undefined
-  for (let index = 0; index < rawArgs.length; index++) {
-    const token = rawArgs[index]!
-    if (token === '--') break
-    if (token === option) {
-      value = rawArgs[index + 1]
-      index++
-    } else if (token.startsWith(`${option}=`)) {
-      value = token.slice(option.length + 1)
-    }
-  }
-  return value
-}
-
-function hasLongOption(rawArgs: readonly string[], option: string): boolean {
-  for (const token of rawArgs) {
-    if (token === '--') return false
-    if (token === option || token.startsWith(`${option}=`)) return true
-  }
-  return false
-}
+export { normalizeLimitFlags } from './program-root'
 
 /**
  * Build the dbcli Commander program with all commands registered.
@@ -149,30 +65,7 @@ function hasLongOption(rawArgs: readonly string[], option: string): boolean {
  * have been repointed. cli.ts builds once; shell.ts builds-and-discards.
  */
 export function buildProgram(): Command {
-  const program = new Command()
-    .name('dbcli')
-    .description('Database CLI for AI agents')
-    .version(pkg.version)
-    .option('--no-color', 'Disable colored output')
-    .option('-v, --verbose', 'Increase verbosity (-v verbose, -vv debug)', (_, prev) => prev + 1, 0)
-    .option('-q, --quiet', 'Suppress non-essential output')
-    .option('--config <path>', 'Path to .dbcli config file', '.dbcli')
-    .option('--global', 'Use the user-global connection registry (~/.config/dbcli)', false)
-    .option(
-      '--timeout <ms>',
-      'Connection timeout in milliseconds; also caps statement time unless --statement-timeout is given (default 5000)',
-      parseConnectionTimeout
-    )
-    .option(
-      '--statement-timeout <ms>',
-      'Statement timeout in milliseconds, independent of the connection timeout (0 removes the limit; default: server setting)',
-      parseStatementTimeout
-    )
-    .addOption(createConnectionSelectorOption())
-    // Required so options after a sub-subcommand (e.g. `dbcli proxy analyze --events ...`)
-    // bind to the leaf command instead of being absorbed by an ancestor that shares the
-    // option name. Commander requires every ancestor in the chain to opt in.
-    .enablePositionalOptions()
+  const program = createRootProgram()
 
   // Register commands
   program.addCommand(initCommand)
@@ -180,200 +73,25 @@ export function buildProgram(): Command {
   program.addCommand(schemaCommand)
 
   // Register query command
-  program
-    .command('query [sql]')
-    .description(t('query.description'))
-    .option('-f, --query-file <path>', 'Read query text from a UTF-8 file, or - for stdin')
-    .option('--format <type>', 'Output format: table, json, csv, html', 'table')
-    .option('--ui', 'Show interactive dashboard in browser', false)
-    .option('--limit <number>', 'Limit result rows (overrides auto-limit)', parsePositiveInteger)
-    .option('--no-limit', 'Disable auto-limit in query-only mode')
-    .option('--collection <name>', 'MongoDB collection name; Elasticsearch index name')
-    .option('--index <name>', 'Elasticsearch index name (alias for --collection)')
-    .option('--fields <list>', 'Include fields, or exclude them with --fields=-field_a,-field_b')
-    .option(
-      '--truncate <number>',
-      'Limit serialized table cells to N Unicode characters',
-      parsePositiveInteger
-    )
-    .option('--no-truncate', 'Disable the default table-cell truncation')
-    .option(
-      '--slow-ms <number>',
-      'Emit a passive performance hint at or above this execution time; 0 disables it',
-      parseSlowMs,
-      1000
-    )
-    .addOption(createConnectionSelectorOption())
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .action(async (sql: string | undefined, options: Record<string, unknown>, command) => {
-      const rawArgs = command.parent?.rawArgs ?? []
-      const rawTruncate = findLongOptionValue(rawArgs, '--truncate')
-      const rootUse = command.parent?.opts().use as string | undefined
-      const commandUse = options.use as string | undefined
-      const connectionSelector =
-        rootUse !== undefined || commandUse !== undefined
-          ? resolveConnectionSelector({ root: rootUse, command: commandUse })
-          : undefined
-      await queryCommand(
-        sql,
-        {
-          ...normalizeLimitFlags(options),
-          connectionSelector,
-          truncate: rawTruncate === undefined ? undefined : parsePositiveInteger(rawTruncate),
-          noTruncate: hasLongOption(rawArgs, '--no-truncate'),
-        } as any,
-        command
-      )
-    })
+  registerQueryCommand(program, queryCommand)
 
   // Register plan command
-  program
-    .command('plan <sql>')
-    .description('Analyze SQL risk without executing')
-    .option('--format <type>', 'Output format: text, json', 'text')
-    .action(async (sql: string, options: Record<string, unknown>, command) => {
-      await planCommand(sql, options as never, command)
-    })
+  registerPlanCommand(program, planCommand)
 
   // Register saved-query (q) command
-  program
-    .command('q <name>')
-    .description(t('q.description'))
-    .option('--format <type>', 'Output format: table, json, csv, html', 'table')
-    .option('--ui', 'Show interactive dashboard in browser', false)
-    .option('--no-limit', 'Disable size guard wrap (LIMIT 1000)')
-    .option('--dry-run', 'Show final SQL + bind values; do not execute')
-    .option(
-      '--param <kv>',
-      'Pass parameter as key=value (repeatable)',
-      (val: string, prev: string[] = []) => prev.concat([val]),
-      [] as string[]
-    )
-    .option('--param-file <path>', 'JSON file containing param values')
-    .option(
-      '--slow-ms <number>',
-      'Emit a passive performance hint at or above this execution time; 0 disables it',
-      parseSlowMs,
-      1000
-    )
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .option('--verify', 'Run verification check after execution if defined', false)
-    .action(async (name: string, options: Record<string, unknown>, command) => {
-      await qCommand(name, normalizeLimitFlags(options) as any, command)
-    })
+  registerQCommand(program, qCommand)
 
   // Register insert command
-  program
-    .command('insert <table>')
-    .description(t('insert.description'))
-    .option('--data <json>', 'JSON object to insert')
-    .option('--dry-run', 'Show generated SQL without executing')
-    .option('--force', 'Skip confirmation prompt')
-    .option('--plan', 'Analyze risk without connecting or executing')
-    .option('--format <type>', 'Output format for --plan: text or json', 'text')
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .action(async (table: string, options: Record<string, unknown>, command) => {
-      try {
-        await insertCommand(table, options, command)
-      } catch (error) {
-        if (options.recovery === true) {
-          const { emitRecoveryEnvelope } = await import('./core/recovery')
-          emitRecoveryEnvelope(error, { operation: 'insert', table, writeOperation: 'INSERT' })
-        }
-        printLocalizedCliError((error as Error).message, error)
-        process.exit(1)
-      }
-    })
+  registerInsertCommand(program, insertCommand)
 
   // Register update command
-  program
-    .command('update <table>')
-    .description(t('update.description'))
-    .option('--where <condition>', 'WHERE clause (required, e.g. "id=1")')
-    .option('--set <json>', 'JSON with fields to update (required, e.g. \'{"name":"Bob"}\')')
-    .option('--dry-run', 'Show generated SQL without executing')
-    .option('--force', 'Skip confirmation prompt')
-    .option('--plan', 'Analyze risk without connecting or executing')
-    .option('--format <type>', 'Output format for --plan: text or json', 'text')
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .action(async (table: string, options: Record<string, unknown>, command) => {
-      try {
-        await updateCommand(table, options as never, command)
-      } catch (error) {
-        if (options.recovery === true) {
-          const { emitRecoveryEnvelope } = await import('./core/recovery')
-          emitRecoveryEnvelope(error, { operation: 'update', table, writeOperation: 'UPDATE' })
-        }
-        printLocalizedCliError((error as Error).message, error)
-        process.exit(1)
-      }
-    })
+  registerUpdateCommand(program, updateCommand)
 
   // Register delete command
-  program
-    .command('delete <table>')
-    .description(t('delete.description'))
-    .option('--where <condition>', 'WHERE clause (required, e.g. "id=1")')
-    .option('--dry-run', 'Show generated SQL without executing')
-    .option('--force', 'Skip confirmation prompt')
-    .option('--plan', 'Analyze risk without connecting or executing')
-    .option('--format <type>', 'Output format for --plan: text or json', 'text')
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .action(async (table: string, options: Record<string, unknown>, command) => {
-      try {
-        await deleteCommand(table, options as never, command)
-      } catch (error) {
-        if (options.recovery === true) {
-          const { emitRecoveryEnvelope } = await import('./core/recovery')
-          emitRecoveryEnvelope(error, { operation: 'delete', table, writeOperation: 'DELETE' })
-        }
-        printLocalizedCliError((error as Error).message, error)
-        process.exit(1)
-      }
-    })
+  registerDeleteCommand(program, deleteCommand)
 
   // Register export command
-  program
-    .command('export <sql>')
-    .description(t('export.description'))
-    .option('--format <format>', 'Output format: json, jsonl, csv, html', 'json')
-    .option('--output <path>', 'Output file path (if omitted, write to stdout)', undefined)
-    .option('--force', 'Skip overwrite confirmation', false)
-    .option('--collection <name>', 'MongoDB collection name; Elasticsearch index name')
-    .option('--index <name>', 'Elasticsearch index name (alias for --collection)')
-    .addOption(createConnectionSelectorOption())
-    .option('--limit <number>', 'Limit result rows (overrides auto-limit)', (val) =>
-      parseInt(val, 10)
-    )
-    .option('--no-limit', 'Disable auto-limit in query-only mode')
-    .option(
-      '--recovery',
-      'On failure, emit a structured recovery envelope to stdout (suppresses human stderr message)',
-      false
-    )
-    .action(async (sql: string, options: Record<string, unknown>, command) => {
-      return await exportCommand(sql, normalizeLimitFlags(options) as never, command)
-    })
+  registerExportCommand(program, exportCommand)
 
   // Register skill command + skill tasks sub-tree
   const skillCmd = registerSkillCommand(program)

--- a/tests/integration/lazy-entry-path.test.ts
+++ b/tests/integration/lazy-entry-path.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The lazy entry path, exercised through a real process.
+ *
+ * `buildProgramFor()` (ADR 0007) only runs in `src/cli-runtime.ts`, so nothing
+ * that constructs a program in-process can observe it. The unit tests next door
+ * compare *declared shape*; this file exists because a command whose behaviour
+ * depends on its siblings passes those and is still broken end to end — which
+ * is exactly what `completion` did: under a one-command root it emitted a
+ * script listing only itself, and `--install` writes that into the user's
+ * shell rc.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const CLI = resolve(import.meta.dir, '../../src/cli.ts')
+
+function run(...args: string[]): string {
+  const result = spawnSync('bun', [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: { ...process.env, DBCLI_NO_UPDATE_CHECK: '1' },
+  })
+  expect(result.status).toBe(0)
+  return result.stdout
+}
+
+describe('lazy entry path', () => {
+  test.each(['bash', 'zsh', 'fish'])(
+    'completion %s describes the whole command tree, not just itself',
+    (shell) => {
+      const script = run('completion', shell)
+
+      // A truncated script still contains `completion`; the siblings are what
+      // disappears when the tree is read off this command's parent.
+      for (const command of ['query', 'schema', 'list', 'export', 'impact']) {
+        expect(script).toContain(command)
+      }
+    }
+  )
+
+  test('root help lists every top-level command', () => {
+    const help = run('--help')
+
+    for (const command of ['query', 'schema', 'list', 'export', 'impact', 'completion']) {
+      expect(help).toContain(command)
+    }
+  })
+
+  test('a lazily dispatched command renders its own full help', () => {
+    const help = run('query', '--help')
+
+    expect(help).toContain('Usage: dbcli query')
+    for (const flag of ['--format', '--limit', '--no-limit', '--fields', '--slow-ms', '--use']) {
+      expect(help).toContain(flag)
+    }
+  })
+})

--- a/tests/unit/program/lazy-registry.test.ts
+++ b/tests/unit/program/lazy-registry.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Contract between the two registration paths.
+ *
+ * buildProgram() stays eager — check-cli-contract.ts, the completion tree and a
+ * dozen tests walk the whole command tree in-process and must keep seeing it.
+ * buildProgramFor(argv) registers only the command argv actually names, so a
+ * real CLI invocation stops paying for the other ~40 command modules.
+ *
+ * Two registration paths can drift. These tests are what stops that: the
+ * registry must name exactly the commands the eager tree has, and each command
+ * built lazily must be indistinguishable from its eager twin — same options,
+ * same arguments, same subcommand tree, all the way down.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { Command } from 'commander'
+import { buildProgram } from '@/program'
+import { buildProgramFor, COMMAND_NAMES } from '@/program-lazy'
+
+function topLevelNames(program: Command): string[] {
+  return program.commands.map((command) => command.name().split(' ')[0]!).sort()
+}
+
+/** Everything about a command that the CLI/help contract can observe. */
+function shape(command: Command) {
+  return {
+    name: command.name(),
+    description: command.description(),
+    arguments: command.registeredArguments.map((argument) => ({
+      name: argument.name(),
+      required: argument.required,
+      variadic: argument.variadic,
+    })),
+    options: command.options
+      .map((option) => ({
+        flags: option.flags,
+        long: option.long,
+        short: option.short,
+        description: option.description,
+        defaultValue: option.defaultValue,
+        required: option.required,
+        optional: option.optional,
+        // A parser moved to the wrong side of the split is exactly the drift
+        // this file guards; record its presence, not its identity.
+        hasParser: typeof option.parseArg === 'function',
+        choices: (option as { argChoices?: string[] }).argChoices,
+      }))
+      .sort((a, b) => (a.flags < b.flags ? -1 : 1)),
+    subcommands: command.commands
+      .slice()
+      .sort((a, b) => (a.name() < b.name() ? -1 : 1))
+      .map(shape),
+  }
+}
+
+function find(program: Command, name: string): Command {
+  const command = program.commands.find((candidate) => candidate.name().split(' ')[0] === name)
+  if (!command) throw new Error(`command not registered: ${name}`)
+  return command
+}
+
+describe('lazy command registry', () => {
+  const eager = buildProgram()
+  const eagerNames = topLevelNames(eager)
+
+  test('the registry names exactly the commands the eager tree registers', () => {
+    expect([...COMMAND_NAMES].sort()).toEqual(eagerNames)
+  })
+
+  test.each(eagerNames)('lazily built %s is identical to its eager twin', async (name: string) => {
+    const lazy = await buildProgramFor(['node', 'dbcli', name])
+    expect(topLevelNames(lazy)).toEqual([name])
+    expect(shape(find(lazy, name))).toEqual(shape(find(buildProgram(), name)))
+  })
+
+  test('root options are identical on both paths', async () => {
+    const lazy = await buildProgramFor(['node', 'dbcli', 'query'])
+    expect(shape(lazy).options).toEqual(shape(buildProgram()).options)
+  })
+})
+
+describe('argv dispatch', () => {
+  test.each([
+    [['node', 'dbcli', 'query', 'SELECT 1'], 'query'],
+    [['node', 'dbcli', '--config', 'x/query', 'schema', 'users'], 'schema'],
+    // A root option that takes a value must not have its value read as the
+    // command name — '5000' would fall back to eager and silently lose the win.
+    [['node', 'dbcli', '--timeout', '5000', 'list'], 'list'],
+    [['node', 'dbcli', '--statement-timeout=0', 'inspect'], 'inspect'],
+    [['node', 'dbcli', '--use', 'prod', 'export', 'SELECT 1'], 'export'],
+    [['node', 'dbcli', '-v', '--global', 'doctor'], 'doctor'],
+    [['node', 'dbcli', 'query', '--help'], 'query'],
+  ] as Array<[string[], string]>)(
+    '%o resolves to a single registered command',
+    async (argv, expected) => {
+      const program = await buildProgramFor(argv)
+      expect(topLevelNames(program)).toEqual([expected])
+    }
+  )
+
+  test.each([
+    ['no command', ['node', 'dbcli']],
+    ['root help', ['node', 'dbcli', '--help']],
+    ['unknown command', ['node', 'dbcli', 'nonexistent']],
+    ['only root options', ['node', 'dbcli', '--verbose']],
+    // Everything after `--` is an operand, never a command name.
+    ['after a bare --', ['node', 'dbcli', '--', 'query']],
+  ] as Array<[string, string[]]>)('%s falls back to the full eager tree', async (_label, argv) => {
+    const program = await buildProgramFor(argv)
+    expect(topLevelNames(program)).toEqual(topLevelNames(buildProgram()))
+  })
+})


### PR DESCRIPTION
Closes #50。

## 為什麼沒走票上列的兩個選項

票上提的兩條路（每個命令拆兩檔／同檔內把重相依搬進 action）都要動全部約 40 個命令模組。但決定性的約束不在命令模組裡：

`buildProgram()` 是**同步**的，而且有三個非測試呼叫點加 8 個測試檔在 process 內走它回傳的整棵樹 —— `scripts/check-cli-contract.ts` 拿它比對 115 個命令路徑與 178 個 long flag、`buildCompletionTree()` 從它推導 shell 補全、`src/commands/shell.ts` 每個 REPL session 重建一次。惰性載入是非同步的。把 `buildProgram()` 改成 async 會讓一個效能改動變成 11 處呼叫點的破壞性改動；而任何維持同步的設計都必須保留靜態 import —— 那正是要拿掉的成本。

所以改成**兩條註冊路徑共用一份宣告**：

- `buildProgram()` 原封不動 —— 同步、eager、註冊順序與簽章都沒變。
- 新的 `buildProgramFor(argv)` 是真實 CLI 入口走的路徑，只註冊 argv 指名的那一個命令。沒有命令名稱、`--help`、未知名稱、`--` 之後，一律回退完整 eager 樹。頂層 help 本來就得列出所有命令，所以它是設計上的 fallback，不是漏網。

兩條路徑不可能在「宣告什麼」上漂移，因為它們不各自持有宣告：七個原本宣告在 `program.ts` 的命令搬進 `src/commands/inline-registrars.ts` 成為接收實作當參數的函式，其餘約 33 個本來就是各自模組匯出的 `Command` 物件。會漂移的是 `COMMAND_LOADERS` 的鍵集合，由 `tests/unit/program/lazy-registry.test.ts` 釘住：註冊表鍵值必須等於 eager 樹的頂層名稱，且每個惰性建出的命令要與 eager 版 deep-equal 到選項旗標、default、parser 存在與否、choices 與整棵子命令樹。

決策與量測過程記於 **ADR 0007**。

## 一個差點出貨的回歸

`dbcli completion <shell>` 原本從 `completionCommand.parent` 取命令樹。lazy 路徑下那個 parent 只有一個命令，產出的補全腳本只列得出 `completion` 自己（433 項 → 6 項），而 `--install` 會把它寫進使用者的 `~/.zshrc`，tab 補全從此失效到重裝為止。

改為和 `src/commands/shell.ts` 一樣從 `buildProgram()` 建樹，bash / zsh / fish 三種輸出與 main 逐字相同。

這種「行為取決於兄弟命令」的失效，對任何在 process 內自己組 program 的測試都是隱形的 —— 它在 5045 條測試全綠的情況下壞掉。所以新增 `tests/integration/lazy-entry-path.test.ts` 直接 spawn 真實 CLI：lazy 路徑只存在於 process 入口，只有真實 process 走得到。（驗證過這條測試會抓：打回舊寫法 3 fail，修好 0 fail。）

## 效益（實測，不是估計）

bun、交錯 A/B 各 21 對、取中位數，**兩側 bundle 變體配對比較**：

| | main | branch | 省 |
| --- | --- | --- | --- |
| `query --help` | 72.1ms | 64.2ms | 7.9ms (11%) |
| `list --help` | 69.9ms | 62.1ms | 7.8ms (11%) |
| `--help`（走 eager fallback） | 68.7ms | 71.8ms | 噪音，約 0 |

bundle 大小**增加**約 22KB。

票上估的 50ms 是對 source 跑 `bun -e 'await import(m)'` 得到的。出貨的是 `bun build --outfile` 的單檔 bundle，沒有 code splitting，延後求值不減少 parse —— 這是估計與實測差 6 倍的原因。

⚠️ 量這組數字踩到一個**既有**問題：`bun run build` 非決定性，同源連續建置會讓 `dist/cli-runtime.mjs` 在相差約 690KB 的兩個大小之間交替（main 1,891,038 / 2,582,505，branch 1,913,004 / 2,604,444）。拿一側的大版比另一側的小版會量出約 13ms 的假象。與本 PR 無關，已另開票追蹤。

## Test plan

- [x] `SKIP_INTEGRATION_TESTS=true bun run test` → **5050 pass / 26 skip / 0 fail**（新增 60 條）
- [x] `bun run typecheck`、`bun run lint`、`bun run format`
- [x] `bun run scripts/check-cli-contract.ts` → 115 command paths、178 live long flags 對齊
- [x] 13 種 `--help` 形狀（含 `impact assess`、`skill`、七個 inline 命令）改動前後逐字比對，全部相同
- [x] `completion` bash / zsh / fish 三種輸出與 main 逐字相同
- [x] 靜態 import 圖驗證：`program-lazy.ts` + `inline-registrars.ts` 的靜態可達模組共 13 個，零 `commands/*`、零 `adapters/*`、零 `formatters/*`、無 `core/config`

## Review 修掉的問題

除了上面的 completion CRITICAL，另有三項：`printLocalizedCliError` 改回靜態 import（`utils/cli-error` 本來就在 cli-runtime 靜態圖裡，動態化零收益，卻讓 import 失敗時吃掉原始錯誤並跳過 `process.exit(1)`）；`buildProgramFor` 的 top-level await 包進錯誤呈現器；`findCommandName` 只建一次 root program，帶值旗標長短拼寫都收，遇到 optional-value 選項直接回退 eager 而不猜（猜錯是靜默的錯誤分派，回退只是少省一點時間）。

🤖 Generated with Claude Code