### PR TITLE
fix: [ build ] @inquirer/prompts 改為 external，修掉無聲降級與建置非決定性

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,19 @@ jobs:
       - name: Prettier
         run: bun run format:check
 
+  build-determinism:
+    # A bundler free to decide differently on the next run ships a different
+    # product than the one that was tested (#56). Builds twice, compares hashes.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - name: Build is reproducible
+        run: bun run build:determinism
+
   docs-parity:
     # Drift guards: fail the build when the CLI, SKILL.md, reference.md, managed
     # platform copies, or user docs fall out of sync. Runs once (not per matrix).

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "scripts": {
     "dev": "bun run src/cli.ts",
     "build": "bun run scripts/build.ts",
+    "build:determinism": "bun run scripts/check-build-determinism.ts",
     "prepublishOnly": "bun run build",
     "release:check": "bash scripts/release-check.sh",
     "plugin:sync": "bun run scripts/sync-plugin-assets.ts --write",
@@ -87,6 +88,7 @@
     "lint:fix": "eslint src tests scripts --ext .ts --fix --max-warnings=0"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.4.3",
     "cli-table3": "^0.6.5",
     "commander": "13.0.0",
     "lru-cache": "^11.4.0",
@@ -107,7 +109,6 @@
     "@cucumber/messages": "^34.2.1",
     "@eslint/js": "^9.39.4",
     "@happy-dom/global-registrator": "^20.10.6",
-    "@inquirer/prompts": "^8.4.3",
     "@testing-library/react": "^16.3.2",
     "@types/bun": "latest",
     "@types/pg": "^8.20.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -31,7 +31,12 @@ const artifacts = [
 ]
 
 // 1. Bundle the full runtime separately so `dbcli --version` does not parse it.
-await $`bun build ./src/cli-runtime.ts --outfile dist/cli-runtime.mjs --target bun --external pg --external mysql2 --external mongodb --external open --external node-sql-parser`
+//     @inquirer/prompts is external for correctness, not size: bundling it was
+//     non-deterministic (#56). Successive builds of identical source alternated
+//     between inlining the prompt implementations and tree-shaking them away
+//     behind an intact barrel, so `await import('@inquirer/prompts')` threw and
+//     every interactive prompt silently degraded to its plain-text fallback.
+await $`bun build ./src/cli-runtime.ts --outfile dist/cli-runtime.mjs --target bun --external pg --external mysql2 --external mongodb --external open --external node-sql-parser --external @inquirer/prompts`
 
 // Keep the launcher's dynamic runtime path external. In source it resolves to
 // cli-runtime.ts; beside the built launcher Bun resolves cli-runtime.mjs.
