### PR TITLE
fix: [ adapters ] 語句逾時的分類與錯誤措辭

### DIFF
--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A statement the server canceled is no longer reported as a connection failure.** PostgreSQL `57014`, MySQL `3024`, and MariaDB `1969` fell through to `UNKNOWN` / `CONN_UNKNOWN`, so the CLI answered a query that ran out of statement time with connection-troubleshooting hints and a recovery plan that opened with `dbcli doctor` — the one thing that was not broken. They now map to a `STATEMENT_TIMEOUT` adapter code whose hints point at the query (`dbcli lint`, `dbcli explain`, re-run with an explicit `--statement-timeout <ms>`). The `--recovery` envelope keeps `schemaVersion` 1 and reports `CONN_TIMEOUT` with `details.connectionCode: "STATEMENT_TIMEOUT"`; that field selects the query-oriented plan, replaces the network-flavored message with one that states the ceiling that was in force, and suppresses both the `doctor-*` branches — whose `branchFork.after: 1` assumed step 1 was `doctor` — and the `verify` step, since nothing verifies this error except re-running the statement, which only the caller has. PostgreSQL `57014` is `query_canceled`, not only `statement_timeout`, so a `pg_cancel_backend()` or recovery-conflict cancel keeps the verbatim `Database error (57014): …` form rather than asserting a ceiling nobody set.
+
 ## [1.54.0] - 2026-08-13 - Query engine hardening: timeout semantics, load-on-demand, deterministic builds
 
 ### Added

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -1156,6 +1156,7 @@ dbcli recover --next --after-step 2 --result @/tmp/r2.json
                 </tbody>
             </table>
             <p>If the doctor JSON cannot be parsed or no keyword matches, <code>--next</code> falls back to the linear <code>recovery</code> plan — branching never causes <code>--next</code> to fail. <code>--apply</code> continues to walk <code>recovery</code> linearly and ignores <code>branches</code>.</p>
