### PR TITLE
test: [ perf ] startup bench 改測噪音下限而非中位數

### DIFF
--- a/tests/perf/startup.bench.ts
+++ b/tests/perf/startup.bench.ts
@@ -1,8 +1,12 @@
 /**
  * CLI Startup Performance
  *
- * Budgets are checked against the median after a discarded warm-up so one
- * descheduled process does not turn this into a flaky gate.
+ * Budgets are checked against the FASTEST of several runs, not the median.
+ * Startup noise is one-sided — a descheduled process is slower, never faster —
+ * so the minimum estimates the real cost and the median mostly reports how
+ * busy the runner was. Measured on `main`, the same workload has reported
+ * anywhere from 84ms to 283ms against a 200ms budget, failing CI on commits
+ * that touched nothing related.
  * Set SKIP_PERF_TESTS=1 to skip (e.g. on noisy CI runners).
  *
  *   --help    < 200ms on macOS/Linux
@@ -20,7 +24,9 @@ const enabled = existsSync(cliPath) && !process.env.SKIP_PERF_TESTS
 const STARTUP_BUDGETS =
   process.platform === 'win32' ? { help: 5000, version: 5000 } : { help: 200, version: 100 }
 
-function medianStartupMs(argument: '--help' | '--version', sampleCount = 5): number {
+const SAMPLE_COUNT = 9
+
+function fastestStartupMs(argument: '--help' | '--version', sampleCount = SAMPLE_COUNT): number {
   const run = () =>
     spawnSync(process.execPath, [cliPath, argument], {
       encoding: 'utf8',
@@ -39,23 +45,22 @@ function medianStartupMs(argument: '--help' | '--version', sampleCount = 5): num
     expect(result.status).toBe(0)
   }
 
-  samples.sort((a, b) => a - b)
-  return samples[Math.floor(samples.length / 2)]!
+  return Math.min(...samples)
 }
 
 function report(label: string, elapsed: number, budget: number): void {
-  console.log(`${label} = ${elapsed.toFixed(2)}ms (budget ${budget}ms)`)
+  console.log(`${label} = ${elapsed.toFixed(2)}ms (fastest of ${SAMPLE_COUNT}, budget ${budget}ms)`)
 }
 
 describe.if(enabled)('Performance: CLI Startup', () => {
   it('--help renders within budget', () => {
-    const elapsed = medianStartupMs('--help')
+    const elapsed = fastestStartupMs('--help')
     report('CLI startup (--help)', elapsed, STARTUP_BUDGETS.help)
     expect(elapsed).toBeLessThan(STARTUP_BUDGETS.help)
   })
 
   it('--version renders within budget', () => {
-    const elapsed = medianStartupMs('--version')
+    const elapsed = fastestStartupMs('--version')
     report('CLI startup (--version)', elapsed, STARTUP_BUDGETS.version)
     expect(elapsed).toBeLessThan(STARTUP_BUDGETS.version)
   })


### PR DESCRIPTION
修 main 上 [run 31671513042](https://github.com/CarlLee1983/dbcli/actions/runs/31671513042) 的紅燈：`test (macos-latest, 1.3.3)` 的 `--help renders within budget`，預算 200ms、量到 248.86ms。

## 這條 guard 量的是 runner 有多忙

把 main 近期各次 CI 回報的 `--help` 值排開：

```
84  86  89  97  99  105  108  120  126  137  179  193  204  248  265  282  283
```

同一份工作負載 **3.4 倍**的散布，而預算是 200ms。`fd9f3c9d` 那次六個 test job 全掛時，這條也紅過（204 / 283 / 265），與當次改動完全無關 —— 它有紅燈前科。

啟動時間的噪音是**單向的**：被排程搶走的 process 只會變慢，不會變快。中位數在這種分布上估的是當下機器負載，N 次取最小值估的才是真實成本。

所以改為 9 次取最小（原本 5 次取中位數），**預算維持 200ms / 100ms 不動**。這是修正量測方法，不是把門檻放寬到讓紅燈消失 —— 後者會讓 100ms → 390ms 的真實回歸也擋不下來。

## 誠實揭露兩件事

**一、本地量不出這個改法的優勢。** 同一台機器跑 6 輪、每輪 9 次：

| 方法 | 觀測範圍 | 散布 |
| --- | --- | --- |
| 最小值 | 61.7–75.0ms | 1.22× |
| 中位數 | 68.2–80.4ms | 1.18× |

安靜的機器沒有右尾，兩者差不多。最小值的好處只在被壓榨的 CI runner 上出現，那個環境我複製不出來。可以確定的是它系統性地低約 7ms，本身就多一點餘裕。

**二、#50 確實讓 `--help` 慢了一點。** 配對 bundle 變體、交錯量測，`--help` 回歸 2.4–6.0ms —— 它走 eager fallback，比以前多一層動態 import。這個量級不可能產生 248ms 的讀數（`createRootProgram()` 單次 0.012ms，fallback 多建一次不是成因），但它確實吃掉一點餘裕，所以一併記在這裡而不是放著不提。

## Test plan

- [x] `bun test ./tests/perf/startup.bench.ts` → `--help` 92.08ms、`--version` 11.47ms，2 pass
- [x] 連跑 5 次確認穩定：62.05 / 70.15 / 75.84 / 71.50 / 66.70ms，全數遠低於預算
- [x] `SKIP_INTEGRATION_TESTS=true bun run test` → 5050 pass / 26 skip / 0 fail
- [x] `bun run typecheck`、`bun run lint`、`bun run format`

## 相關

量測期間發現的建置非決定性另記於 #56 —— 那個問題會讓任何 bundle 大小或啟動時間的比較失真，跟本 PR 是不同的成因。

🤖 Generated with Claude Code