@@ -49,7 +54,7 @@ if (process.platform !== 'win32') {
 
 // 3b. Bundle core library (no shebang) for the `./core` subpath export.
 //     Same externals as the CLI so native drivers stay peer-resolved.
-await $`bun build ./src/core/public.ts --outfile dist/core.mjs --target bun --external pg --external mysql2 --external mongodb --external open --external node-sql-parser`
+await $`bun build ./src/core/public.ts --outfile dist/core.mjs --target bun --external pg --external mysql2 --external mongodb --external open --external node-sql-parser --external @inquirer/prompts`
 
 // 3c. Generate a single flat declaration file for the `./core` subpath.
 //     Requires devDep @types/pg: dts-bundle-generator resolves pg types reachable via AdapterFactory.

--- a/scripts/check-build-determinism.ts
+++ b/scripts/check-build-determinism.ts
@@ -1,0 +1,64 @@
+// Verify that `bun run build` produces the same artifacts twice in a row.
+//
+// It did not (#56). Successive builds of identical source alternated
+// dist/cli-runtime.mjs between two sizes ~690KB apart, depending on whether the
+// bundler inlined @inquirer/prompts' implementations or tree-shook them away
+// behind an intact barrel. The second outcome shipped a CLI whose interactive
+// prompts threw on import and silently degraded to plain text.
+//
+// The fix was to stop bundling that package at all, but the failure mode is
+// general: a bundler that is free to make a different call on the next run can
+// ship a different product than the one that was tested. This checks the
+// property rather than the one package.
+//
+// Not part of `bun test` — it builds twice, which takes far too long for the
+// default suite. Run it in CI, or by hand before a release.
+
+import { $ } from 'bun'
+
+const ARTIFACTS = [
+  'dist/cli.mjs',
+  'dist/cli-runtime.mjs',
+  'dist/core.mjs',
+  'dist/agent-core.mjs',
+] as const
+
+async function digest(path: string): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer()
+  const hash = new Bun.CryptoHasher('sha256')
+  hash.update(new Uint8Array(bytes))
+  return hash.digest('hex')
+}
+
+async function buildAndDigest(label: string): Promise<Map<string, string>> {
+  console.log(`building (${label})...`)
+  await $`bun run build`.quiet()
+
+  const digests = new Map<string, string>()
+  for (const artifact of ARTIFACTS) {
+    digests.set(artifact, await digest(artifact))
+  }
+  return digests
+}
+
+const first = await buildAndDigest('first')
+const second = await buildAndDigest('second')
+
+const drifted = ARTIFACTS.filter((artifact) => first.get(artifact) !== second.get(artifact))
+
+for (const artifact of ARTIFACTS) {
+  const stable = !drifted.includes(artifact)
+  const mark = stable ? '✓' : '✗'
+  console.log(`${mark} ${artifact} ${first.get(artifact)?.slice(0, 16)}`)
+  if (!stable) console.log(`    second build: ${second.get(artifact)?.slice(0, 16)}`)
+}
+
+if (drifted.length > 0) {
+  console.error(
+    `\n✗ build is not reproducible: ${drifted.join(', ')} differ between two builds of identical source.\n` +
+      '  A bundler free to decide differently on the next run can ship a different product than the one tested (#56).'
+  )
+  process.exit(1)
+}
+
+console.log(`\n✓ build is reproducible: ${ARTIFACTS.length} artifacts identical across two builds`)

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -4,7 +4,39 @@
  * Attempts to use @inquirer/prompts for rich interactive experience.
  * If that fails (due to Bun compatibility issues), falls back to simple
  * console-based prompts using Bun's built-in stdin.
