### PR TITLE
fix: [ typecheck ] 測試檔的型別護欄立起來，清乾淨的目錄不會再退回去

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Test files were never typechecked at all until #97. They are being
+      # cleared one directory at a time, and `tsconfig.tests.json` lists the ones
+      # already clean — so this is green today and stops them regressing while
+      # the rest catch up. `bun run typecheck:tests:all` shows what is left.
+      - name: Typecheck tests
+        run: bun run typecheck:tests
+
       # Via `bun run` so the timeout lives in one place (package.json). Bun's 5s
       # default is too tight for windows-latest, where spawning a process costs
       # seconds; `[test] timeout` in bunfig.toml is documented but not honoured by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,19 +75,27 @@ DBCLI_LANG=zh-TW ./dist/cli.mjs --help
 
 #### Typechecking
 
-`bun run typecheck` covers `src/` and `scripts/`. Test files are a separate project,
-`tsconfig.tests.json`, run with `bun run typecheck:tests`.
+`bun run typecheck` covers `src/` and `scripts/`. Test files are a separate project:
 
-They are separate because they are not clean yet. The main `include` carried a
+| Command | Project | Covers | State |
+| :--- | :--- | :--- | :--- |
+| `bun run typecheck:tests` | `tsconfig.tests.json` | the test directories already clean | green, **enforced in CI** |
+| `bun run typecheck:tests:all` | `tsconfig.tests.all.json` | every test file | red — the remaining backlog |
+
+They are split because they are not all clean yet. The main `include` carried a
 `tests/**/*.{ts,tsx}` pattern for a long time, and TypeScript does not expand braces in an
-include glob — so it matched nothing and no test file had ever been typechecked. Turning it
-on reports 339 errors across 174 files, about six in ten of them an unchecked array index or
-optional field under `noUncheckedIndexedAccess`. Those are being cleared one test directory
-at a time, and `typecheck:tests` joins CI and the release checklist once they are (#97).
+include glob — so it matched nothing and no test file had ever been typechecked (#97).
+Turning it on reported 339 errors across 174 files, about six in ten an unchecked array index
+or optional field under `noUncheckedIndexedAccess`.
 
-Until then, a type-level assertion written in a test file compiles but nothing in CI runs it.
-Put compile-time guards in `src/` — `src/commands/audit.ts` has one, with a note explaining
-why it lives there rather than beside the code it guards.
+**When you clean a directory, add it to `tsconfig.tests.json`'s `include`.** That list is the
+ratchet: everything in it is checked in CI and cannot regress, and the backlog shrinks as the
+list grows. When the two projects cover the same files, delete `tsconfig.tests.all.json` and
+add `typecheck:tests` to the pre-release checklist.
+
+A type-level assertion in a directory that is not on the list yet compiles but nothing runs
+it — `src/commands/audit.ts` has one and a note explaining why it lives there rather than
+beside the code it guards.
 
 ### 5. Commit
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
+    "typecheck:tests:all": "tsc --noEmit --pretty false -p tsconfig.tests.all.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",
     "lint": "eslint src tests scripts --ext .ts --max-warnings=0",
     "format:check": "prettier --check .",

--- a/tests/gherkin/review-blacklist.test.ts
+++ b/tests/gherkin/review-blacklist.test.ts
@@ -72,11 +72,11 @@ await defineFeature<BlacklistWorld>({
     },
     {
       pattern: /^the protected tables are "([^"]+)"$/,
-      run: (world, match) => expect(world.report?.tables).toEqual([match[1]]),
+      run: (world, match) => expect(world.report?.tables).toEqual([match[1]!]),
     },
     {
       pattern: /^the protected columns for "([^"]+)" are "([^"]+)"$/,
-      run: (world, match) => expect(world.report?.columns[match[1]]).toEqual([match[2]]),
+      run: (world, match) => expect(world.report?.columns[match[1]!]).toEqual([match[2]!]),
     },
   ],
 })