+            <p>One connection-class error does <strong>not</strong> branch: a statement canceled by the server for exceeding the statement timeout (PostgreSQL SQLSTATE <code>57014</code>, MySQL <code>3024</code>, MariaDB <code>1969</code>). It reports as <code>CONN_TIMEOUT</code> with <code>details.connectionCode</code> set to <code>STATEMENT_TIMEOUT</code>, and that field is what separates it from a real connection timeout — the connection is healthy, so the plan works on the query (<code>dbcli lint</code>, <code>dbcli explain</code>, then a re-run with an explicit <code>--statement-timeout &lt;ms&gt;</code>) instead of running <code>doctor</code>. Because step 1 is not <code>doctor</code>, no <code>branches</code> or <code>branchFork</code> is emitted, and no <code>verify</code> step either — nothing verifies this error except re-running the statement, which only the caller has. All three steps carry placeholders, so <code>dbcli recover --apply</code> reports <code>skipped-only</code> and runs nothing.</p>
 
             <h3 class="mt-10">Audit ↔ Envelope pivot</h3>
             <ul>

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -1454,6 +1454,8 @@ For connection-class errors (`CONN_REFUSED`, `CONN_AUTH_FAILED`, `CONN_TIMEOUT`,
 
 If the doctor JSON cannot be parsed or no keyword matches, `--next` falls back to the linear `recovery` plan — branching never causes `--next` to fail. `--apply` continues to walk `recovery` linearly and ignores `branches`.
 
+One connection-class error does **not** branch: a statement canceled by the server for exceeding the statement timeout (PostgreSQL SQLSTATE `57014`, MySQL `3024`, MariaDB `1969`). It reports as `CONN_TIMEOUT` with `details.connectionCode` set to `STATEMENT_TIMEOUT`, and that field is what separates it from a real connection timeout — the connection is healthy, so the plan works on the query (`dbcli lint`, `dbcli explain`, then a re-run with an explicit `--statement-timeout <ms>`) instead of running `doctor`. Because step 1 is not `doctor`, no `branches` or `branchFork` is emitted, and no `verify` step either — nothing verifies this error except re-running the statement, which only the caller has. All three steps carry placeholders, so `dbcli recover --apply` reports `skipped-only` and runs nothing.
+
 ### Audit ↔ Envelope pivot
 
 Every `--recovery` failure writes a UUID link in both directions:

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -1156,6 +1156,7 @@ dbcli recover --next --after-step 2 --result @/tmp/r2.json
                 </tbody>
             </table>
             <p>若 doctor JSON 無法解析或沒有關鍵字匹配，<code>--next</code> 會回落為線性的 <code>recovery</code> 計畫 — 分支永遠不會造成 <code>--next</code> 失敗。<code>--apply</code> 維持線性走訪 <code>recovery</code>，不使用 <code>branches</code>。</p>
+            <p>有一種連線類別錯誤<strong>不會</strong>分支：語句因超過 statement timeout 被伺服器取消（PostgreSQL SQLSTATE <code>57014</code>、MySQL <code>3024</code>、MariaDB <code>1969</code>）。它回報為 <code>CONN_TIMEOUT</code>，並將 <code>details.connectionCode</code> 設為 <code>STATEMENT_TIMEOUT</code>，這個欄位就是它與真正連線逾時的分辨依據 — 連線是通的，因此計畫針對查詢本身（<code>dbcli lint</code>、<code>dbcli explain</code>，再以明確的 <code>--statement-timeout &lt;ms&gt;</code> 重跑），而不是去跑 <code>doctor</code>。因為步驟 1 不是 <code>doctor</code>，envelope 不會帶 <code>branches</code> 與 <code>branchFork</code>，也不會帶 <code>verify</code> — 這個錯誤除了重跑原語句沒有別的驗證方式，而原語句只有呼叫端有。三個步驟都帶 placeholder，因此 <code>dbcli recover --apply</code> 會回報 <code>skipped-only</code> 且不執行任何指令。</p>
 
             <h3 class="mt-10">Audit ↔ Envelope 反查</h3>
             <ul>

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -1344,6 +1344,8 @@ dbcli recover --next --after-step 2 --result @/tmp/r2.json
 
 若 doctor JSON 無法解析或沒有關鍵字匹配，`--next` 會回落為線性的 `recovery` 計畫 — 分支永遠不會造成 `--next` 失敗。`--apply` 維持線性走訪 `recovery`，不使用 `branches`。
 
+有一種連線類別錯誤**不會**分支：語句因超過 statement timeout 被伺服器取消（PostgreSQL SQLSTATE `57014`、MySQL `3024`、MariaDB `1969`）。它回報為 `CONN_TIMEOUT`，並將 `details.connectionCode` 設為 `STATEMENT_TIMEOUT`，這個欄位就是它與真正連線逾時的分辨依據 — 連線是通的，因此計畫針對查詢本身（`dbcli lint`、`dbcli explain`，再以明確的 `--statement-timeout <ms>` 重跑），而不是去跑 `doctor`。因為步驟 1 不是 `doctor`，envelope 不會帶 `branches` 與 `branchFork`，也不會帶 `verify` — 這個錯誤除了重跑原語句沒有別的驗證方式，而原語句只有呼叫端有。三個步驟都帶 placeholder，因此 `dbcli recover --apply` 會回報 `skipped-only` 且不執行任何指令。
+
 ### Audit ↔ Envelope 反查
 
 每次 `--recovery` 失敗都會雙向寫入對應的 UUID：

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -1660,6 +1660,13 @@ shape (`schemaVersion: 1`):
 Recovery codes (fixed in v1.15.0):
 - `CONFIG_MISSING` — no `.dbcli` config; run `dbcli init`.
 - `CONN_REFUSED` / `CONN_AUTH_FAILED` / `CONN_TIMEOUT` / `CONN_HOST_NOT_FOUND` / `CONN_UNKNOWN` — connection failure variants.
+  `CONN_TIMEOUT` also covers a statement the server canceled for exceeding the statement
+  timeout (PostgreSQL `57014`, MySQL `3024`, MariaDB `1969`); `details.connectionCode` is
+  `STATEMENT_TIMEOUT` there instead of `ETIMEDOUT`, the plan targets the query (`lint` →
+  `explain` → re-run with `--statement-timeout <ms>`) rather than `doctor`, and no
+  `branches` / `branchFork` / `verify` is emitted. PostgreSQL `57014` only counts as a
+  statement timeout when the server says so — a `pg_cancel_backend()` cancel keeps the
+  verbatim `Database error (57014): …` form instead of claiming a ceiling.
 - `PERMISSION_DENIED` — active permission level forbids the operation.
 - `BLACKLIST_TABLE` / `BLACKLIST_COLUMN_WRITE` — blacklist violations.
 - `SNIPPET_NOT_FOUND` / `SNIPPET_AMBIGUOUS` / `SNIPPET_PARAM_MISSING` — saved-query failures.

--- a/src/adapters/error-mapper.ts
+++ b/src/adapters/error-mapper.ts
@@ -22,6 +22,7 @@ type CodedCategory =
   | 'TABLE_NOT_FOUND'
   | 'COLUMN_NOT_FOUND'
   | 'SQL_SYNTAX_ERROR'
+  | 'STATEMENT_TIMEOUT'
 
 /** OS / driver 層級的連線錯誤代碼 */
 const TRANSPORT_CODES: Record<string, CodedCategory> = {
@@ -43,6 +44,10 @@ const MYSQL_CODES: Record<string, CodedCategory> = {
   ER_DBACCESS_DENIED_ERROR: 'AUTH_FAILED',
   ER_NOT_SUPPORTED_AUTH_MODE: 'AUTH_FAILED',
   ER_MUST_CHANGE_PASSWORD_LOGIN: 'AUTH_FAILED',
+  // MySQL 3024 / MariaDB 1969：兩者都只由各自的語句上限觸發，與 KILL QUERY 的
+  // 1317 (ER_QUERY_INTERRUPTED) 不同——後者刻意不列，那是人為中斷不是逾時。
+  ER_QUERY_TIMEOUT: 'STATEMENT_TIMEOUT', // MySQL max_execution_time
+  ER_STATEMENT_TIMEOUT: 'STATEMENT_TIMEOUT', // MariaDB max_statement_time
 }
 
 /** MySQL / MariaDB 的數字 errno（部分 driver 只給數字） */
@@ -54,6 +59,8 @@ const MYSQL_ERRNOS: Record<number, CodedCategory> = {
   1146: 'TABLE_NOT_FOUND',
   1251: 'AUTH_FAILED',
   1698: 'AUTH_FAILED',
+  1969: 'STATEMENT_TIMEOUT', // MariaDB ER_STATEMENT_TIMEOUT
+  3024: 'STATEMENT_TIMEOUT', // MySQL ER_QUERY_TIMEOUT
 }
 
 /** PostgreSQL SQLSTATE */
@@ -63,6 +70,7 @@ const SQLSTATES: Record<string, CodedCategory> = {
   '42601': 'SQL_SYNTAX_ERROR', // syntax_error
   '42P01': 'TABLE_NOT_FOUND', // undefined_table
   '42703': 'COLUMN_NOT_FOUND', // undefined_column
+  '57014': 'STATEMENT_TIMEOUT', // query_canceled — statement_timeout 或人為取消
 }
 
 /** Redis 的錯誤前綴（redis 的錯誤沒有 code 欄位，第一個 token 就是類別） */
@@ -90,6 +98,15 @@ const FALLBACK_PATTERNS: [RegExp, CodedCategory][] = [
   [/password supplied/i, 'AUTH_FAILED'],
 ]
 
+/**
+ * PostgreSQL `57014` is query_canceled, and statement_timeout is only one of its
+ * sources — `pg_cancel_backend()`, a client-side cancel, and a standby recovery
+ * conflict all raise the same SQLSTATE. Postgres separates them in the message,
+ * and the distinction matters: the timeout branch states a ceiling in ms, which
+ * would be a fabricated number for a cancel nobody configured a limit for.
+ */
+const PG_CANCEL_BY_TIMEOUT = /statement timeout/i
+
 function categorize(errCode: string, errno: unknown, errMsg: string): CodedCategory | null {
   if (errCode) {
     const known =
@@ -97,6 +114,14 @@ function categorize(errCode: string, errno: unknown, errMsg: string): CodedCateg
       MYSQL_CODES[errCode] ??
       SQLSTATES[errCode] ??
       REDIS_PREFIXES[errCode]
+    if (
+      known === 'STATEMENT_TIMEOUT' &&
+      errCode === '57014' &&
+      !PG_CANCEL_BY_TIMEOUT.test(errMsg)
+    ) {
+      // 取消但不是逾時：伺服器已經說清楚原因，原樣轉述比套一個類別誠實
+      return null
+    }
     if (known) return known
   }
   if (typeof errno === 'number' && MYSQL_ERRNOS[errno]) return MYSQL_ERRNOS[errno]
@@ -251,6 +276,21 @@ export function mapError(
         'Run `dbcli schema <table>` to see the actual column names',
         'Column names are case-sensitive on some databases (PostgreSQL with quoted identifiers)',
       ])
+    }
+
+    case 'STATEMENT_TIMEOUT': {
+      // 連線是通的，被砍掉的是這道語句——連線疑難排解在這裡是雜訊。
+      const limitMs = options.statementTimeout ?? options.timeout
+      return new ConnectionError(
+        'STATEMENT_TIMEOUT',
+        `Statement timed out${limitMs ? ` (${limitMs}ms)` : ''} — the server canceled this query before it finished`,
+        [
+          'Inspect the query plan: dbcli explain "<sql>"',
+          'Raise the ceiling for this run: dbcli --statement-timeout <ms> … (0 removes it)',
+          'Narrow the query: add WHERE filters, reduce the LIMIT, or index the scanned columns',
+        ],
+        limitMs
+      )
     }
 
     case 'SQL_SYNTAX_ERROR':

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -139,22 +139,31 @@ export interface TableSchema {
 /**
  * Connection error with categorized error code and troubleshooting hints
  */
+export type ConnectionErrorCode =
+  | 'ECONNREFUSED'
+  | 'ETIMEDOUT'
+  | 'AUTH_FAILED'
+  | 'ENOTFOUND'
+  | 'SQL_SYNTAX_ERROR'
+  | 'STATEMENT_TIMEOUT'
+  | 'TABLE_NOT_FOUND'
+  | 'COLUMN_NOT_FOUND'
+  | 'UNKNOWN'
+
 export class ConnectionError extends Error {
   constructor(
     /** Error category code */
-    public code:
-      | 'ECONNREFUSED'
-      | 'ETIMEDOUT'
-      | 'AUTH_FAILED'
-      | 'ENOTFOUND'
-      | 'SQL_SYNTAX_ERROR'
-      | 'TABLE_NOT_FOUND'
-      | 'COLUMN_NOT_FOUND'
-      | 'UNKNOWN',
+    public code: ConnectionErrorCode,
     /** User-friendly error message */
     message: string,
     /** Array of actionable troubleshooting hints */
-    public hints: string[]
+    public hints: string[],
+    /**
+     * The ceiling that was in force, in milliseconds. Set on STATEMENT_TIMEOUT so
+     * consumers can state it without parsing `message`; the recovery envelope needs
+     * it to tell an agent what `--statement-timeout <ms>` it was already up against.
+     */
+    public limitMs?: number
   ) {
     super(message)
     this.name = 'ConnectionError'

--- a/src/core/recovery/classify.ts
+++ b/src/core/recovery/classify.ts
@@ -8,6 +8,7 @@ import { buildConnectionBranches } from './connection-branches'
 import {
   RECOVERY_CODE_METADATA,
   RECOVERY_SCHEMA_VERSION,
+  STATEMENT_TIMEOUT_CODE,
   SchemaCacheMissingError,
   type RecoveryCode,
   type RecoveryContext,
@@ -20,8 +21,13 @@ export function classifyError(error: unknown, ctx: RecoveryContext): RecoveryEnv
   const ctxWithDetails = applyDetailsToContext(ctx, recoveryError)
   const recovery = stepsForCode(recoveryError.code, ctxWithDetails)
   const verify = verifyForCode(recoveryError.code, ctxWithDetails)
+  // 分支計畫的 branchFork.after = 1 指的是「跑完第 1 步 doctor 之後」。語句逾時
+  // 的計畫第 1 步不是 doctor，掛上這組分支等於要 agent 依一個沒跑過的結果選路。
   const branchExtras =
-    recoveryError.category === 'connection' ? buildConnectionBranches(ctxWithDetails) : null
+    recoveryError.category === 'connection' &&
+    ctxWithDetails.connectionCode !== STATEMENT_TIMEOUT_CODE
+      ? buildConnectionBranches(ctxWithDetails)
+      : null
   return {
     schemaVersion: RECOVERY_SCHEMA_VERSION,
     generatedAt: new Date().toISOString(),
@@ -69,14 +75,27 @@ function classifyConnection(err: ConnectionError): RecoveryError {
   const code: RecoveryCode =
     err.code === 'ECONNREFUSED'
       ? 'CONN_REFUSED'
-      : err.code === 'ETIMEDOUT'
-        ? 'CONN_TIMEOUT'
+      : err.code === 'ETIMEDOUT' || err.code === STATEMENT_TIMEOUT_CODE
+        ? // 語句逾時共用 CONN_TIMEOUT，避免為它加一個 code 而動到 schemaVersion；
+          // details.connectionCode 是兩者的分辨依據，步驟庫據此給不同的計畫。
+          'CONN_TIMEOUT'
         : err.code === 'AUTH_FAILED'
           ? 'CONN_AUTH_FAILED'
           : err.code === 'ENOTFOUND'
             ? 'CONN_HOST_NOT_FOUND'
             : 'CONN_UNKNOWN'
-  return baseError(code, { connectionCode: err.code })
+  const base = baseError(code, { connectionCode: err.code })
+  if (err.code === STATEMENT_TIMEOUT_CODE) {
+    // CONN_TIMEOUT 的靜態描述講的是網路，對「連線正常但語句被伺服器取消」是誤導。
+    // 覆寫成固定字串加上一個毫秒數——數字不是 host / port / SQL / 憑證，沒有洩漏，
+    // 而少了它 agent 無從得知計畫裡的 `--statement-timeout <ms>` 該填多少。
+    const ceiling = err.limitMs !== undefined ? ` The ceiling in force was ${err.limitMs}ms.` : ''
+    return {
+      ...base,
+      message: `The server canceled the statement for exceeding the statement timeout.${ceiling}`,
+    }
+  }
+  return base
 }
 
 function classifyBlacklist(err: BlacklistError): RecoveryError {
@@ -138,5 +157,6 @@ function applyDetailsToContext(ctx: RecoveryContext, err: RecoveryError): Recove
     table: err.details?.table ?? ctx.table,
     snippet: err.details?.snippet ?? ctx.snippet,
     hint: err.details?.paramName ?? ctx.hint,
+    connectionCode: err.details?.connectionCode ?? ctx.connectionCode,
   }
 }

--- a/src/core/recovery/recovery-steps.ts
+++ b/src/core/recovery/recovery-steps.ts
@@ -1,5 +1,5 @@
 import type { GuideStep } from '@/core/guide/types'
-import type { RecoveryCode, RecoveryContext } from './types'
+import { STATEMENT_TIMEOUT_CODE, type RecoveryCode, type RecoveryContext } from './types'
 import { shellQuote } from './shell-quote'
 
 /** Hard cap on emitted recovery steps; prevents drowning agents in suggestions. */
@@ -43,6 +43,41 @@ function dryRunStepForWrite(
   return draft
 }
 
+/**
+ * Plan for a statement the server canceled (PostgreSQL 57014, MySQL 3024,
+ * MariaDB 1969). The connection is healthy, so the plan works on the query:
+ * an offline static read first, then the plan, then a re-run with a raised
+ * ceiling. All three carry `<sql>` placeholders — the agent supplies the
+ * statement it just lost, and `--apply` skips them rather than running blind.
+ */
+function statementTimeoutSteps(): StepDraft[] {
+  return [
+    {
+      command: 'dbcli lint "<sql>"',
+      rationale:
+        'Static anti-pattern read of the statement; needs no connection, so it cannot time out in turn.',
+      risk: 'readonly',
+      expects: 'Findings with rewrite drafts, or an empty list when nothing is flagged.',
+      placeholders: ['<sql>'],
+    },
+    {
+      command: 'dbcli explain "<sql>"',
+      rationale: 'Read the query plan to find the scan or join that exceeded the statement limit.',
+      risk: 'readonly',
+      expects: 'Annotated query plan; look for sequential scans and unindexed joins.',
+      placeholders: ['<sql>'],
+    },
+    {
+      command: 'dbcli --statement-timeout <ms> query "<sql>"',
+      rationale:
+        'Re-run with an explicit ceiling once the cost is understood; 0 removes the limit entirely.',
+      risk: 'readonly',
+      expects: 'Query result, or the same timeout if <ms> is still below what the plan costs.',
+      placeholders: ['<ms>', '<sql>'],
+    },
+  ]
+}
+
 export function stepsForCode(code: RecoveryCode, ctx: RecoveryContext): GuideStep[] {
   const drafts = draftsForCode(code, ctx)
   return drafts.slice(0, MAX_RECOVERY_STEPS).map((d, i) => ({ ...d, order: i + 1 }))
@@ -70,6 +105,11 @@ function draftsForCode(code: RecoveryCode, ctx: RecoveryContext): StepDraft[] {
     case 'CONN_REFUSED':
     case 'CONN_TIMEOUT':
     case 'CONN_UNKNOWN': {
+      // 語句逾時共用 CONN_TIMEOUT，但連線是通的——doctor / inspect 只會把方向帶偏。
+      // classifyConnection 保證它只映到 CONN_TIMEOUT，這裡照樣收窄到那一碼。
+      if (code === 'CONN_TIMEOUT' && ctx.connectionCode === STATEMENT_TIMEOUT_CODE) {
+        return statementTimeoutSteps()
+      }
       const out: StepDraft[] = [
         {
           command: 'dbcli doctor --format json',

--- a/src/core/recovery/types.ts
+++ b/src/core/recovery/types.ts
@@ -1,4 +1,5 @@
 import type { GuideStep } from '@/core/guide/types'
+import type { ConnectionErrorCode } from '@/adapters/types'
 
 /** Stable contract version for RecoveryEnvelope JSON. Bump on breaking shape change. */
 export const RECOVERY_SCHEMA_VERSION = 1 as const
@@ -56,7 +57,7 @@ export interface RecoveryError {
     table?: string
     columns?: string
     requiredPermission?: string
-    connectionCode?: string
+    connectionCode?: ConnectionErrorCode
     snippet?: string
     intent?: string
     paramName?: string
@@ -125,7 +126,20 @@ export interface RecoveryContext {
    * inspecting it.
    */
   writeOperation?: 'INSERT' | 'UPDATE' | 'DELETE'
+  /**
+   * Adapter-level ConnectionError code, promoted from `error.details.connectionCode`
+   * by the classifier. Lets the step library separate causes that share a recovery
+   * code — `STATEMENT_TIMEOUT` vs a real `ETIMEDOUT`, both reported as CONN_TIMEOUT.
+   */
+  connectionCode?: ConnectionErrorCode
 }
+
+/**
+ * The one connection code that changes which plan a shared RecoveryCode emits.
+ * Named rather than compared inline: a typo in the string would silently fall
+ * back to the connection plan, and that comparison is the whole fork.
+ */
+export const STATEMENT_TIMEOUT_CODE = 'STATEMENT_TIMEOUT' as const satisfies ConnectionErrorCode
 
 /**
  * Sentinel error thrown when a caller needs a cached table schema but the

--- a/src/core/recovery/verify-steps.ts
+++ b/src/core/recovery/verify-steps.ts
@@ -1,5 +1,5 @@
 import type { GuideStep } from '@/core/guide/types'
-import type { RecoveryCode, RecoveryContext } from './types'
+import { STATEMENT_TIMEOUT_CODE, type RecoveryCode, type RecoveryContext } from './types'
 
 /**
  * Per-RecoveryCode verifier step appended to the envelope.
@@ -10,6 +10,9 @@ import type { RecoveryCode, RecoveryContext } from './types'
  * - Never `interactive: true`.
  * - argv must be allowlisted under classifyArgvForCode for the same code.
  * - `order: 0` is a sentinel meaning "verify, not part of the main plan".
+ *
+ * One context-dependent exception: a statement timeout shares CONN_TIMEOUT but has
+ * no verifier that does not re-run the caller's own query, so it gets none.
  */
 
 const VERIFY_COMMAND_BY_CODE: Record<RecoveryCode, string> = {
@@ -63,7 +66,11 @@ const VERIFY_EXPECTS_BY_CODE: Record<RecoveryCode, string> = {
   UNKNOWN: 'JSON doctor report.',
 }
 
-export function verifyForCode(code: RecoveryCode, _ctx: RecoveryContext): GuideStep | null {
+export function verifyForCode(code: RecoveryCode, ctx: RecoveryContext): GuideStep | null {
+  // 語句逾時共用 CONN_TIMEOUT，但 doctor 驗證的是連線——連線從來沒壞，它會在查詢
+  // 仍然逾時的情況下回報 passed。這個錯誤沒有「不重跑原查詢就能驗證」的辦法，而原
+  // 查詢只有 agent 手上有，所以誠實的答案是不給 verify。
+  if (ctx.connectionCode === STATEMENT_TIMEOUT_CODE) return null
   const command = VERIFY_COMMAND_BY_CODE[code]
   if (!command) return null
   return {

--- a/tests/integration/adapters/mysql.test.ts
+++ b/tests/integration/adapters/mysql.test.ts
@@ -198,7 +198,9 @@ describe('MySQL statement timeout', () => {
     await adapter.connect()
     const started = Date.now()
     try {
-      await expect(adapter.execute(SLOW_QUERY)).rejects.toThrow(/interrupted|timeout/i)
+      // driver 的 ER_QUERY_TIMEOUT (3024) 會被 error-mapper 轉成 STATEMENT_TIMEOUT，
+      // 訊息是分類後的說法而非 driver 原文。
+      await expect(adapter.execute(SLOW_QUERY)).rejects.toThrow(/statement timed out/i)
       expect(Date.now() - started).toBeLessThan(10_000)
     } finally {
       await adapter.disconnect()

--- a/tests/integration/adapters/postgresql.test.ts
+++ b/tests/integration/adapters/postgresql.test.ts
@@ -185,7 +185,13 @@ describe('PostgreSQL statement timeout', () => {
     const adapter = new PostgreSQLAdapter({ ...validOptions, statementTimeout: 500 })
     await adapter.connect()
     try {
-      await expect(adapter.execute('SELECT pg_sleep(3)')).rejects.toThrow()
+      // 伺服器回的是 SQLSTATE 57014，error-mapper 要把它分類成 STATEMENT_TIMEOUT
+      // 而非連線問題——這條是該分類唯一的實機證據。
+      const thrown = await adapter.execute('SELECT pg_sleep(3)').catch((e: unknown) => e)
+      expect(thrown).toBeInstanceOf(ConnectionError)
+      expect((thrown as ConnectionError).code).toBe('STATEMENT_TIMEOUT')
+      expect((thrown as ConnectionError).limitMs).toBe(500)
+      expect((thrown as ConnectionError).hints.join(' ')).not.toContain('ping')
     } finally {
       await adapter.disconnect()
     }

--- a/tests/unit/adapters/error-mapper.test.ts
+++ b/tests/unit/adapters/error-mapper.test.ts
@@ -265,7 +265,8 @@ test('mapError: 訊息含 "timeout" 但帶查詢 code 時不被判成連線逾�
   const error = { code: '57014', message: 'canceling statement due to statement timeout' }
   const result = mapError(error, 'postgresql', mockOptions)
   expect(result.code).not.toBe('ECONNREFUSED')
-  expect(result.message).toContain('statement timeout')
+  expect(result.code).not.toBe('ETIMEDOUT')
+  expect(result.message).toMatch(/statement timed out/i)
 })
 
 test('mapError: 無 code 時字串後備需完整詞組，"user" 不足以判成認證失敗', () => {
@@ -282,4 +283,96 @@ test('mapError: 無 code 時 "authentication failed" 仍判成 AUTH_FAILED', () 
 test('mapError: pg 連線池的 "timeout exceeded" 沒有 code，仍分類為 ETIMEDOUT', () => {
   const error = { message: 'timeout exceeded when trying to connect' }
   expect(mapError(error, 'postgresql', mockOptions).code).toBe('ETIMEDOUT')
+})
+
+test('mapError: MySQL ER_QUERY_TIMEOUT (3024) 與 MariaDB 1969 同樣是語句逾時', () => {
+  const mysqlOptions: ConnectionOptions = { ...mockOptions, system: 'mysql', port: 3306 }
+
+  const byCode = mapError(
+    { code: 'ER_QUERY_TIMEOUT', errno: 3024, message: 'Query execution was interrupted' },
+    'mysql',
+    mysqlOptions
+  )
+  expect(byCode.code).toBe('STATEMENT_TIMEOUT')
+
+  // 部分 driver 只給數字 errno
+  const byErrno = mapError(
+    { errno: 3024, message: 'Query execution was interrupted' },
+    'mysql',
+    mysqlOptions
+  )
+  expect(byErrno.code).toBe('STATEMENT_TIMEOUT')
+
+  const mariadb = mapError(
+    { errno: 1969, message: 'Query execution was interrupted (max_statement_time exceeded)' },
+    'mariadb',
+    { ...mysqlOptions, system: 'mariadb' }
+  )
+  expect(mariadb.code).toBe('STATEMENT_TIMEOUT')
+})
+
+test('mapError: 語句逾時訊息帶出實際生效的上限值', () => {
+  const result = mapError(
+    { code: '57014', message: 'canceling statement due to statement timeout' },
+    'postgresql',
+    { ...mockOptions, statementTimeout: 800 }
+  )
+
+  expect(result.message).toContain('800ms')
+})
+
+test('mapError: pg SQLSTATE 57014 是語句被取消，不是連線問題', () => {
+  const error = { code: '57014', message: 'canceling statement due to statement timeout' }
+  const result = mapError(error, 'postgresql', mockOptions)
+
+  expect(result.code).toBe('STATEMENT_TIMEOUT')
+  expect(result.hints.join(' ')).toContain('--statement-timeout')
+  // 連線是通的，連線疑難排解在這裡只會把方向帶偏
+  expect(result.hints.join(' ')).not.toContain('doctor')
+  expect(result.hints.join(' ')).not.toContain('ping')
+})
+
+test('mapError: 57014 但不是逾時（pg_cancel_backend）不冒充語句逾時', () => {
+  const result = mapError(
+    { code: '57014', message: 'canceling statement due to user request' },
+    'postgresql',
+    { ...mockOptions, statementTimeout: 5000 }
+  )
+
+  expect(result.code).not.toBe('STATEMENT_TIMEOUT')
+  // 沒有逾時就沒有上限值可言——編一個具體毫秒數是憑空斷言
+  expect(result.message).not.toContain('5000ms')
+  expect(result.message).toContain('57014')
+})
+
+test('mapError: 57014 因 recovery conflict 取消同樣不算語句逾時', () => {
+  const result = mapError(
+    { code: '57014', message: 'canceling statement due to conflict with recovery' },
+    'postgresql',
+    mockOptions
+  )
+
+  expect(result.code).not.toBe('STATEMENT_TIMEOUT')
+})
+
+test('mapError: 未設 statementTimeout 時，訊息用實際生效的連線逾時值', () => {
+  const result = mapError(
+    { code: '57014', message: 'canceling statement due to statement timeout' },
+    'postgresql',
+    { ...mockOptions, timeout: 4000 }
+  )
+
+  expect(result.message).toContain('4000ms')
+  expect(result.limitMs).toBe(4000)
+})
+
+test('mapError: statementTimeout 為 0（取消上限）不印出 (0ms)', () => {
+  const result = mapError(
+    { code: '57014', message: 'canceling statement due to statement timeout' },
+    'postgresql',
+    { ...mockOptions, timeout: 5000, statementTimeout: 0 }
+  )
+
+  expect(result.message).not.toContain('0ms')
+  expect(result.message).not.toContain('5000ms')
 })

--- a/tests/unit/core/recovery/__snapshots__/connection-envelopes.snap.test.ts.snap
+++ b/tests/unit/core/recovery/__snapshots__/connection-envelopes.snap.test.ts.snap
@@ -792,3 +792,52 @@ exports[`connection envelopes — snapshots CONN_UNKNOWN 1`] = `
   },
 }
 `;
+
+exports[`connection envelopes — snapshots CONN_TIMEOUT — statement timeout variant 1`] = `
+{
+  "error": {
+    "category": "connection",
+    "code": "CONN_TIMEOUT",
+    "details": {
+      "connectionCode": "STATEMENT_TIMEOUT",
+    },
+    "message": "The server canceled the statement for exceeding the statement timeout. The ceiling in force was 800ms.",
+  },
+  "generatedAt": "__stripped__",
+  "ok": false,
+  "recovery": [
+    {
+      "command": "dbcli lint "<sql>"",
+      "expects": "Findings with rewrite drafts, or an empty list when nothing is flagged.",
+      "order": 1,
+      "placeholders": [
+        "<sql>",
+      ],
+      "rationale": "Static anti-pattern read of the statement; needs no connection, so it cannot time out in turn.",
+      "risk": "readonly",
+    },
+    {
+      "command": "dbcli explain "<sql>"",
+      "expects": "Annotated query plan; look for sequential scans and unindexed joins.",
+      "order": 2,
+      "placeholders": [
+        "<sql>",
+      ],
+      "rationale": "Read the query plan to find the scan or join that exceeded the statement limit.",
+      "risk": "readonly",
+    },
+    {
+      "command": "dbcli --statement-timeout <ms> query "<sql>"",
+      "expects": "Query result, or the same timeout if <ms> is still below what the plan costs.",
+      "order": 3,
+      "placeholders": [
+        "<ms>",
+        "<sql>",
+      ],
+      "rationale": "Re-run with an explicit ceiling once the cost is understood; 0 removes the limit entirely.",
+      "risk": "readonly",
+    },
+  ],
+  "schemaVersion": 1,
+}
+`;

--- a/tests/unit/core/recovery/classify-branches.test.ts
+++ b/tests/unit/core/recovery/classify-branches.test.ts
@@ -47,3 +47,17 @@ describe('classifyError — non-connection codes do NOT emit branches', () => {
     expect(env.branchFork).toBeUndefined()
   })
 })
+
+describe('classifyError — 語句逾時不掛 doctor 分支', () => {
+  test('STATEMENT_TIMEOUT 不發 branches/branchFork', () => {
+    const env = classifyError(new ConnectionError('STATEMENT_TIMEOUT', 'timed out', []), {
+      operation: 'query',
+      system: 'postgresql',
+    })
+
+    // branchFork.after 指的是「跑完第 1 步 doctor 之後」；語句逾時的第 1 步不是
+    // doctor，掛上這組分支等於叫 agent 依一個沒跑過的結果選路。
+    expect(env.branches).toBeUndefined()
+    expect(env.branchFork).toBeUndefined()
+  })
+})

--- a/tests/unit/core/recovery/classify.test.ts
+++ b/tests/unit/core/recovery/classify.test.ts
@@ -180,3 +180,73 @@ describe('classifyError populates envelope.verify', () => {
     expect(env.verify).toBeDefined()
   })
 })
+
+describe('classifyError — 語句逾時', () => {
+  test('STATEMENT_TIMEOUT 走 CONN_TIMEOUT，但復原步驟針對查詢而非連線', () => {
+    const err = new ConnectionError('STATEMENT_TIMEOUT', 'Statement timed out (800ms)', [])
+    const env = classifyError(err, { operation: 'query', system: 'postgresql' })
+
+    expect(env.schemaVersion).toBe(1)
+    expect(env.error.code).toBe('CONN_TIMEOUT')
+    expect(env.error.details?.connectionCode).toBe('STATEMENT_TIMEOUT')
+
+    const commands = env.recovery.map((s) => s.command).join(' | ')
+    expect(commands).toContain('dbcli explain')
+    expect(commands).toContain('--statement-timeout')
+    // 連線是通的，doctor / init 在這裡只會把 agent 帶錯方向
+    expect(commands).not.toContain('dbcli doctor')
+    expect(commands).not.toContain('dbcli init')
+  })
+
+  test('真正的連線逾時仍然拿到連線疑難排解步驟', () => {
+    const err = new ConnectionError('ETIMEDOUT', 'Connection timed out', [])
+    const env = classifyError(err, { operation: 'query', system: 'postgresql' })
+
+    expect(env.error.code).toBe('CONN_TIMEOUT')
+    expect(env.recovery.map((s) => s.command).join(' | ')).toContain('dbcli doctor')
+  })
+})
+
+describe('classifyError — 語句逾時的 message', () => {
+  test('不沿用 CONN_TIMEOUT 的「網路慢或被擋」描述', () => {
+    const env = classifyError(new ConnectionError('STATEMENT_TIMEOUT', 'timed out (800ms)', []), {
+      operation: 'query',
+      system: 'postgresql',
+    })
+
+    expect(env.error.message).not.toBe(RECOVERY_CODE_METADATA.CONN_TIMEOUT.description)
+    expect(env.error.message).toMatch(/statement/i)
+    // 訊息仍不得帶出 host / port / SQL
+    expect(env.error.message).not.toContain('pg_sleep')
+    expect(env.error.message).not.toContain('localhost')
+  })
+})
+
+describe('classifyError — 語句逾時的 envelope 整體不叫人跑 doctor', () => {
+  test('recovery、verify、branches 都不含 doctor', () => {
+    const env = classifyError(new ConnectionError('STATEMENT_TIMEOUT', 'timed out (800ms)', []), {
+      operation: 'query',
+      system: 'postgresql',
+    })
+
+    // 對整個 envelope 斷言：只看 recovery 會讓 verify 夾帶的 doctor 溜過去
+    expect(JSON.stringify(env)).not.toContain('dbcli doctor')
+  })
+})
+
+describe('classifyError — 語句逾時的上限值', () => {
+  test('envelope 的 message 帶出當時生效的上限，agent 才知道 <ms> 要填多少', () => {
+    const err = new ConnectionError('STATEMENT_TIMEOUT', 'Statement timed out (800ms)', [], 800)
+    const env = classifyError(err, { operation: 'query', system: 'postgresql' })
+
+    expect(env.error.message).toContain('800')
+  })
+
+  test('沒有上限值時不編一個出來', () => {
+    const err = new ConnectionError('STATEMENT_TIMEOUT', 'Statement timed out', [])
+    const env = classifyError(err, { operation: 'query', system: 'postgresql' })
+
+    expect(env.error.message).toMatch(/statement/i)
+    expect(env.error.message).not.toMatch(/\d+\s*ms/)
+  })
+})

--- a/tests/unit/core/recovery/connection-envelopes.snap.test.ts
+++ b/tests/unit/core/recovery/connection-envelopes.snap.test.ts
@@ -54,4 +54,15 @@ describe('connection envelopes — snapshots', () => {
       })
     ).toMatchSnapshot()
   })
+
+  // 語句逾時共用 CONN_TIMEOUT，但整個 envelope 的形狀不同：計畫針對查詢、沒有
+  // verify、沒有 branches。這張快照就是那三點的釘樁。
+  test('CONN_TIMEOUT — statement timeout variant', () => {
+    expect(
+      stableEnvelope(
+        () => new ConnectionError('STATEMENT_TIMEOUT', 'statement timed out (800ms)', [], 800),
+        { operation: 'query' }
+      )
+    ).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
兩個相鄰的錯誤分類缺陷，第二個是在第一個的 code review 中發現的。closes #61

---

# 1. 語句逾時被歸類為連線錯誤

## 問題

一條查詢超過語句上限被伺服器取消時，dbcli 會說連線壞了。

PostgreSQL SQLSTATE `57014`、MySQL `3024` (`ER_QUERY_TIMEOUT`)、MariaDB `1969` (`ER_STATEMENT_TIMEOUT`) 在 `error-mapper.ts` 都沒有對應，落到 `UNKNOWN`，再經 `classify.ts` 變成 `CONN_UNKNOWN`。實測（PG 16 / MySQL 8.4）：

```
$ dbcli --statement-timeout 800 query "SELECT pg_sleep(8)" --recovery
"code": "CONN_UNKNOWN", "category": "connection"
recovery[1]: dbcli doctor --format json   ← 檢查網路與 driver
recovery[2]: dbcli inspect --no-connect   ← 比對 host/port
```

連線從頭到尾是通的，被砍掉的是那道語句。這是 v1.54.0 兩項改動的交界處：新增了 `--statement-timeout` 這個錯誤來源，錯誤分類沒跟上。

## 改動

**adapter 層**新增 `STATEMENT_TIMEOUT` 分類，提示指向查詢本身（`dbcli explain`、調高上限、縮小掃描範圍）。

`57014` 是 `query_canceled` 而不只是 `statement_timeout`——`pg_cancel_backend()`、client 取消、standby recovery conflict 都回同一個 SQLSTATE。只有伺服器訊息確認是逾時才進這個分類，其餘維持 `Database error (57014): …` 的原樣轉述，不宣稱一個沒人設過的毫秒數。MySQL / MariaDB 兩碼只由各自的語句上限觸發，`1317` (`ER_QUERY_INTERRUPTED`, KILL QUERY) 刻意不列。

**envelope** 沿用既有的 `CONN_TIMEOUT`、`schemaVersion` 維持 1（`RECOVERY_CODES` 新增值依 `types.ts` 的規定要 bump schemaVersion，會影響已接 v1 的 agent），以 `details.connectionCode` 分辨：

```json
{ "code": "CONN_TIMEOUT",
  "details": { "connectionCode": "STATEMENT_TIMEOUT" },
  "message": "The server canceled the statement for exceeding the statement timeout. The ceiling in force was 800ms.",
  "recovery": ["dbcli lint \"<sql>\"", "dbcli explain \"<sql>\"", "dbcli --statement-timeout <ms> query \"<sql>\""] }
```

同時抑制兩樣東西：`doctor-*` 分支（`branchFork.after: 1` 的語意是「跑完第 1 步 doctor 之後」，而第 1 步已不是 doctor），以及 `verify`（這個錯誤除了重跑原語句沒有別的驗證方式，而原語句只有呼叫端有；`verify-heuristic` 的 `default: 'passed'` 會讓 doctor exit 0 在查詢仍然逾時的情況下回報「已修復」）。

`ConnectionError` 新增可選的 `limitMs`，讓 envelope 能說出當時生效的上限而不必回頭解析自己的訊息字串。

---

# 2. 錯誤措辭一律說「無法連接到資料庫」(#61)

## 問題

上面的修正只有讀 `--recovery` envelope 的 agent 受益。一般使用者跑 `insert` 看到的是：

```
Failed to connect to database: Statement timed out (500ms) — the server canceled this query before it finished
```

`insert` / `update` / `delete` / `q` 都用 `instanceof ConnectionError` 判斷後套同一個 i18n key，但 `ConnectionError` 是 adapter 層所有錯誤的載體，九個 code 裡只有四個是傳輸層失敗。`TABLE_NOT_FOUND`、`SQL_SYNTAX_ERROR` 也一樣被冠上連線失敗。`query` 沒有這個問題——它往上拋給集中的 presenter。

## 改動

新增 `presentConnectionError()` 依 code 挑 message key，回傳 `CliErrorPresentation` 交給既有的 `formatCliError` 排版。這四條路徑先前走的 `printLocalizedCliError` 只印訊息，`Code:` 行與 hints 全被吞掉：

```
改動前：Failed to connect to database: Table 'nonexistent_table' not found in database 'dbcli_test'
        （完整輸出，沒有第二行）

改動後：Error: Table 'nonexistent_table' not found in database 'dbcli_test'
        Code: TABLE_NOT_FOUND
        Hint: Run `dbcli list` to see available tables
        Hint: Run `dbcli schema <table>` to confirm the exact name …
```

分類表寫成涵蓋整個 `ConnectionErrorCode` union 的 `Record`，日後新增 code 不補就編不過——這個分類是使用者看到哪句話的唯一依據。`init` / `init-mongodb` 沿用原 key，那兩處確實在建立連線。

---

## Test plan

- `bun test` — 5080 pass / 0 fail（docker 容器起著跑，integration 未被 skip）
- `bun run typecheck` / `lint` / `format:check` — 綠
- `docs:check` / `contract:check` / `skill:check` / `platform:check` / `plugin:check` / `agent-core:check` — 綠
- 端對端實跑 PG 16 真實 57014 與 MySQL 8.4 真實 3024（後者用三重 `information_schema` join 觸發，避開 `SLEEP()` 被中斷回傳 1 而非報錯的語意）
- 新增測試：57014 的逾時 / 非逾時兩條路徑、MySQL 具名 code 與純 errno 兩種 driver 形狀、MariaDB 1969、`limitMs` 的兩個邊界、envelope 整體不含 doctor、statement-timeout envelope 快照、code → message key 的完整 union 覆蓋、四個寫入命令的接線與反方向
- 新的整合測試已驗證移除修正後會紅（stash `insert.ts` 重跑）
- 收緊兩條既有整合測試：PG 那條原本只有空的 `rejects.toThrow()`，MySQL 那條原本釘 driver 原文

## 已知取捨與後續

- `dbcli recovery --code CONN_TIMEOUT` 的查表視圖只呈現得出連線那份計畫（查表模式建的 context 沒有 `connectionCode` 入口）。這是重用 code 換掉 schemaVersion bump 的直接代價。
- #62：`ECONNRESET`、`EPIPE`、PG `08006`、MySQL `1040` 等真正的傳輸層錯誤沒進 `TRANSPORT_CODES`，會停在 `UNKNOWN`。在本 PR 之後它們會被歸到語句側，優先度比原本高，但正確的修法在 `error-mapper.ts` 的表，不該靠特例化 `UNKNOWN`。

🤖 Generated with Claude Code