+ *
+ * Two failures used to be indistinguishable here, and both were swallowed
+ * (#56). Loading the module can fail — a bundle that tree-shook the prompt
+ * implementations away leaves an intact barrel that throws on import, which is
+ * how every interactive prompt silently degraded to plain text for however
+ * long. That case warns, once, and falls back. The prompt *call* failing is a
+ * different thing entirely: that is the user pressing Ctrl-C, and re-asking
+ * them in plain text is the opposite of what they wanted, so it propagates.
  */
+
+let promptsUnavailableReported = false
+
+/**
+ * Load @inquirer/prompts, reporting unavailability once per process.
+ *
+ * Returns undefined rather than throwing so each prompt can fall back, but the
+ * degradation is never silent again.
+ */
+async function loadInquirer(): Promise<typeof import('@inquirer/prompts') | undefined> {
+  try {
+    return await import('@inquirer/prompts')
+  } catch (error) {
+    if (!promptsUnavailableReported) {
+      promptsUnavailableReported = true
+      const reason = error instanceof Error ? error.message : String(error)
+      process.stderr.write(
+        `[dbcli] rich interactive prompts are unavailable (${reason}); ` +
+          'falling back to plain-text input\n'
+      )
+    }
+    return undefined
+  }
+}
 
 /**
  * Read a line from stdin using Node.js compatible API.
@@ -43,6 +75,33 @@ async function readLineFromStdin(prompt: string = ''): Promise<string> {
   })
 }
 
+async function textFallback(message: string, defaultValue?: string): Promise<string> {
+  const displayMessage = defaultValue ? `${message} [${defaultValue}]: ` : `${message}: `
+  const answer = await readLineFromStdin(displayMessage)
+  return answer.trim() || defaultValue || ''
+}
+
+async function selectFallback(message: string, choices: string[]): Promise<string> {
+  console.log(message)
+  choices.forEach((choice, index) => {
+    console.log(`  ${index + 1}) ${choice}`)
+  })
+
+  const answer = await readLineFromStdin('Select option (number): ')
+  const selectedIndex = parseInt(answer, 10) - 1
+
+  if (selectedIndex >= 0 && selectedIndex < choices.length) {
+    return choices[selectedIndex] ?? choices[0] ?? ''
+  }
+
+  return choices[0] ?? ''
+}
+
+async function confirmFallback(message: string): Promise<boolean> {
+  const answer = await readLineFromStdin(`${message} (y/n): `)
+  return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes'
+}
+
 /**
  * Prompt user for text input with optional default value.
  *
@@ -52,21 +111,12 @@ async function readLineFromStdin(prompt: string = ''): Promise<string> {
  */
 export async function text(message: string, defaultValue?: string): Promise<string> {
   // Skip inquirer if not a TTY (e.g., piped input)
-  if (!process.stdin.isTTY) {
-    const displayMessage = defaultValue ? `${message} [${defaultValue}]: ` : `${message}: `
-    const answer = await readLineFromStdin(displayMessage)
-    return answer.trim() || defaultValue || ''
-  }
+  if (!process.stdin.isTTY) return textFallback(message, defaultValue)
 
-  try {
-    const { input: inquirerText } = await import('@inquirer/prompts')
-    return await inquirerText({ message, default: defaultValue })
-  } catch {
-    // Fallback: use simple console prompts
-    const displayMessage = defaultValue ? `${message} [${defaultValue}]: ` : `${message}: `
-    const answer = await readLineFromStdin(displayMessage)
-    return answer.trim() || defaultValue || ''
-  }
+  const inquirer = await loadInquirer()
+  if (!inquirer) return textFallback(message, defaultValue)
+
+  return await inquirer.input({ message, default: defaultValue })
 }
 
 /**
@@ -78,41 +128,12 @@ export async function text(message: string, defaultValue?: string): Promise<stri
  */
 export async function select(message: string, choices: string[]): Promise<string> {
   // Skip inquirer if not a TTY (e.g., piped input)
-  if (!process.stdin.isTTY) {
-    console.log(message)
-    choices.forEach((choice, index) => {
-      console.log(`  ${index + 1}) ${choice}`)
-    })
+  if (!process.stdin.isTTY) return await selectFallback(message, choices)
 
-    const answer = await readLineFromStdin('Select option (number): ')
-    const selectedIndex = parseInt(answer, 10) - 1
+  const inquirer = await loadInquirer()
+  if (!inquirer) return await selectFallback(message, choices)
 
-    if (selectedIndex >= 0 && selectedIndex < choices.length) {
-      return choices[selectedIndex] ?? choices[0] ?? ''
-    }
-
-    return choices[0] ?? ''
-  }
-
-  try {
-    const { select: inquirerSelect } = await import('@inquirer/prompts')
-    return await inquirerSelect({ message, choices })
-  } catch {
-    // Fallback: print choices and ask user to select
-    console.log(message)
-    choices.forEach((choice, index) => {
-      console.log(`  ${index + 1}) ${choice}`)
-    })
-
-    const answer = await readLineFromStdin('Select option (number): ')
-    const selectedIndex = parseInt(answer, 10) - 1
-
-    if (selectedIndex >= 0 && selectedIndex < choices.length) {
-      return choices[selectedIndex] ?? choices[0] ?? ''
-    }
-
-    return choices[0] ?? ''
-  }
+  return await inquirer.select({ message, choices })
 }
 
 /**
@@ -123,19 +144,12 @@ export async function select(message: string, choices: string[]): Promise<string
  */
 export async function confirm(message: string): Promise<boolean> {
   // Skip inquirer if not a TTY (e.g., piped input)
-  if (!process.stdin.isTTY) {
-    const answer = await readLineFromStdin(`${message} (y/n): `)
-    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes'
-  }
+  if (!process.stdin.isTTY) return await confirmFallback(message)
 
-  try {
-    const { confirm: inquirerConfirm } = await import('@inquirer/prompts')
-    return await inquirerConfirm({ message })
-  } catch {
-    // Fallback: simple y/n prompt
-    const answer = await readLineFromStdin(`${message} (y/n): `)
-    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes'
-  }
+  const inquirer = await loadInquirer()
+  if (!inquirer) return await confirmFallback(message)
+
+  return await inquirer.confirm({ message })
 }
 
 /**

--- a/tests/unit/build/inquirer-shipping-contract.test.ts
+++ b/tests/unit/build/inquirer-shipping-contract.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @inquirer/prompts has to reach the user, and only two arrangements do that.
+ *
+ * It was neither: declared as a devDependency and left to the bundler, which
+ * inlined the prompt implementations on some builds and tree-shook them away on
+ * others (#56) — leaving an intact barrel whose import threw, so every
+ * interactive prompt degraded to plain text with no error anywhere. The npm
+ * package ships `dist/` only, so a devDependency the bundle failed to inline is
+ * simply absent on the user's machine.
+ *
+ * Marking it external makes the bundle emit a real import, which only resolves
+ * if it is a runtime dependency. The two facts are one decision, and this pins
+ * them together: changing either half alone reintroduces the silent fallback.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+
+const PACKAGE = '@inquirer/prompts'
+
+const manifest = (await Bun.file('package.json').json()) as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  files?: string[]
+}
+const buildScript = await Bun.file('scripts/build.ts').text()
+
+/** Bundles that can reach a prompt: the CLI runtime and the ./core subpath. */
+const PROMPT_BEARING_BUNDLES = ['dist/cli-runtime.mjs', 'dist/core.mjs']
+
+describe('@inquirer/prompts shipping contract', () => {
+  test('is a runtime dependency, not a devDependency', () => {
+    expect(manifest.dependencies?.[PACKAGE]).toBeString()
+    expect(manifest.devDependencies?.[PACKAGE]).toBeUndefined()
+  })
+
+  test.each(PROMPT_BEARING_BUNDLES)('the build marks it external for %s', (outfile) => {
+    const command = buildScript.split('\n').find((line) => line.includes(`--outfile ${outfile}`))
+
+    expect(command).toBeString()
+    expect(command).toContain(`--external ${PACKAGE}`)
+  })
+
+  // The two tests above pin the intent; this one pins the result. Skipped when
+  // dist/ is absent so the suite still runs pre-build.
+  describe.if(PROMPT_BEARING_BUNDLES.every((path) => existsSync(path)))('built artifacts', () => {
+    test.each(PROMPT_BEARING_BUNDLES)('%s imports it rather than inlining it', async (outfile) => {
+      const bundle = await Bun.file(outfile).text()
+
+      // An external dependency survives as a real import specifier. An inlined
+      // one leaves Bun's module comment instead — and that is the arrangement
+      // that shipped a barrel without its implementations.
+      expect(bundle).toMatch(/import\(["']@inquirer\/prompts["']\)/)
+      expect(bundle).not.toContain('// node_modules/@inquirer/prompts/')
+    })
+  })
+
+  test('the published package ships dist/, which is why the above matters', () => {
+    // If `files` ever grew node_modules or the sources, bundling would become a
+    // size decision again rather than a correctness one — and this whole file
+    // would be arguing about the wrong thing.
+    expect(manifest.files).toContain('dist/')
+    expect(manifest.files).not.toContain('node_modules/')
+  })
+})


### PR DESCRIPTION
Closes #56。

## 出貨的產物有沒有可用的互動 prompt，取決於建置時擲骰子的結果

`bun build` 對 `@inquirer/prompts` 的處理不一致：同源連續建置，有時內聯 prompt 實作，有時把實作搖掉、只留下完整的 barrel。後者讓 `await import('@inquirer/prompts')` 直接拋錯，於是每個互動提示都退成純文字版。`dist/cli-runtime.mjs` 因此在相差約 690KB 的兩個產物間交替（main 上是 1,891,038 / 2,582,505）。

**在真實 TTY 下驗證過**：小版產物跑 `dbcli init`，第一個 `select` 出現的是編號清單加 `Select option (number):` —— 那是 `src/utils/prompts.ts` 的 fallback，不是 inquirer 的方向鍵選單。產物內容佐證：

| | small | large |
| --- | --- | --- |
| `isUpKey` | 0 | 13 |
| `isDownKey` | 0 | 10 |
| `@inquirer` runtime import | 無 | 無 |

小版連方向鍵處理都不在產物裡，也沒有任何會向外解析的 import —— 所以不是「執行時找不到 node_modules」，而是內聯的 barrel 指向不存在的 binding，repo 內外一樣壞。

## 為什麼潛伏這麼久

三件事疊在一起。`prompts.ts` 的 `catch` 把失敗吞成「比較陽春但能用」的提示，沒有錯誤訊息，沒人會回報；`@inquirer/prompts` 掛在 devDependencies 而 `files` 只帶 `dist/`，所以連「在 repo 裡試一下」都測不出差別；現有測試全在非 TTY 下跑，`prompts.ts:54` 直接跳過 inquirer 分支，那條路徑從來沒被執行過。

## 修法：停止打包

原本考慮過「確保 bundler 一律內聯」，但我們無法要求 bundler 下次做出同樣的決定 —— 那正是本問題的成因。所以改為 `--external` 並移進 `dependencies`。

這讓它與 pg / mysql2 / mongodb / open / node-sql-parser 一致 —— 那五個全都是「標 external + 放 dependencies」，`@inquirer/prompts` 是唯一的例外，也是唯一出事的。

`src/utils/prompts.ts` 另外把兩件事分開：

- **模組載不進來** → 對 stderr 警告一次（每 process 一次）再降級。降級仍然發生，但不再無聲。
- **prompt 呼叫失敗** → 直接往外拋。那是使用者按 Ctrl-C，舊寫法會吞掉再用純文字問一次，等於取消鍵失效。這是附帶修掉的。

## 護欄

`tests/unit/build/inquirer-shipping-contract.test.ts` 把四件事綁在一起測：在 `dependencies`、不在 devDependencies；兩個 bundle 的建置指令都標 `--external`；產物留下真的 `import("@inquirer/prompts")` 且不得出現 `// node_modules/@inquirer/prompts/`（內聯痕跡）；`files` 仍只帶 `dist/`。只改一半就會讓無聲降級復活，所以綁在一起。

新增 `build-determinism` CI job：連建兩次、比對四個產物的 sha256。一支沒人跑的腳本不算護欄，所以直接接上 CI。

## 偽 TTY 測試：評估後不做

`script` 的參數在 macOS（`script -q /dev/null cmd`）與 Linux（`script -qec cmd /dev/null`）不同、Windows 沒有；`node-pty` 是原生相依。而真正壞掉的性質「產物有沒有內聯 barrel」已被上面的確定性斷言蓋到。要的是一條穩定測試，不是一條會偶爾紅的測試。理由完整記於 #56。

## Test plan

- [x] `bun run build:determinism` → 四個產物兩次建置 sha256 完全相同（改動前會交替）
- [x] `bun test ./tests/unit/build/inquirer-shipping-contract.test.ts` → 6 pass
- [x] 產物檢查：`import("@inquirer/prompts")` 存在、內聯痕跡 0 次、大小 1,862,106 穩定
- [x] `SKIP_INTEGRATION_TESTS=true bun test` → **5056 pass / 26 skip / 0 fail**
- [x] `bun run typecheck`、`bun run lint`、`bun run format`
- [x] CLI 冒煙：`--version`、`--help` 正常

需要人工確認的一項：合併後在真實 TTY 跑一次 `dbcli init`，確認第一個提示是可上下鍵選的 inquirer 選單，而不是 `Select option (number):`。這正是本票最初被發現的方式，自動化測試蓋不到。

🤖 Generated with Claude Code