### PR TITLE
fix: [ audit ] 閘門決策一律記成 db-write，以 tier 篩破壞性操作不再漏

### DIFF
--- a/docs/adr/0010-unattended-callers-are-refused-full-table-writes.md
+++ b/docs/adr/0010-unattended-callers-are-refused-full-table-writes.md
@@ -87,7 +87,10 @@ Its effect is a measurement, not an assumption. Every tier-two evaluation is wri
 audit log — allowed, declined and refused alike — because a log that kept only refusals
 could not tell "nobody writes like that" apart from "everyone found a way around it". If
 the records show tier two is almost never reached, the criterion is wrong rather than the
-gate unnecessary.
+gate unnecessary. Every such entry is filed under `side_effect_tier: db-write` whatever
+entry point produced it, so filtering the log for destructive operations by tier — the
+first filter anyone reaches for — returns all of them and not the third that happened to
+come from a command whose own capability is a write (#83).
 
 **Falsified if:** `src/commands/write-gate.ts` stops classifying an unqualified
 `UPDATE` / `DELETE`, `DROP`, `TRUNCATE` or unparseable statement as tier two, or

--- a/src/commands/write-gate-guard.ts
+++ b/src/commands/write-gate-guard.ts
@@ -40,6 +40,12 @@ export async function recordGateDecision(request: {
 }): Promise<void> {
   await writeAuditEntry(request.config, request.command, request.options, {
     success: request.outcome === 'allowed',
+    // The decision is about a statement that writes, whatever the command's own
+    // capability tier says. Read off the command, one DROP decision was filed
+    // as `readonly` from `query`, `db-write` from `delete` and `interactive`
+    // from `shell`, so filtering the log for destructive operations by tier —
+    // the obvious first filter — found a third of them (#83).
+    sideEffectTier: 'db-write',
     ...(request.sql && { sql: request.sql }),
     ...(request.verdict.table && { target: request.verdict.table }),
     metadata: {

--- a/src/core/audit/integration-helper.ts
+++ b/src/core/audit/integration-helper.ts
@@ -7,7 +7,7 @@ import { resolveConfigStoragePath } from '../config-binding'
 import { getGlobalConnectionName } from '../config'
 import type { DbcliConfig } from '../../utils/validation'
 import type { DatabaseSystem } from '../../adapters/types'
-import { getEngineCapability } from '../../adapters/capabilities'
+import { getEngineCapability, type SideEffectTier } from '../../adapters/capabilities'
 import {
   redactArgv,
   redactArgvSensitiveText,
@@ -63,6 +63,24 @@ export interface AuditOutcome {
   metadata?: Record<string, unknown>
   sql?: string
   target?: string
+  /**
+   * What the statement this entry is about would do, when the command's
+   * capability tier says something else. The capability describes the command
+   * as a whole — `query` is `readonly` because most queries read — which is the
+   * wrong answer for an entry about one specific statement that writes.
+   *
+   * The field states the statement's effect, not whether it happened: a
+   * refused or declined write is still `db-write`, and `success` together with
+   * the entry's own metadata says what became of it. `--dry-run` / `--plan`
+   * still win, because those are an explicit execution mode rather than an
+   * outcome.
+   *
+   * Deliberately narrower than `SideEffectTier`: this exists so a caller that
+   * knows more than the capability table can say so, never to file a write
+   * under a quieter tier than it deserves. Widen it when something actually
+   * needs a value that is not here.
+   */
+  sideEffectTier?: Extract<SideEffectTier, 'db-write' | 'local-write'>
   /** Phase 25 D-J: envelope id from the catch block, propagated onto the persisted audit entry as `recovery_ref`. */
   recovery_ref?: string
 }
@@ -94,7 +112,7 @@ export async function writeAuditEntry(
     const target = outcome.target || getOperationTarget(engine, commandName, options, outcome.sql)
 
     // 2. Resolve Side Effect Tier
-    let tier = getEngineCapability(engine, commandName as any).tier
+    let tier = outcome.sideEffectTier ?? getEngineCapability(engine, commandName as any).tier
     if (options.dryRun || options.plan) {
       tier = 'dry-run'
     }

--- a/tests/unit/commands/write-gate-audit.test.ts
+++ b/tests/unit/commands/write-gate-audit.test.ts
@@ -156,6 +156,42 @@ describe('tier-two decisions in the audit log', () => {
     expect((entries[0]!.metadata as Record<string, unknown>).write_gate_outcome).toBe('declined')
   })
 
+  test('every entry point files the same decision under the same side-effect tier', async () => {
+    // The tier used to be read off the *command's* capability, so one DROP
+    // decision was filed as `readonly` from `query`, `db-write` from `delete`
+    // and `interactive` from `shell`. An auditor filtering for destructive
+    // operations by tier — the obvious first filter — saw a third of them.
+    setTTY(false)
+    await runQuery('DROP TABLE users')
+
+    const { createShellWriteGate } = await import('@/commands/shell-write-gate')
+    const gate = createShellWriteGate({
+      config: (await configModule.read(workDir)) as never,
+      configPath: workDir,
+      dialect: 'postgresql',
+    })
+    await gate('DROP TABLE users')
+
+    const { deleteCommand } = await import('@/commands/delete')
+    try {
+      await deleteCommand('users', {
+        where: 'status=active',
+        force: true,
+        config: workDir,
+      } as never)
+    } catch {
+      // Refusals throw; the log is what this file is about.
+    }
+
+    const entries = await gateEntries()
+    expect(entries.map((entry) => entry.command)).toEqual(['query', 'shell', 'delete'])
+    expect(entries.map((entry) => entry.side_effect_tier)).toEqual([
+      'db-write',
+      'db-write',
+      'db-write',
+    ])
+  })
+
   test('a structured delete refused for matching on nothing unique says so', async () => {
     setTTY(false)
     const { deleteCommand } = await import('@/commands/delete')


### PR DESCRIPTION
Closes #83

## 為什麼

第二級閘門的稽核紀錄，`side_effect_tier` 來自 `getEngineCapability(engine, commandName).tier`，也就是「指令」的能力層級。實作時把測試先寫成 RED，印出來的是：

```
- ["db-write", "db-write"]      期望
+ ["readonly",  "interactive"]  實際（query / shell）
```

所以 issue 的前提只說對一半：不是 shell 一個入口偏掉，而是三個入口各說各話——`query` 的 `DROP TABLE users` 決策一直被歸類成 **readonly**，比 shell 那筆更誤導。以 tier 篩破壞性操作是任何稽核消費端會用的第一個 filter，它只篩得到 `update` / `delete` 那三分之一。

ADR 0010 的整個價值主張是「這道閘門的效果是可量測的」，而量測正好卡在這條線上。

## 做了什麼

- `AuditOutcome` 多一個 `sideEffectTier`，讓知道得比能力表更多的呼叫端說出這筆紀錄的**語句**做什麼。型別是 `Extract<SideEffectTier, 'db-write' | 'local-write'>`：這個口子是為了說得更準，不是為了把寫入降級記成 readonly，需要更多值時再放寬。
- `--dry-run` / `--plan` 仍然勝出——那是明示的執行模式，不是結果。（實務上目前不可達：`delete` / `update` 在 dry-run 時整個跳過閘門，`query` 沒有這兩個旗標。所以這條優先序不改變任何現有行為。）
- 共用的 `recordGateDecision` 一律填 `db-write`。被判定的語句必定會寫：`classifySqlWriteGate` 在型別不是寫入時直接回 `tier: 'none'`，所有 tier-two 出口都在型別確定之後才可達。被拒絕或取消的決策同樣是 `db-write`——欄位說的是語句的效果，成敗看 `success` 與 `metadata.write_gate_outcome`。
- 能力表沒有動：`interactive` 對「shell 這個指令」本身仍然是正確的描述。
- ADR 0010 的 Consequences 補一句，讓「可量測」這個承諾變成可檢查的敘述。

## 測試

`tests/unit/commands/write-gate-audit.test.ts` 新增一條：同一句 `DROP TABLE users` 分別走 `query`、`shell`、以及結構化 `delete` 的閘門，斷言三筆稽核的 `command` 依序是 query / shell / delete 而 `side_effect_tier` 三筆都是 `db-write`。直接斷言欄位本身，而不是像既有測試那樣用 `metadata.write_gate_tier` 篩——後者正是這個 bug 一直沒被發現的原因。

先確認 RED（見上方輸出）再實作。全綠：typecheck / eslint / prettier / 4631 個 unit+core / gherkin / docs。

`side_effect_tier` 在 `docs/` 與 skill 資產裡都沒有出現，沒有使用者文件要同步；`src` 內唯一的消費端是 `src/commands/audit.ts` 的顯示邏輯，沒有任何篩選會因此改變行為。

## 順帶發現，未處理

`tests/integration/evidence-command.test.ts:68` 的 fixture 用了 `side_effect_tier: 'write'`，不在 `SideEffectTier` 聯集裡。既有問題、與本 PR 無關，沒有一併改動。