--- a/tests/gherkin/support/feature-runner.ts
+++ b/tests/gherkin/support/feature-runner.ts
@@ -48,11 +48,12 @@ export async function defineFeature<World>({
                   Boolean(candidate.match)
               )
 
-            if (matches.length !== 1) {
+            const [only] = matches
+            if (matches.length !== 1 || only === undefined) {
               const reason = matches.length === 0 ? 'No' : 'More than one'
               throw new Error(`${reason} step definition matched "${step.text}" in ${featurePath}`)
             }
-            await matches[0].definition.run(world, matches[0].match)
+            await only.definition.run(world, only.match)
           }
         } finally {
           await afterScenario?.(world)

--- a/tests/helpers/test-config.ts
+++ b/tests/helpers/test-config.ts
@@ -21,14 +21,19 @@ const DEFAULT_PG_CONNECTION: DbcliConfig['connection'] = {
 
 export function makeTestConfig(overrides: ConfigOverrides = {}): DbcliConfig {
   const { connection: connOverride, ...rest } = overrides
-  return {
+  // Spreading the partial overrides last is what callers expect, and it is also
+  // what makes the literal stop matching `DbcliConfig`: every key the partial
+  // mentions comes back optional. Building the complete value first and merging
+  // into it keeps the required keys required.
+  const base: DbcliConfig = {
     connection: { ...DEFAULT_PG_CONNECTION, ...connOverride } as DbcliConfig['connection'],
     permission: 'query-only',
     schema: {},
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
-    ...rest,
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
+  return { ...base, ...rest }
 }
 
 export function makeTestV2Config(

--- a/tests/unit/adapters/postgresql-schema-identity.test.ts
+++ b/tests/unit/adapters/postgresql-schema-identity.test.ts
@@ -30,7 +30,9 @@ function installForeignKeyCatalogFixture(
   }
 ): { foreignKeyQueries: string[] } {
   const foreignKeyQueries: string[] = []
-  adapter.execute = async (sql: string, params) => {
+  // A concrete mock cannot satisfy `execute`'s `<T>() => ExecutionResult<T>`
+  // for every T; it returns the rows this test's caller will ask for.
+  adapter.execute = (async (sql: string, params) => {
     const isForeignKeyQuery =
       sql.includes("constraint_type = 'FOREIGN KEY'") || sql.includes("contype = 'f'")
     if (!isForeignKeyQuery) {
@@ -43,7 +45,7 @@ function installForeignKeyCatalogFixture(
       ? fixture.oidKeyedRows[tableName]
       : fixture.nameJoinedRows[tableName]
     return { rows: rows ?? [], affectedRows: 0 }
-  }
+  }) as typeof adapter.execute
   return { foreignKeyQueries }
 }
 
@@ -91,7 +93,7 @@ function installSchemaQueryCapture(adapter: PostgreSQLAdapter): {
 } {
   const queries: Array<{ sql: string; params: unknown[] | undefined }> = []
 
-  adapter.execute = async (sql: string, params) => {
+  adapter.execute = (async (sql: string, params) => {
     queries.push({ sql, params })
 
     if (sql.includes('array_agg(primary_key_column.attname')) {
@@ -106,7 +108,7 @@ function installSchemaQueryCapture(adapter: PostgreSQLAdapter): {
     }
 
     return { rows: [], affectedRows: 0 }
-  }
+  }) as typeof adapter.execute
 
   return { queries }
 }
@@ -117,7 +119,7 @@ function normalizedQuery(sql: string): string {
 
 test('listTables preserves exact catalog schema and table names', async () => {
   const adapter = createAdapter()
-  adapter.execute = async () => ({
+  adapter.execute = (async () => ({
     rows: [
       {
         schema_name: 'Public',
@@ -128,7 +130,7 @@ test('listTables preserves exact catalog schema and table names', async () => {
       },
     ],
     affectedRows: 0,
-  })
+  })) as typeof adapter.execute
 
   expect(await adapter.listTables()).toContainEqual(
     expect.objectContaining({ schema: 'Public', name: 'Users' })

--- a/tests/unit/adapters/redis-adapter.test.ts
+++ b/tests/unit/adapters/redis-adapter.test.ts
@@ -533,10 +533,14 @@ describe('RedisAdapter — middleware (blacklist + size guard)', () => {
   })
 })
 
-function makeClientClass(reply: unknown) {
+// The adapter's client-class parameter type is not exported; take it from the
+// constructor rather than restating a shape that could drift from it.
+type RedisClientClass = ConstructorParameters<typeof RedisAdapter>[1]
+
+function makeClientClass(reply: unknown): RedisClientClass {
   return function (this: unknown) {
     return { connect: async () => {}, close: () => {}, send: async () => reply }
-  } as unknown as new () => unknown
+  } as unknown as RedisClientClass
 }
 
 test('RedisAdapter masks GET value per mask rules', async () => {

--- a/tests/unit/program/lazy-registry.test.ts
+++ b/tests/unit/program/lazy-registry.test.ts
@@ -21,8 +21,31 @@ function topLevelNames(program: Command): string[] {
   return program.commands.map((command) => command.name().split(' ')[0]!).sort()
 }
 
-/** Everything about a command that the CLI/help contract can observe. */
-function shape(command: Command) {
+/**
+ * Everything about a command that the CLI/help contract can observe.
+ *
+ * Written out rather than inferred because `shape` recurses through
+ * `subcommands`, and TypeScript cannot infer a type that refers to itself.
+ */
+interface CommandShape {
+  name: string
+  description: string
+  arguments: Array<{ name: string; required: boolean; variadic: boolean }>
+  options: Array<{
+    flags: string
+    long: string | undefined
+    short: string | undefined
+    description: string
+    defaultValue: unknown
+    required: boolean
+    optional: boolean
+    hasParser: boolean
+    choices: string[] | undefined
+  }>
+  subcommands: CommandShape[]
+}
+
+function shape(command: Command): CommandShape {
   return {
     name: command.name(),
     description: command.description(),

--- a/tests/unit/querylens/querylens.test.ts
+++ b/tests/unit/querylens/querylens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { analyzeQuerylensEvents, redactEventsForAnalysis } from '@/querylens/analyze'
 import { renderQuerylensMarkdown } from '@/querylens/render'
+import type { QueryCompletedEvent } from '@/proxy/events'
 import { completed, errored, sessionStarted } from '../proxy/event-fixtures'
 
 const analyzeOptions = { slowMs: 50, top: 3, nPlusOne: 2, sourceFiles: [], malformedLines: 0 }
@@ -10,7 +11,9 @@ describe('QueryLens analysis', () => {
     const original = completed({
       sql: "SELECT * FROM users WHERE email = 'secret@example.com' AND id = 42",
     })
-    const redacted = redactEventsForAnalysis([original])
+    // `redactEventsForAnalysis` takes and returns the whole `ProxyEvent` union,
+    // only three members of which carry `sql`. What went in here is one of them.
+    const redacted = redactEventsForAnalysis([original]) as QueryCompletedEvent[]
     expect(redacted[0]!.sql).toBe('SELECT * FROM users WHERE email = ? AND id = ?')
     expect(original.sql).toContain('secret@example.com')
 

--- a/tests/unit/utils/update-hint-state.test.ts
+++ b/tests/unit/utils/update-hint-state.test.ts
@@ -29,7 +29,7 @@ describe('update hint session state', () => {
     expect(await claimUpdateHint(configPath, 'update', 'session-b', '1.3.0')).toBe(true)
 
     const state = JSON.parse(await readFile(updateHintStatePathForTest(configPath), 'utf8')) as {
-      sessions: Record<string, { update?: string; skill?: string }>
+      sessions: Record<string, { update?: string; skill?: string; updatedAt: string }>
     }
     expect(state.sessions['session-a']).toEqual({
       update: '1.2.0',

--- a/tsconfig.tests.all.json
+++ b/tsconfig.tests.all.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,4 +1,28 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
+  "include": [
+    "tests/commands/**/*.ts",
+    "tests/contract/**/*.ts",
+    "tests/core/**/*.ts",
+    "tests/fixtures/**/*.ts",
+    "tests/gherkin/**/*.ts",
+    "tests/graft/**/*.ts",
+    "tests/helpers/**/*.ts",
+    "tests/perf/**/*.ts",
+    "tests/unit/*.ts",
+    "tests/unit/adapters/**/*.ts",
+    "tests/unit/agent-core/**/*.ts",
+    "tests/unit/agent-tasks/**/*.ts",
+    "tests/unit/build/**/*.ts",
+    "tests/unit/formatters/**/*.ts",
+    "tests/unit/i18n/**/*.ts",
+    "tests/unit/program/**/*.ts",
+    "tests/unit/proxy/**/*.ts",
+    "tests/unit/querylens/**/*.ts",
+    "tests/unit/recovery/**/*.ts",
+    "tests/unit/scripts/**/*.ts",
+    "tests/unit/skill-assets/**/*.ts",
+    "tests/unit/ui-template/**/*.ts",
+    "tests/unit/utils/**/*.ts"
+  ]
 }


### PR DESCRIPTION
#97 第二步的第一批。#100 讓測試檔可以被 typecheck，這個 PR 開始清，並且把**護欄**立起來。

## 為什麼先立護欄

`tsconfig.tests.json` 改成「已清乾淨的目錄」清單，直接接進 CI。這樣它今天就是綠的，而清完的部分不會在其餘目錄追上來之前退回去——分好幾個 PR 清 326 個錯誤，中間如果沒有 ratchet，就是一場追不完的賽跑。

新增 `tsconfig.tests.all.json` 與 `bun run typecheck:tests:all` 用來看還剩多少。

| 指令 | 專案 | 涵蓋 | 狀態 |
| :--- | :--- | :--- | :--- |
| `bun run typecheck:tests` | `tsconfig.tests.json` | 已清乾淨的目錄 | 綠，**CI 強制** |
| `bun run typecheck:tests:all` | `tsconfig.tests.all.json` | 全部測試檔 | 紅——剩餘的量 |

清完一個目錄就把它加進 `tsconfig.tests.json` 的 include。兩邊涵蓋範圍相同時，刪掉 `tsconfig.tests.all.json`，把 `typecheck:tests` 加進 release checklist。

## 這批清掉的

13 個錯誤，涵蓋 151 個測試檔（23 個目錄）。不全是 issue 預估的 `!` / `?.` 機械類，幾個值得記一筆：

**`tests/helpers/test-config.ts` 的 `makeTestConfig` 產出的根本不是合法的 `DbcliConfig`。** Partial 覆寫展開在必要欄位後面，把它們全變回 optional，而且缺 `audit`。改成先組完整值再合併覆寫，並補上 `audit` 預設（與 zod schema 的預設一致）。這是共用 helper，所有用它的測試都跟著改變，全套 5499 個測試通過。

**`tests/unit/utils/update-hint-state.test.ts` 自己寫的 state 型別漏了 `updatedAt`**，但斷言裡正在檢查它——測試檔裡的型別註記從來沒被檢查過的直接後果。

**`tests/unit/program/lazy-registry.test.ts` 的 `shape` 會遞迴走 `subcommands`**，TypeScript 推不出指涉自己的型別，補上明確的 `CommandShape` interface。

其餘是 `noUncheckedIndexedAccess` 下的正規式捕獲群組索引、mock 的具體回傳值無法滿足 `<T>() => ExecutionResult<T>`（改用 `as typeof adapter.execute`，並在註解說明為什麼具體 mock 不可能滿足任意 T）、以及 `RedisCtor` 沒有 export 所以改用 `ConstructorParameters<typeof RedisAdapter>[1]` 取型別而不是自己重述一份會漂移的形狀。

## 剩餘

```
211  tests/unit/core
 48  tests/unit/commands
 37  tests/integration
 30  tests/docs
```

`tests/docs` 不是機械類——是 happy-dom 與 lib.dom 的型別衝突（`Document`、`HTMLElement` 兩套定義互不相容），需要真的想過怎麼收，留給自己的 PR。

## Test plan

- `bun run typecheck` — 綠
- `bun run typecheck:tests` — 綠（新的 CI gate）
- `bun run typecheck:tests:all` — 326 個錯誤（清乾淨前預期為紅）
- `bun test` — 5499 通過、0 失敗（含 `makeTestConfig` 改動後的全套回歸）
- `bun run lint` / `prettier --check .` — 綠

Refs #97
