### PR TITLE
fix: [ tsconfig ] include 的大括號 TypeScript 不展開，518 個測試檔從來不在專案裡

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,22 @@ DBCLI_LANG=en ./dist/cli.mjs --help
 DBCLI_LANG=zh-TW ./dist/cli.mjs --help
 ```
 
+#### Typechecking
+
+`bun run typecheck` covers `src/` and `scripts/`. Test files are a separate project,
+`tsconfig.tests.json`, run with `bun run typecheck:tests`.
+
+They are separate because they are not clean yet. The main `include` carried a
+`tests/**/*.{ts,tsx}` pattern for a long time, and TypeScript does not expand braces in an
+include glob — so it matched nothing and no test file had ever been typechecked. Turning it
+on reports 339 errors across 174 files, about six in ten of them an unchecked array index or
+optional field under `noUncheckedIndexedAccess`. Those are being cleared one test directory
+at a time, and `typecheck:tests` joins CI and the release checklist once they are (#97).
+
+Until then, a type-level assertion written in a test file compiles but nothing in CI runs it.
+Put compile-time guards in `src/` — `src/commands/audit.ts` has one, with a note explaining
+why it lives there rather than beside the code it guards.
+
 ### 5. Commit
 
 Use conventional commit format:

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "agent-core:check": "bun run scripts/check-agent-core-purity.ts",
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "typecheck": "tsc --noEmit --pretty false",
+    "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",
     "lint": "eslint src tests scripts --ext .ts --max-warnings=0",
     "format:check": "prettier --check .",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -49,9 +49,11 @@ import type { GateOutcome } from '@/commands/write-gate-guard'
  * This layer may import both, so the tie is made here, in the direction the
  * layering allows. Each pair fails to compile on a member missing from the seed
  * list and on one invented there. (It is deliberately not in the summary's own
- * test file: `tsconfig.json`'s `include` uses a brace pattern TypeScript does
- * not expand, so no test file is typechecked at all — a compile-time guard put
- * there would silently guard nothing.)
+ * test file. `tsconfig.json`'s `include` used a brace pattern TypeScript does
+ * not expand, so no test file was typechecked at all and a compile-time guard
+ * put there would have guarded nothing; `tsconfig.tests.json` now covers them,
+ * but nothing runs it in CI until the 339 errors it reports are cleared, so the
+ * conclusion stands for now (#97).)
  */
 type Covers<A, B> = [A] extends [B] ? true : false
 const _noInventedReason: Covers<(typeof GATE_REASONS)[number], WriteGateReason> = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     },
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts", "tests/**/*.{ts,tsx}"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
+}


### PR DESCRIPTION
`tsconfig.json` 的 include 第四條寫成 `"tests/**/*.{ts,tsx}"`，而 TypeScript 的 include glob 只支援 `*`、`?`、`**/`，**不做大括號展開**。這條 pattern 因此匹配不到任何檔案。

```
$ bunx tsc --noEmit --listFiles | grep -c "/tests/"
0
$ find tests -name "*.ts" | wc -l
518
```

`bun run typecheck` 的綠燈從來不包含測試檔。ESLint 有跑 `tests`，所以 implicit any、未使用變數這類還擋得住，但型別錯誤沒有——**任何寫在測試檔裡的型別層級斷言目前都是裝飾**。發現於 #93：把一個編譯期守衛放進測試檔後，把聯集成員拿掉也不會編譯失敗。

## 這個 PR 是兩步修法的第一步

照 issue #97 訂的做法，中間不留半綠狀態。

**這一步**：讓 include 誠實，但把測試檔隔離出去。

- 主 `tsconfig.json` 拿掉那條匹配不到東西的 pattern——行為零變化，只是不再宣稱它沒有的覆蓋範圍
- 新增 `tsconfig.tests.json`（`extends` 主檔，只 include `tests/**/*.ts` 與 `.tsx`）
- 新增 `bun run typecheck:tests`
- 主 `typecheck`、CI、release checklist 全部不動

直接把測試檔納進主專案會讓綠燈變成 **339 個錯誤、174 個檔案**，等於擋住所有其他工作。

**第二步**（後續 PR）：按目錄分批清，`tests/unit` / `tests/core` / `tests/integration` / `tests/gherkin` 各一個 PR。全部清完後把 `typecheck:tests` 併回 `typecheck`，加進 CI 與 release checklist。

## 打開之後的規模（本次量測）

| | |
| --- | --- |
| 錯誤總數 | 339 |
| 涉及檔案 | 174 |

```
174  TS2532   Object is possibly 'undefined'
 35  TS2345   參數型別不符
 27  TS18048  possibly 'undefined'
 24  TS2741   缺少必要屬性
 15  TS2769   多載都不符
 13  TS7006   implicit any
 12  TS2322   型別不可指派
  8  TS2352   轉型不重疊
```

約六成是 `TS2532` / `TS18048`——在 `noUncheckedIndexedAccess` 下對陣列索引與 optional 欄位不做檢查就直接用（`rows[0].id` 這類）。測試裡資料多半是自己造的，所以修起來多是加 `!` 或 `?.`，機械但量大。

（issue 當時量到 341 / 175，差額來自這段期間新增的測試碼。）

## 一併更新

`src/commands/audit.ts` 裡那段解釋「編譯期守衛為何不放在測試檔」的註解。理由從「測試檔完全不被 typecheck」變成「有工具了但還沒進 CI」——結論暫時不變，但原本的說法從這個 PR 起就不準確了。

`CONTRIBUTING.md` 加一節說明兩個 typecheck 專案的分工、為什麼分開、以及在清乾淨之前編譯期守衛該放哪。

## Test plan

驗收條件（issue #97 訂的兩條）：

```
$ bunx tsc --noEmit -p tsconfig.tests.json --listFiles | grep -c "/tests/"
519
```

型別層級斷言現在會失敗——臨時放一個壞掉的守衛進 `tests/unit/`：

```
$ bun run typecheck:tests
tests/unit/_probe-typecheck.test.ts(3,7): error TS2322: Type 'true' is not assignable to type 'false'.
$ bun run typecheck        # 主專案不受影響
（無輸出）
```

其餘：

- `bun run typecheck` — 綠（維持現狀）
- `bun test` — 5499 通過、0 失敗
- `bun run lint` / `prettier --check .` — 綠
- `bun run build` — 綠（`dts-bundle-generator --project tsconfig.json` 仍讀主檔，不受影響）

Refs #97
