### PR TITLE
refactor: core 不再寫 stdout，呈現與確認移到指令層

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Agent core purity
         run: bun run agent-core:check
 
+      - name: Core writes no stdout
+        run: bun run core-stdout:check
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/docs/adr/0009-core-does-not-write-to-stdout.md
+++ b/docs/adr/0009-core-does-not-write-to-stdout.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+date: 2026-08-14
+---
+
+# Core does not write to stdout
+
+`DataExecutor.executeMutation` printed the generated SQL and its parameters with
+`console.log`, then called `promptUser.confirm` — inside `src/core`. Two consequences,
+neither of them cosmetic.
+
+The first is that a module whose job is to execute a statement could block on stdin. A
+library consumer importing the published `./core` subpath got an interactive prompt it
+never asked for, and `dist/core.mjs` shipped a real `import("@inquirer/prompts")` to make
+that possible.
+
+The second is the one that matters for what comes next. `dbcli update` and `dbcli delete`
+emit a JSON envelope that agents parse. The confirmation block was written to the same
+stdout, immediately before it. Anything core decided to print landed in the machine's
+input stream, and the only thing keeping the two apart was that core happened to print
+little. The upcoming interactive ceremony work would have made core print a great deal
+more.
+
+Measured before the change: 17 of 228 modules under `src/core` wrote to stdout or stderr,
+about 40 call sites in total. 93% of core was already clean.
+
+## Decision
+
+Modules under `src/core` do not write to stdout or stderr. Core reports what happened as
+structured data; the command layer decides how — and whether — to say it.
+
+`DataExecutionOptions` gained a `confirm` callback. Core assembles a
+`MutationConfirmationRequest` describing the pending mutation and asks the caller;
+`src/commands/mutation-confirm.ts` holds the CLI's implementation, which reproduces the
+previous output byte for byte. When a mutation would execute unconfirmed and no handler
+was supplied, core throws rather than defaulting: proceeding silently and declining
+silently are both worse than saying nobody was available to ask.
+
+`scripts/check-core-no-stdout.ts` enforces this in CI, mirroring the existing agent-core
+purity gate. The 16 modules that predate the rule sit in `CORE_STDOUT_EXCEPTIONS`, a
+ratchet rather than an amnesty: a contract test fails if a listed module no longer
+violates, so cleaning one forces its line to be deleted, and the list can only shrink.
+`data-executor.ts` is deliberately not on it.
+
+Detection is textual, like its sibling gate. It catches `console.*`, `process.std*.write`,
+`writeSync` on a literal fd 1 or 2 — `src/core/recovery/emit.ts` already writes fd 1
+directly, on purpose, to survive a pipe truncated by `process.exit` on Windows — and
+`Bun.write` targeting `Bun.stdout`. An aliased write (`const c = console`) slips past. The
+gate guards against drift by ordinary edits, not against deliberate circumvention, and an
+AST pass would cost more than that buys.
+
+## Why record this
+
+The obvious reading of this rule is tidiness, and tidiness is negotiable under deadline.
+It is not tidiness. It is what makes "ceremony cannot pollute the agent-facing output" a
+structural fact instead of a habit: core has no way to reach stdout, so no amount of
+presentation work in core can leak into a parsed stream. A later contributor who adds one
+`console.log` to a core module "just for debugging" is not making a small mess, they are
+removing the guarantee.
+
+The cheaper-looking alternative — leaving the existing 17 modules alone and only forbidding
+new writes in the files being touched — was rejected because a gate that does not cover
+future core modules is not a gate. The more thorough alternative — cleaning all 40 call
+sites now — was rejected because it turns a scoped change into a 17-file refactor. The
+ratchet gets the boundary today and the cleanup incrementally, and it is a long-term
+arrangement rather than a stopgap: the end state is an empty exception list, reached one
+deletion at a time.
+
+`tests/unit/build/inquirer-shipping-contract.test.ts` carries the artifact-level half.
+`dist/core.mjs` used to be required to import `@inquirer/prompts`; it is now required not
+to reference it at all, so the removed edge cannot reappear unnoticed.
+
+**Falsified if:** a module under `src/core/**` writes to stdout or stderr without
+appearing in `CORE_STDOUT_EXCEPTIONS` in `scripts/check-core-no-stdout.ts`, or that list
+grows, or `.github/workflows/ci.yml` stops running the gate, or `dist/core.mjs` regains a
+reference to `@inquirer/prompts`.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "skill:check": "bun run scripts/check-skill-parity.ts",
     "platform:check": "bun run scripts/check-platform-parity.ts",
     "agent-core:check": "bun run scripts/check-agent-core-purity.ts",
