### PR TITLE
fix: [ q ] snippet 執行前自己驗權限，不再靠別的模組替它守著

### DIFF
--- a/src/commands/q.ts
+++ b/src/commands/q.ts
@@ -6,7 +6,7 @@ import { resolveConfigPath } from '@/utils/config-path'
 import { BlacklistManager } from '@/core/blacklist-manager'
 import { BlacklistValidator } from '@/core/blacklist-validator'
 import { BlacklistError } from '@/types/blacklist'
-import { PermissionError, SQL_DIALECTS } from '@/core/permission-guard'
+import { enforcePermission, PermissionError, SQL_DIALECTS } from '@/core/permission-guard'
 import { extractTableReferences } from '@/utils/sql-tables'
 import { QueryResultFormatter } from '@/formatters'
 import { generateHtmlReport } from '@/formatters/html-formatter'
@@ -113,10 +113,28 @@ export async function qCommand(
     for (const w of prepared.warnings) console.error(`⚠ ${w}`)
     if (prepared.warnings.length > 0) console.error('')
 
+    const family = engineFamily(engine)
+    const sqlDialect = SQL_DIALECTS.find((dialect) => dialect === connectionSystem)
+
+    // Defence in depth (issue #81): until now "q only runs reads" was held up
+    // entirely by `validateBody`'s parse-time rule in another module, so q.ts
+    // read as if it executed arbitrary SQL unchecked. Every snippet the contract
+    // allows still passes — the value is that the guarantee is now provable here.
+    //
+    // Above the dry-run branch, not below it: a refusal should read the same
+    // whether or not the statement was going to run, which is the choice
+    // `q-mongo.ts` already documents. And the rewritten SQL, not the driver SQL —
+    // the latter is the size guard's wrapper, so classifying it would describe
+    // dbcli's wrapping rather than the statement the snippet asked for.
+    const classification =
+      family === 'sql'
+        ? enforcePermission(prepared.rewrittenSql, config.permission, sqlDialect)
+        : undefined
+
     if (options.dryRun) {
       console.log(
         formatDryRun({
-          family: engineFamily(engine),
+          family,
           driverSql: prepared.driver.sql,
           values: prepared.driver.values,
           execHints: prepared.execHints,
@@ -140,8 +158,6 @@ export async function qCommand(
 
     const blacklistManager = new BlacklistManager(config)
     const blacklistValidator = new BlacklistValidator(blacklistManager)
-    const family = engineFamily(engine)
-    const sqlDialect = SQL_DIALECTS.find((dialect) => dialect === connectionSystem)
     // A snippet is checked against every table it references, not just the
     // first one — a JOIN, a comma, or a UNION branch reaches a table the
     // leading FROM never names (issue #23).
@@ -165,8 +181,12 @@ export async function qCommand(
       // `index:` in a snippet's frontmatter is an expression too — comma lists
       // and wildcards reach an index that equality never matches.
       blacklistValidator.checkIndexBlacklist('SELECT', targetName)
-    } else if (family !== 'redis' && targets.length > 0) {
-      blacklistValidator.checkTablesBlacklist('SELECT', targets)
+    } else if (classification && targets.length > 0) {
+      // Gated on the classification rather than on the family, so the operation
+      // label is the statement type the guard actually read. Hardcoding 'SELECT'
+      // wrote the snippet contract into this call site a second time, where it
+      // would have gone on saying SELECT if that contract ever widened.
+      blacklistValidator.checkTablesBlacklist(classification.type, targets)
     }
 
     const adapter = AdapterFactory.createAdapter(config.connection as ConnectionOptions)

--- a/tests/integration/commands/q-live.test.ts
+++ b/tests/integration/commands/q-live.test.ts
@@ -21,6 +21,10 @@ describe.skipIf(SKIP)('dbcli q (live PostgreSQL)', () => {
       `-- ---\n-- name: one\n-- engine: postgres\n-- params:\n--   v:\n--     type: int\n--     default: 1\n-- ---\nSELECT :v AS x;`
     )
     writeFileSync(
+      join(workdir, '.dbcli-shared/queries/cte.sql'),
+      `-- ---\n-- name: cte\n-- engine: postgres\n-- ---\nWITH src AS (SELECT 7 AS x) SELECT x FROM src;`
+    )
+    writeFileSync(
       join(workdir, '.dbcli'),
       JSON.stringify({
         connection: {
@@ -50,6 +54,18 @@ describe.skipIf(SKIP)('dbcli q (live PostgreSQL)', () => {
     // what the snippet returns. The assertion said `1` and had never been run
     // against a server to find out.
     expect(out.rows).toEqual([{ x: '1' }])
+  })
+
+  // The live half of the permission check added in issue #81 — the same CTE
+  // shape as the unit test, but against a real server, so the statement the
+  // guard classified is also the statement PostgreSQL accepted.
+  test('read-only CTE snippet still runs on a query-only connection', () => {
+    const r = spawnSync('bun', ['run', cliPath, 'q', '@cte', '--format', 'json'], {
+      cwd: workdir,
+      encoding: 'utf8',
+    })
+    expect(r.status).toBe(0)
+    expect(JSON.parse(r.stdout).rows).toEqual([{ x: 7 }])
   })
 
   test('--param overrides', () => {

--- a/tests/unit/commands/q.test.ts
+++ b/tests/unit/commands/q.test.ts
@@ -103,6 +103,22 @@ describe('dbcli q', () => {
     expect(logSpy).toHaveBeenCalled()
   })
 
+  // `q` enforces the connection's permission on the rewritten SQL before it
+  // executes (issue #81). A CTE is the case that check most easily gets wrong:
+  // its leading keyword is WITH, not SELECT, so a classifier reading only the
+  // first word would refuse a read on this query-only connection. The snippet
+  // contract makes the refusal path unreachable, so what is pinned here is the
+  // other direction — the check kept every allowed snippet runnable.
+  test('read-only CTE snippet still reaches the adapter on a query-only connection', async () => {
+    writeFileSync(
+      join(workdir, '.dbcli-shared/queries/cte.sql'),
+      `-- ---\n-- name: cte\n-- engine: postgres\n-- ---\nWITH src AS (SELECT 1 AS dau) SELECT dau FROM src;`
+    )
+    await qCommand('@cte', { format: 'json', noLimit: true })
+    expect(mock.lastSql).toMatch(/WITH src AS/)
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
   describe('passive slow-query advisory', () => {
     /**
      * `q` measures its own elapsed time, so the mock adapter has to actually


### PR DESCRIPTION
Closes #81

## 動機

`src/commands/q.ts` 只 import 了 `PermissionError` 用來呈現錯誤，從頭到尾沒有呼叫過 `enforcePermission`，adapter 自己也不做權限檢查。它把 snippet 的 SQL 直接交給 `adapter.execute`。

今天這不會出事，但原因不在 `q.ts`：`src/core/saved-queries/parser.ts` 的 `validateBody` 在載入時就拒絕任何非 `SELECT` / `WITH` 開頭、含寫入關鍵字、或多句的 snippet。也就是說「q 只跑得動唯讀語句」這件事由兩個模組共同維持，而其中一個並不知道自己在維持它。任何一次「讓 snippet 支援寫入」的合理需求，都會在沒有人注意的情況下同時打開這個洞。

這是深度防禦，不是修 bug——以現行契約，每一個實際可執行的 snippet 都會通過這個檢查。價值在於讓那個保證在 `q.ts` 自己就能驗證。

## 改動

- SQL family 在執行前呼叫 `enforcePermission(prepared.rewrittenSql, config.permission, sqlDialect)`。用 rewritten SQL 而非 driver SQL：後者是 size guard 的包裝（`SELECT * FROM (...) AS _dbcli_guard LIMIT 1001`），分類它描述的是 dbcli 的包裝，不是 snippet 要求的語句。參數此時已改寫成 placeholder，所以參數值裡的 `;` 不可能影響分類。
- 放在 `--dry-run` 分支**之前**。第一版放在後面，code review 指出那讓註解的主張變成假的：`q @x --dry-run` 會印出從未被檢查的 SQL，而 `q-mongo.ts:34` 明確記錄了相反的選擇（「每一個權限層級，包括 `--dry-run` 之內」）。現在兩條 q 路徑一致。
- `checkTablesBlacklist` 改傳 `classification.type` 而非寫死的 `'SELECT'`。分支條件也從 `family !== 'redis'` 改成 `classification &&`——同樣的可達集合，但不需要一個永遠用不到的 `?? 'SELECT'` fallback 去騙型別，而那個 fallback 正好會把剛拿掉的字面值放回來。

非 SQL family 不受影響：檢查以 `family === 'sql'` 為閘，mongodb 更早就 return 並保有自己的 `assertNoMongoWriteStages`。

## 測試

釘的是「加了檢查沒弄壞既有行為」，不是拒絕路徑——以現行契約拒絕路徑到不了。

語料選 CTE：`WITH` 開頭是這個檢查最容易做錯的形狀，只讀第一個字的分類器會把它判成 `UNKNOWN` 而在 query-only 下拒絕一個純讀取。實測 `classifyStatement` 對 `WITH s AS (SELECT 7 AS x) SELECT x FROM s` 回 `SELECT` / HIGH confidence。

- `tests/unit/commands/q.test.ts` — mock adapter，零基礎設施成本，任何 CI leg 都會跑
- `tests/integration/commands/q-live.test.ts` — 同樣形狀但打真的 PostgreSQL

第一版只有 live 那條，review 指出它掛在 `describe.skipIf(!isDbReachable(...))` 之下，沒有 compose stack 的機器上等於沒測。單元那條是補上的。

**mutation 檢查**：把受檢 SQL 暫時換成 `DELETE FROM t`，`tests/unit/commands/q.test.ts` 12 條裡 11 條轉紅——確認這個呼叫真的在執行路徑上，而不是一條永遠通過的裝飾。

## 驗證

`typecheck` / `lint` / `format:check` / `docs:check` / `skill:check` / `contract:check` / `plugin:check` / `core-stdout:check` 全綠。
`bun test tests/unit tests/core` 4648 pass / 0 fail、`tests/gherkin` 4 pass、`tests/integration` 647 pass / 12 skip / 0 fail（compose PostgreSQL on 5433）。

手動：query-only + CTE snippet，`--dry-run` 印出預覽 exit 0、實際執行回傳結果 exit 0。

使用者可見行為沒有改變，所以沒有動 `docs/user/**` 與 `assets/reference.md`。