+    "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "test:perf": "bun test ./tests/perf/*.bench.ts",
     "lint": "eslint src tests scripts --ext .ts --max-warnings=0",

--- a/scripts/check-core-no-stdout.ts
+++ b/scripts/check-core-no-stdout.ts
@@ -1,0 +1,116 @@
+/**
+ * Gate: modules under src/core must not write to stdout or stderr.
+ *
+ * Core decides *what* happened; the command layer decides how to say it. Once
+ * core cannot reach stdout at all, presentation concerns — colour, ceremony,
+ * prompts — are structurally incapable of leaking into the machine-readable
+ * output that agents parse. That guarantee is the point; the tidier layering
+ * is a side effect.
+ *
+ * CORE_STDOUT_EXCEPTIONS is a ratchet, not an amnesty. Every entry is a module
+ * that predates the rule. The list may shrink and never grow: a contract test
+ * fails if an entry no longer violates (clean it, then delete the line), and
+ * this script fails if a module outside the list violates.
+ *
+ * Detection is textual, matching the sibling agent-core purity gate. A write
+ * spelled through an alias (`const c = console; c.log(...)`) slips past, and a
+ * string literal containing `console.log(` false-positives. Both are accepted:
+ * the gate guards against drift by ordinary edits, not against deliberate
+ * circumvention, and an AST pass would cost more than that buys.
+ */
+
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = new URL('../src/core/', import.meta.url)
+const rootPath = fileURLToPath(root)
+
+/**
+ * Modules that wrote to stdout before this gate existed.
+ *
+ * Paths are relative to src/core, forward-slashed. Only ever remove entries.
+ */
+export const CORE_STDOUT_EXCEPTIONS: readonly string[] = [
+  'atomic-writer.ts',
+  'audit/logger.ts',
+  'audit/reader.ts',
+  'blacklist-manager.ts',
+  'blacklist-validator.ts',
+  'config.ts',
+  'error-recovery.ts',
+  'index.ts',
+  'mongo/field-masker.ts',
+  'query-executor.ts',
+  'recovery/emit.ts',
+  'repl/repl-engine.ts',
+  'saved-queries/loader.ts',
+  'schema-cache.ts',
+  'schema-index.ts',
+  'schema-loader.ts',
+]
+
+const WRITERS: ReadonlyArray<{ pattern: RegExp; callee: string }> = [
+  { pattern: /\bconsole\s*\.\s*log\s*\(/g, callee: 'console.log' },
+  { pattern: /\bconsole\s*\.\s*error\s*\(/g, callee: 'console.error' },
+  { pattern: /\bconsole\s*\.\s*warn\s*\(/g, callee: 'console.warn' },
+  { pattern: /\bconsole\s*\.\s*info\s*\(/g, callee: 'console.info' },
+  { pattern: /\bconsole\s*\.\s*debug\s*\(/g, callee: 'console.debug' },
+  { pattern: /\bprocess\s*\.\s*stdout\s*\.\s*write\s*\(/g, callee: 'process.stdout.write' },
+  { pattern: /\bprocess\s*\.\s*stderr\s*\.\s*write\s*\(/g, callee: 'process.stderr.write' },
+  // Writing the fd directly is the escape route that matters in practice:
+  // recovery/emit.ts already does it deliberately, to survive a pipe being
+  // truncated by process.exit on Windows. Only literal fds are detectable.
+  { pattern: /\bwriteSync\s*\(\s*1\s*,/g, callee: 'writeSync(1)' },
+  { pattern: /\bwriteSync\s*\(\s*2\s*,/g, callee: 'writeSync(2)' },
+  { pattern: /\bBun\s*\.\s*write\s*\(\s*Bun\s*\.\s*stdout\b/g, callee: 'Bun.write(Bun.stdout)' },
+  { pattern: /\bBun\s*\.\s*write\s*\(\s*Bun\s*\.\s*stderr\b/g, callee: 'Bun.write(Bun.stderr)' },
+]
+
+/**
+ * Report one violation per distinct callee, in the order they first appear.
+ */
+export function findCoreStdoutViolations(source: string, relativePath: string): string[] {
+  const byOffset: Array<{ offset: number; callee: string }> = []
+
+  for (const { pattern, callee } of WRITERS) {
+    for (const match of source.matchAll(pattern)) {
+      byOffset.push({ offset: match.index, callee })
+      break
+    }
+  }
+
+  return byOffset
+    .sort((a, b) => a.offset - b.offset)
+    .map(({ callee }) => `${relativePath}: writes to stdout via '${callee}'`)
+}
+
+/**
+ * Scan src/core, skipping the exception list.
+ */
+export async function collectCoreStdoutViolations(): Promise<string[]> {
+  const exempt = new Set(CORE_STDOUT_EXCEPTIONS)
+  const violations: string[] = []
+
+  for await (const scanned of new Bun.Glob('**/*.ts').scan({ cwd: rootPath })) {
+    const relativePath = scanned.replaceAll('\\', '/')
+    if (exempt.has(relativePath)) continue
+    const source = await Bun.file(join(rootPath, relativePath)).text()
+    violations.push(...findCoreStdoutViolations(source, relativePath))
+  }
+
+  return violations.sort()
+}
+
+if (import.meta.main) {
+  const violations = await collectCoreStdoutViolations()
+
+  if (violations.length > 0) {
+    console.error(
+      `core no-stdout check failed:\n${violations.map((item) => `- ${item}`).join('\n')}\n\n` +
+        'Core returns structured data; the command layer renders it.'
+    )
+    process.exit(1)
+  }
+
+  console.log('core no-stdout check passed')
+}

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -14,6 +14,7 @@ import {
   type SqlConnectionOptions,
 } from '@/adapters'
 import { DataExecutor } from '@/core/data-executor'
+import { confirmMutationInteractively } from '@/commands/mutation-confirm'
 import { configModule } from '@/core/config'
 import { PermissionError } from '@/core/permission-guard'
 import { BlacklistManager } from '@/core/blacklist-manager'
@@ -289,6 +290,7 @@ export async function deleteCommand(
       const result = await executor.executeDelete(table, whereConditions, schema, {
         dryRun: options.dryRun,
         force: options.force,
+        confirm: confirmMutationInteractively,
       })
 
       // 9. Format output as JSON

--- a/src/commands/insert.ts
+++ b/src/commands/insert.ts
@@ -14,6 +14,7 @@ import {
   type SqlConnectionOptions,
 } from '@/adapters'
 import { DataExecutor } from '@/core/data-executor'
+import { confirmMutationInteractively } from '@/commands/mutation-confirm'
 import { configModule } from '@/core/config'
 import { enforcePermission, PermissionError } from '@/core/permission-guard'
 import { BlacklistManager } from '@/core/blacklist-manager'
@@ -288,6 +289,7 @@ export async function insertCommand(
       const result = await executor.executeInsert(table, data, schema, {
         dryRun: options.dryRun,
         force: options.force,
+        confirm: confirmMutationInteractively,
       })
 
       // 8. Format output as JSON

--- a/src/commands/mutation-confirm.ts
+++ b/src/commands/mutation-confirm.ts
@@ -1,0 +1,29 @@
+/**
+ * The command layer's answer to "how do we ask before writing?".
+ *
+ * This is the presentation half of what used to live inside DataExecutor.
+ * Core now reports what is about to happen and this decides how it looks, so
+ * that stdout — the surface agents parse — is owned entirely by the layer that
+ * knows whether a human is watching.
+ *
+ * The wording and spacing here are load-bearing for now: they reproduce the
+ * pre-refactor output byte for byte, which is what lets the move be verified
+ * rather than trusted. Ceremony changes them on purpose, later.
+ */
+
+import type { MutationConfirmationRequest, MutationConfirmer } from '@/types'
+import { promptUser } from '@/utils/prompts'
+
+export const confirmMutationInteractively: MutationConfirmer = async (
+  request: MutationConfirmationRequest
+): Promise<boolean> => {
+  if (request.warning) {
+    console.log(`\n${request.warning}`)
+  }
+  console.log('\nGenerated SQL:')
+  console.log(`  ${request.sql}`)
+  console.log('\nParameters:')
+  console.log(`  ${JSON.stringify(request.params, null, 2)}`)
+
+  return promptUser.confirm(request.prompt)
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -14,6 +14,7 @@ import {
   type SqlConnectionOptions,
 } from '@/adapters'
 import { DataExecutor } from '@/core/data-executor'
+import { confirmMutationInteractively } from '@/commands/mutation-confirm'
 import { configModule } from '@/core/config'
 import { enforcePermission, PermissionError } from '@/core/permission-guard'
 import { BlacklistManager } from '@/core/blacklist-manager'
@@ -320,6 +321,7 @@ export async function updateCommand(
       const result = await executor.executeUpdate(table, setData, whereConditions, schema, {
         dryRun: options.dryRun,
         force: options.force,
+        confirm: confirmMutationInteractively,
       })
 
       // 10. Format output as JSON

--- a/src/core/data-executor.ts
+++ b/src/core/data-executor.ts
@@ -9,7 +9,6 @@ import type { DatabaseAdapter, TableSchema } from '@/adapters/types'
 import type { Permission } from '@/types'
 import type { DataExecutionResult, DataExecutionOptions } from '@/types/data'
 import { enforcePermission, PermissionError } from '@/core/permission-guard'
-import { promptUser } from '@/utils/prompts'
 import type { BlacklistValidator } from '@/core/blacklist-validator'
 import { BlacklistError } from '@/types/blacklist'
 
@@ -234,15 +233,22 @@ export class DataExecutor {
     }
 
     if (!options?.force) {
-      if (confirmation.warning) {
-        console.log(`\n${confirmation.warning}`)
+      if (!options?.confirm) {
+        throw new Error(
+          `Refusing to ${operation} without confirmation: no confirmation handler was supplied. ` +
+            'Pass options.confirm to ask the user, or options.force to proceed unattended.'
+        )
       }
-      console.log('\nGenerated SQL:')
-      console.log(`  ${statement.sql}`)
-      console.log('\nParameters:')
-      console.log(`  ${JSON.stringify(statement.params, null, 2)}`)
 
-      if (!(await promptUser.confirm(confirmation.prompt))) {
+      const proceed = await options.confirm({
+        operation,
+        sql: statement.sql,
+        params: statement.params,
+        ...(confirmation.warning && { warning: confirmation.warning }),
+        prompt: confirmation.prompt,
+      })
+
+      if (!proceed) {
         return this.successResult(operation, 0, timestamp, statement.sql)
       }
     }

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -40,4 +40,39 @@ export interface DataExecutionOptions {
 
   /** Verbose output */
   verbose?: boolean
+
+  /**
+   * How to ask the caller's user whether to proceed.
+   *
+   * Core states what is about to happen; the caller decides how to present it
+   * and how to collect an answer. Required whenever a mutation would execute
+   * without `force`, and absent by design rather than defaulted: silently
+   * proceeding unconfirmed, or silently declining, are both worse than saying
+   * that nobody was available to ask.
+   */
+  confirm?: MutationConfirmer
 }
+
+/**
+ * Everything a caller needs to describe a pending mutation to its user.
+ */
+export interface MutationConfirmationRequest {
+  operation: DataExecutionResult['operation']
+
+  /** The parameterised statement that will run if confirmed */
+  sql: string
+
+  /** Values bound to the statement's placeholders */
+  params: (string | number | boolean | null)[]
+
+  /** Present when the operation is irreversible */
+  warning?: string
+
+  /** The question to put to the user */
+  prompt: string
+}
+
+/**
+ * Returns true to proceed, false to abandon the mutation.
+ */
+export type MutationConfirmer = (request: MutationConfirmationRequest) => Promise<boolean>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
 // Shared type definitions for dbcli
-export type { DataExecutionResult, DataExecutionOptions } from './data'
+export type {
+  DataExecutionResult,
+  DataExecutionOptions,
+  MutationConfirmationRequest,
+  MutationConfirmer,
+} from './data'
 export type { BlacklistConfig, ColumnBlacklist, BlacklistState } from './blacklist'
 export { BlacklistError } from './blacklist'
 

--- a/tests/contract/core-no-stdout.test.ts
+++ b/tests/contract/core-no-stdout.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  CORE_STDOUT_EXCEPTIONS,
+  collectCoreStdoutViolations,
+  findCoreStdoutViolations,
+} from '../../scripts/check-core-no-stdout'
+
+describe('core no-stdout gate', () => {
+  test.each([
+    ["console.log('hi')", 'console.log'],
+    ["console.error('boom')", 'console.error'],
+    ["console.warn('careful')", 'console.warn'],
+    ["console.info('fyi')", 'console.info'],
+    ["console.debug('trace')", 'console.debug'],
+    ["process.stdout.write('raw')", 'process.stdout.write'],
+    ["process.stderr.write('raw')", 'process.stderr.write'],
+    ["writeSync(1, 'raw')", 'writeSync(1)'],
+    ["writeSync(2, 'raw')", 'writeSync(2)'],
+    ['Bun.write(Bun.stdout, payload)', 'Bun.write(Bun.stdout)'],
+    ['Bun.write(Bun.stderr, payload)', 'Bun.write(Bun.stderr)'],
+  ])('rejects %s', (source, callee) => {
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toContain(
+      `fixture.ts: writes to stdout via '${callee}'`
+    )
+  })
+
+  test('reports each distinct callee once', () => {
+    const source = "console.log('a')\nconsole.log('b')\nconsole.error('c')"
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toEqual([
+      "fixture.ts: writes to stdout via 'console.log'",
+      "fixture.ts: writes to stdout via 'console.error'",
+    ])
+  })
+
+  test('allows code that merely mentions logging', () => {
+    const source = [
+      'const logger = { log: (message: string) => sink.push(message) }',
+      'logger.log("routed through the caller")',
+      'export type Console = { log(message: string): void }',
+    ].join('\n')
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toEqual([])
+  })
+
+  test('allows reading stdout metadata without writing to it', () => {
+    const source = 'const interactive = process.stdout.isTTY === true'
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toEqual([])
+  })
+
+  test('allows writing files, which is what Bun.write is normally for', () => {
+    const source = 'await Bun.write(tempFile, JSON.stringify(lockData))'
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toEqual([])
+  })
+
+  test('allows writing to a file descriptor that is not stdout or stderr', () => {
+    const source = 'writeSync(handle, buffer)'
+    expect(findCoreStdoutViolations(source, 'fixture.ts')).toEqual([])
+  })
+
+  test('the exception list only shrinks: every entry still violates', async () => {
+    const stale: string[] = []
+    for (const relativePath of CORE_STDOUT_EXCEPTIONS) {
+      const source = await Bun.file(new URL(`../../src/core/${relativePath}`, import.meta.url)).text()
+      if (findCoreStdoutViolations(source, relativePath).length === 0) stale.push(relativePath)
+    }
+    expect(stale).toEqual([])
+  })
+
+  test('src/core has no violations outside the exception list', async () => {
+    expect(await collectCoreStdoutViolations()).toEqual([])
+  })
+
+  test('the data executor is not exempt', () => {
+    expect(CORE_STDOUT_EXCEPTIONS).not.toContain('data-executor.ts')
+  })
+})

--- a/tests/unit/build/inquirer-shipping-contract.test.ts
+++ b/tests/unit/build/inquirer-shipping-contract.test.ts
@@ -25,8 +25,18 @@ const manifest = (await Bun.file('package.json').json()) as {
 }
 const buildScript = await Bun.file('scripts/build.ts').text()
 
-/** Bundles that can reach a prompt: the CLI runtime and the ./core subpath. */
-const PROMPT_BEARING_BUNDLES = ['dist/cli-runtime.mjs', 'dist/core.mjs']
+/**
+ * Bundles that can reach a prompt.
+ *
+ * `dist/core.mjs` used to be one of them. Core no longer prompts or prints —
+ * it reports what is about to happen and the command layer asks — so the ./core
+ * subpath has no path to @inquirer/prompts at all, and the assertion below
+ * inverts for it: absence is now the contract, checked so the edge cannot
+ * reappear unnoticed.
+ */
+const PROMPT_BEARING_BUNDLES = ['dist/cli-runtime.mjs']
+const PROMPT_FREE_BUNDLES = ['dist/core.mjs']
+const ALL_CHECKED_BUNDLES = [...PROMPT_BEARING_BUNDLES, ...PROMPT_FREE_BUNDLES]
 
 describe('@inquirer/prompts shipping contract', () => {
   test('is a runtime dependency, not a devDependency', () => {
@@ -43,7 +53,7 @@ describe('@inquirer/prompts shipping contract', () => {
 
   // The two tests above pin the intent; this one pins the result. Skipped when
   // dist/ is absent so the suite still runs pre-build.
-  describe.if(PROMPT_BEARING_BUNDLES.every((path) => existsSync(path)))('built artifacts', () => {
+  describe.if(ALL_CHECKED_BUNDLES.every((path) => existsSync(path)))('built artifacts', () => {
     test.each(PROMPT_BEARING_BUNDLES)('%s imports it rather than inlining it', async (outfile) => {
       const bundle = await Bun.file(outfile).text()
 
@@ -52,6 +62,14 @@ describe('@inquirer/prompts shipping contract', () => {
       // that shipped a barrel without its implementations.
       expect(bundle).toMatch(/import\(["']@inquirer\/prompts["']\)/)
       expect(bundle).not.toContain('// node_modules/@inquirer/prompts/')
+    })
+
+    test.each(PROMPT_FREE_BUNDLES)('%s cannot reach a prompt at all', async (outfile) => {
+      // Not a size optimisation: a core that can prompt is a core that can
+      // block on stdin and write to stdout, which is the thing the layering
+      // rule exists to prevent. If this fails, something in src/core started
+      // asking the user questions again.
+      expect(await Bun.file(outfile).text()).not.toContain(PACKAGE)
     })
   })
 

--- a/tests/unit/commands/mutation-output-characterisation.test.ts
+++ b/tests/unit/commands/mutation-output-characterisation.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Characterisation tests for what update/delete print to stdout.
+ *
+ * These exist to freeze current behaviour across the move of presentation out
+ * of core. They are deliberately exact-match: the whole point of the refactor
+ * is that not one byte changes, so a loose assertion would defeat it.
+ *
+ * Once ceremony lands these expectations change on purpose, and that diff is
+ * the reviewable record of what a human's output became.
+ *
+ * Uses spyOn rather than mock.module, per the convention in the sibling
+ * blacklist wiring test, to avoid leaking mocks across files.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test'
+import { AdapterFactory } from '@/adapters'
+import { configModule } from '@/core/config'
+import { promptUser } from '@/utils/prompts'
+
+const schema = {
+  name: 'users',
+  columns: [
+    { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+    { name: 'amount', type: 'integer', nullable: false, primaryKey: false },
+  ],
+  rowCount: 0,
+  primaryKey: 'id',
+  foreignKeys: [],
+}
+
+const mockAdapter = {
+  connect: mock(async () => {}),
+  disconnect: mock(async () => {}),
+  execute: mock(async () => ({ affectedRows: 3, rows: [] })),
+  getTableSchema: mock(async () => schema),
+  listTables: mock(async () => []),
+  ping: mock(async () => {}),
+}
+
+const config = {
+  connection: {
+    system: 'postgresql',
+    host: 'localhost',
+    port: 5432,
+    database: 'test',
+    user: 'user',
+    password: 'pass',
+  },
+  permission: 'admin',
+  blacklist: { tables: [], columns: {} },
+}
+
+describe('update/delete stdout characterisation', () => {
+  let lines: string[] = []
+  let spies: Array<{ mockRestore: () => void }> = []
+  let originalExit: typeof process.exit
+  let confirmAnswer = true
+
+  beforeEach(() => {
+    lines = []
+    confirmAnswer = true
+    originalExit = process.exit
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as any
+
+    spies = [
+      spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        lines.push(args.map(String).join(' '))
+      }),
+      spyOn(AdapterFactory, 'createSqlAdapter').mockReturnValue(mockAdapter as any),
+      spyOn(configModule, 'read').mockImplementation(async () => config as any),
+      spyOn(promptUser, 'confirm').mockImplementation(async () => confirmAnswer),
+    ]
+  })
+
+  afterEach(() => {
+    process.exit = originalExit
+    for (const spy of spies) spy.mockRestore()
+  })
+
+  async function run(fn: () => Promise<void>): Promise<string> {
+    try {
+      await fn()
+    } catch {
+      // process.exit sentinel
+    }
+    // The only nondeterministic part of the envelope; everything else is
+    // compared byte for byte.
+    return lines.join('\n').replace(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g, '<timestamp>')
+  }
+
+  test('update prints the confirmation block, then the result envelope', async () => {
+    const { updateCommand } = await import('@/commands/update')
+    const output = await run(() =>
+      updateCommand('users', { where: 'id=1', set: '{"amount":100}' })
+    )
+
+    expect(output).toBe(
+      [
+        '',
+        'Generated SQL:',
+        '  UPDATE "users" SET "amount" = $1 WHERE "id" = $2',
+        '',
+        'Parameters:',
+        '  [',
+        '  100,',
+        '  1',
+        ']',
+        '{',
+        '  "status": "success",',
+        '  "operation": "update",',
+        '  "rows_affected": 3,',
+        '  "timestamp": "<timestamp>",',
+        '  "sql": "UPDATE \\"users\\" SET \\"amount\\" = $1 WHERE \\"id\\" = $2"',
+        '}',
+      ].join('\n')
+    )
+  })
+
+  test('cancelling at the prompt still prints a success envelope today', async () => {
+    confirmAnswer = false
+    const { updateCommand } = await import('@/commands/update')
+    const output = await run(() =>
+      updateCommand('users', { where: 'id=1', set: '{"amount":100}' })
+    )
+
+    expect(output).toContain('"rows_affected": 0')
+    expect(output).toContain('"status": "success"')
+  })
+
+  test('delete leads with the destructive warning', async () => {
+    const { deleteCommand } = await import('@/commands/delete')
+    const output = await run(() => deleteCommand('users', { where: 'id=1' }))
+
+    expect(output).toContain('⚠️  Warning: DELETE operation is destructive and cannot be undone!')
+    expect(output).toContain('Generated SQL:')
+    expect(output).toContain('  DELETE FROM "users" WHERE "id" = $1')
+  })
+})


### PR DESCRIPTION
三個 PR 的第一個，對應 #70。**純重構，指令輸出零位元組變更**——後面兩個 PR 才有行為變更。

## 為什麼

`DataExecutor.executeMutation` 用 `console.log` 印 SQL 與參數，再直接呼叫 `promptUser.confirm`，全都在 `src/core` 裡。兩個後果：

1. 匯入 `./core` 子路徑的函式庫使用者會拿到沒要求過的互動提示——`dist/core.mjs` 為此真的 ship 了 `import("@inquirer/prompts")`。
2. 更要緊的是，那些輸出與 agent 解析的 JSON 信封共用同一個 stdout。兩者至今不相撞，只是因為 core 剛好印得少。#70 的儀式感工作會讓 core 印得非常多。

重構前實測：`src/core` 的 228 個模組裡有 17 個會寫 stdout/stderr，約 40 個呼叫點——93% 本來就是乾淨的。

## 做了什麼

**Core 回報結構，指令層決定怎麼說。** `DataExecutionOptions` 新增 `confirm` 回呼，core 組出 `MutationConfirmationRequest` 交給呼叫端。CLI 的實作在 `src/commands/mutation-confirm.ts`，逐位元組重現原本的輸出。未帶 `force` 又沒提供 handler 時 core 拋錯——不預設放行也不預設拒絕，兩者都比說出「沒有人可問」更糟。

**閘門。** `scripts/check-core-no-stdout.ts` 上 CI，比照既有的 agent-core purity gate。攔 `console.*`、`process.std*.write`、字面 fd 1/2 的 `writeSync`（`src/core/recovery/emit.ts` 已經刻意這樣用，為了在 Windows 上撐過被 `process.exit` 截斷的 pipe），以及指向 `Bun.stdout` 的 `Bun.write`。

**例外清單是棘輪，不是特赦。** 先前違規的 16 個模組進 `CORE_STDOUT_EXCEPTIONS`；contract test 會在清單中的模組不再違規時失敗，逼人刪掉那一行，所以清單只能縮短。終點是空清單，一次一個刪除。`data-executor.ts` 刻意不在其中。

## 怎麼驗證「零變更」

`tests/unit/commands/mutation-output-characterisation.test.ts` 在重構**之前**寫好並跑綠，逐位元組釘住 `update`/`delete` 的完整 stdout（只正規化時間戳），重構後依然綠。這是驗收，不是信任。

`tests/unit/build/inquirer-shipping-contract.test.ts`（#56 留下的契約）在重構後失敗了——這是設計正確性的信號：`dist/core.mjs` 對 `@inquirer/prompts` 的引用從 4 處歸零。契約因此反轉：從「必須 import」變成「不得引用」，讓被移除的那條邊無法悄悄長回來。

## Test plan

- `bun test` — 5156 pass / 0 fail (484 files)
- `bun run typecheck`、`bun run lint` — clean
- `bun run build` 後六個 CI 檢查腳本全過（含新的 `core-stdout:check`）
- `dbcli --version` / `--help` smoke test

## 需要注意

`./core` 子路徑的公開 API 有破壞性變更：函式庫使用者若呼叫 `executeUpdate`/`executeDelete`/`executeInsert` 而未帶 `force` 或 `confirm`，現在會拿到明確的錯誤而非互動提示。這要進 2.0.0 的 CHANGELOG——本 PR 未動 CHANGELOG，因為整個功能在第三個 PR 才發版。

決策記錄：`docs/adr/0009-core-does-not-write-to-stdout.md`。

🤖 Generated with Claude Code