### PR TITLE
fix: [ typecheck ] tests/integration 清乾淨並納入護欄

### DIFF
--- a/tests/integration/audit-contract.test.ts
+++ b/tests/integration/audit-contract.test.ts
@@ -211,10 +211,10 @@ describe('Audit Contract Integration', () => {
 
     const entries = await auditLines()
     expect(entries).toHaveLength(1)
-    expect(entries[0].success).toBe(true)
-    expect(entries[0].command).toBe('query')
-    expect(entries[0].target).toBe('users')
-    expect((entries[0].metadata as Record<string, unknown>).execution_ms).toBeNumber()
+    expect(entries[0]!.success).toBe(true)
+    expect(entries[0]!.command).toBe('query')
+    expect(entries[0]!.target).toBe('users')
+    expect((entries[0]!.metadata as Record<string, unknown>).execution_ms).toBeNumber()
   })
 
   test('one CLI query writes exactly one audit entry — failure', async () => {
@@ -238,7 +238,7 @@ describe('Audit Contract Integration', () => {
 
     const entries = await auditLines()
     expect(entries).toHaveLength(1)
-    expect(entries[0].success).toBe(false)
-    expect(entries[0].error).toContain('table not found')
+    expect(entries[0]!.success).toBe(false)
+    expect(entries[0]!.error).toContain('table not found')
   })
 })

--- a/tests/integration/audit-engines.test.ts
+++ b/tests/integration/audit-engines.test.ts
@@ -132,7 +132,7 @@ describe('Cross-Engine Audit & Rejection Paths', () => {
 
     const logPath = join(auditDir, 'mongo-conn.jsonl')
     const logLines = (await readFile(logPath, 'utf8')).split('\n').filter(Boolean)
-    const entry = JSON.parse(logLines[0])
+    const entry = JSON.parse(logLines[0]!)
 
     expect(entry.engine).toBe('mongodb')
     expect(entry.target).toBe('logs')

--- a/tests/integration/commands/query.test.ts
+++ b/tests/integration/commands/query.test.ts
@@ -6,7 +6,6 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { queryCommand } from '@/commands/query'
 import { PostgreSQLAdapter } from '@/adapters/postgresql-adapter'
-import type { DbcliConfig } from '@/utils/validation'
 
 // Use SQLite for testing (no external database required)
 // In production, can be configured to use real PostgreSQL/MySQL
@@ -17,22 +16,6 @@ let mockConsoleError: string[] = []
 
 describe('Query Command Integration', () => {
   beforeAll(async () => {
-    // Create mock config
-    const _config: DbcliConfig = {
-      connection: {
-        system: 'postgresql',
-        host: 'localhost',
-        port: 5432,
-        user: 'postgres',
-        password: 'postgres',
-        database: 'test_db',
-      },
-      permission: 'query-only',
-      schema: {},
-      metadata: { version: '1.0' },
-      blacklist: { tables: [], columns: {} },
-    }
-
     // Mock console for capturing output
     mockConsoleLog = []
     mockConsoleError = []

--- a/tests/integration/connection-selector.test.ts
+++ b/tests/integration/connection-selector.test.ts
@@ -42,7 +42,9 @@ async function run(
   args: string[],
   environmentConnection?: string
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  const env = {
+  // `process.env` spreads into an object with only the declared keys, so the
+  // annotation is what lets a test add or drop a variable dbcli reads.
+  const env: Record<string, string | undefined> = {
     ...process.env,
     NODE_ENV: 'test',
     DBCLI_NO_UPDATE_CHECK: '1',

--- a/tests/integration/core/audit-concurrent.test.ts
+++ b/tests/integration/core/audit-concurrent.test.ts
@@ -13,6 +13,32 @@ import { join } from 'node:path'
 
 import { AuditLogger } from '../../../src/core/audit/logger'
 import { SessionIdService } from '../../../src/core/audit/session-id'
+import type { AuditEntry } from '../../../src/core/audit/types'
+
+/**
+ * A valid audit entry carrying the marker these assertions read.
+ *
+ * `write` takes a whole `AuditEntry` minus the three fields the logger fills in.
+ * This file used to hand it a bare `{ src, i }`, which no typechecker ever saw;
+ * the markers now travel in `metadata`, where arbitrary keys belong.
+ */
+function markedEntry(
+  marker: Record<string, unknown>
+): Omit<AuditEntry, 'id' | 'ts' | 'session_id'> {
+  return {
+    engine: 'postgresql',
+    command: 'query',
+    side_effect_tier: 'readonly',
+    target: 'test_table',
+    success: true,
+    redacted_query: 'query test_table',
+    metadata: marker,
+  }
+}
+
+function markerOf(row: Record<string, unknown>): string | undefined {
+  return (row['metadata'] as { src?: string } | undefined)?.src
+}
 
 let workDir: string
 let originalEnv: string | undefined
@@ -53,8 +79,8 @@ describe('AuditLogger concurrent integration (STORE-03)', () => {
     const sessionIdService = new SessionIdService(workDir)
     const loggerA = makeLogger('default', sessionIdService)
     const loggerB = makeLogger('default', sessionIdService)
-    const entriesA = Array.from({ length: 50 }, (_, i) => ({ src: 'a', i }))
-    const entriesB = Array.from({ length: 50 }, (_, i) => ({ src: 'b', i }))
+    const entriesA = Array.from({ length: 50 }, (_, i) => markedEntry({ src: 'a', i }))
+    const entriesB = Array.from({ length: 50 }, (_, i) => markedEntry({ src: 'b', i }))
 
     const results = await Promise.all([
       ...entriesA.map((entry) => loggerA.write(entry)),
@@ -72,7 +98,7 @@ describe('AuditLogger concurrent integration (STORE-03)', () => {
     expect(parsed.length).toBe(successCount)
     for (const row of parsed) {
       expect(row['session_id']).toBe('concurrent-test-session')
-      expect(row['src'] === 'a' || row['src'] === 'b').toBe(true)
+      expect(markerOf(row) === 'a' || markerOf(row) === 'b').toBe(true)
     }
     expect(successCount).toBeGreaterThanOrEqual(95)
   })
@@ -93,8 +119,8 @@ describe('AuditLogger concurrent integration (STORE-03)', () => {
       rotation: { maxBytes: 10_000_000, maxEntries: 10_000 },
       sessionIdService,
     })
-    const entriesA = Array.from({ length: 50 }, (_, i) => ({ src: 'a', i }))
-    const entriesB = Array.from({ length: 50 }, (_, i) => ({ src: 'b', i }))
+    const entriesA = Array.from({ length: 50 }, (_, i) => markedEntry({ src: 'a', i }))
+    const entriesB = Array.from({ length: 50 }, (_, i) => markedEntry({ src: 'b', i }))
 
     const results = await Promise.all([
       ...entriesA.map((entry) => loggerA.write(entry)),
@@ -108,7 +134,7 @@ describe('AuditLogger concurrent integration (STORE-03)', () => {
 
     expect(connALines.length).toBe(50)
     expect(connBLines.length).toBe(50)
-    expect(connALines.every((row) => row['src'] === 'a')).toBe(true)
-    expect(connBLines.every((row) => row['src'] === 'b')).toBe(true)
+    expect(connALines.every((row) => markerOf(row) === 'a')).toBe(true)
+    expect(connBLines.every((row) => markerOf(row) === 'b')).toBe(true)
   })
 })

--- a/tests/integration/core/audit-readonly.test.ts
+++ b/tests/integration/core/audit-readonly.test.ts
@@ -12,6 +12,28 @@ import { join } from 'node:path'
 
 import { AuditLogger } from '../../../src/core/audit/logger'
 import { SessionIdService } from '../../../src/core/audit/session-id'
+import type { AuditEntry } from '../../../src/core/audit/types'
+
+/**
+ * A valid audit entry carrying whatever marker a test needs to recognise it.
+ *
+ * `write` takes a whole `AuditEntry` minus the three fields the logger fills in.
+ * These tests are about a readonly directory rather than about entry content, so
+ * they used to pass a bare `{ i: 1 }` — which no typechecker ever saw.
+ */
+function markedEntry(
+  marker: Record<string, unknown>
+): Omit<AuditEntry, 'id' | 'ts' | 'session_id'> {
+  return {
+    engine: 'postgresql',
+    command: 'query',
+    side_effect_tier: 'readonly',
+    target: 'test_table',
+    success: true,
+    redacted_query: 'query test_table',
+    metadata: marker,
+  }
+}
 
 let workDir: string
 let auditDir: string
@@ -76,13 +98,13 @@ describe('AuditLogger readonly-dir integration (STORE-04 / D6)', () => {
     stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true)
     const logger = makeLogger()
 
-    const first = await logger.write({ i: 1 })
+    const first = await logger.write(markedEntry({ i: 1 }))
 
     // A readonly audit dir commonly exhausts the lock budget because the
     // lockfile temp write cannot succeed; either skip marker is fail-soft.
     expect(first).toEqual(expect.objectContaining({ skipped: expect.any(String) }))
     for (let i = 2; i <= 6; i += 1) {
-      const result = await logger.write({ i })
+      const result = await logger.write(markedEntry({ i }))
       expect(result).toEqual(expect.objectContaining({ skipped: expect.any(String) }))
     }
 
@@ -101,7 +123,11 @@ describe('AuditLogger readonly-dir integration (STORE-04 / D6)', () => {
 
     async function simulatedMainCommand(auditLogger: AuditLogger) {
       const result = { rows: 3, command: 'query' }
-      await auditLogger.write({ command: 'query', success: true, rowsAffected: 3 })
+      await auditLogger.write({
+        ...markedEntry({ rowsAffected: 3 }),
+        command: 'query',
+        success: true,
+      })
       return { result, exitCode: 0 }
     }
 
@@ -115,12 +141,12 @@ describe('AuditLogger readonly-dir integration (STORE-04 / D6)', () => {
     await makeReadonlyAuditDir()
     stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true)
     const logger1 = makeLogger()
-    const failed = await logger1.write({ beforeRestore: true })
+    const failed = await logger1.write(markedEntry({ beforeRestore: true }))
     expect(failed).toEqual(expect.objectContaining({ skipped: expect.any(String) }))
 
     await chmod(auditDir, 0o755)
     const logger2 = makeLogger()
-    const result = await logger2.write({ recovered: true })
+    const result = await logger2.write(markedEntry({ recovered: true }))
 
     expect(result).toEqual(expect.objectContaining({ success: true }))
     const raw = await readFile(join(auditDir, 'default.jsonl'), 'utf8')
@@ -128,7 +154,7 @@ describe('AuditLogger readonly-dir integration (STORE-04 / D6)', () => {
     expect(lines.length).toBe(1)
     expect(JSON.parse(lines[0]!)).toEqual(
       expect.objectContaining({
-        recovered: true,
+        metadata: { recovered: true },
         session_id: 'readonly-test-session',
         id: expect.any(String),
         ts: expect.any(String),

--- a/tests/integration/core/schema-system.integration.test.ts
+++ b/tests/integration/core/schema-system.integration.test.ts
@@ -82,6 +82,7 @@ test('Integration: Schema refresh detects changes', async () => {
     schema: {},
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
 
   const configPath = join(testDir, 'config.json')
@@ -155,6 +156,7 @@ test('Integration: Error recovery restores on failure', async () => {
     schema: { test_table: { name: 'test', columns: [] } },
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
 
   const configPath = join(testDir, 'config.json')
@@ -283,6 +285,7 @@ test('Integration: Complete workflow with all components', async () => {
     schema: {},
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
 
   // Add tables

--- a/tests/integration/elasticsearch.test.ts
+++ b/tests/integration/elasticsearch.test.ts
@@ -34,7 +34,6 @@ describe('Elasticsearch Integration', () => {
     const index = 'test-index-' + Date.now()
 
     // 1. Create index with mapping (using fetch directly since adapter doesn't have createIndex)
-    // @ts-expect-error - accessing private request() for test setup
     await adapter.request('PUT', `/${index}`, {
       mappings: {
         properties: {
@@ -48,7 +47,6 @@ describe('Elasticsearch Integration', () => {
     await adapter.insert(index, { id: 'doc1', title: 'Hello ES', tags: ['test'] })
 
     // Refresh index
-    // @ts-expect-error - accessing private request() for test setup
     await adapter.request('POST', `/${index}/_refresh`)
 
     // 3. Query document
@@ -67,7 +65,6 @@ describe('Elasticsearch Integration', () => {
     expect(schema.columns).toContainEqual({ name: 'tags', type: 'keyword', nullable: true })
 
     // Cleanup
-    // @ts-expect-error - accessing private request() for test cleanup
     await adapter.request('DELETE', `/${index}`)
   })
 })

--- a/tests/integration/init-command.test.ts
+++ b/tests/integration/init-command.test.ts
@@ -103,6 +103,7 @@ describe('Init Command Integration Tests', () => {
         createdAt: '2026-03-25T00:00:00Z',
       },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
 
     // 合併新值
@@ -130,6 +131,7 @@ describe('Init Command Integration Tests', () => {
       schema: {},
       metadata: { version: '1.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
 
     const originalCopy = JSON.stringify(original)

--- a/tests/integration/mongo-operator-tier.test.ts
+++ b/tests/integration/mongo-operator-tier.test.ts
@@ -80,7 +80,9 @@ describe('mongo operator tier integration', () => {
       }
     )
     expect(plan.decision).toBe('WARN')
-    await col.updateOne({ _id: 't' } as any, { $push: { tags: 'new' } })
+    // The driver types `$push` against the collection's document type, which
+    // this test never declares — the surrounding `_id` casts say the same.
+    await col.updateOne({ _id: 't' } as any, { $push: { tags: 'new' } } as any)
     const doc = await col.findOne({ _id: 't' } as any)
     expect((doc as any).tags).toEqual(['new'])
   })

--- a/tests/integration/multi-connection.test.ts
+++ b/tests/integration/multi-connection.test.ts
@@ -36,6 +36,7 @@ const v2ConfigBase = {
   schemas: {},
   metadata: { version: '1.0' },
   blacklist: { tables: [], columns: {} },
+  audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
 }
 
 describe('multi-connection integration', () => {

--- a/tests/integration/no-limit-flag.test.ts
+++ b/tests/integration/no-limit-flag.test.ts
@@ -19,7 +19,13 @@ let workspace: string
 let configDir: string
 
 async function run(args: string[]) {
-  const env = { ...process.env, NODE_ENV: 'test', DBCLI_NO_UPDATE_CHECK: '1' }
+  // `process.env` spreads into an object with only the declared keys, so the
+  // annotation is what lets a test add or drop a variable dbcli reads.
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    NODE_ENV: 'test',
+    DBCLI_NO_UPDATE_CHECK: '1',
+  }
   delete env.DBCLI_CONNECTION
   const child = Bun.spawn({
     cmd: ['bun', 'run', CLI, '--config', configDir, ...args],

--- a/tests/integration/query-fields.test.ts
+++ b/tests/integration/query-fields.test.ts
@@ -9,7 +9,13 @@ let workspace: string
 let configDir: string
 
 async function run(args: string[]) {
-  const env = { ...process.env, NODE_ENV: 'test', DBCLI_NO_UPDATE_CHECK: '1' }
+  // `process.env` spreads into an object with only the declared keys, so the
+  // annotation is what lets a test add or drop a variable dbcli reads.
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    NODE_ENV: 'test',
+    DBCLI_NO_UPDATE_CHECK: '1',
+  }
   delete env.DBCLI_CONNECTION
   const child = Bun.spawn({
     cmd: ['bun', 'run', CLI, '--config', configDir, '--use', 'missing', 'query', ...args],

--- a/tests/integration/query-input.test.ts
+++ b/tests/integration/query-input.test.ts
@@ -33,8 +33,10 @@ async function run(
     stderr: 'pipe',
   })
   if (stdin !== undefined) {
-    child.stdin.write(stdin)
-    child.stdin.end()
+    // `stdin: 'pipe'` is what the spawn above asked for on exactly this branch,
+    // but the handle's type does not carry that correlation.
+    child.stdin!.write(stdin)
+    child.stdin!.end()
   }
   const [stdout, stderr, code] = await Promise.all([
     new Response(child.stdout).text(),

--- a/tests/integration/query-truncate.test.ts
+++ b/tests/integration/query-truncate.test.ts
@@ -9,7 +9,13 @@ let workspace: string
 let configDir: string
 
 async function run(args: string[]) {
-  const env = { ...process.env, NODE_ENV: 'test', DBCLI_NO_UPDATE_CHECK: '1' }
+  // `process.env` spreads into an object with only the declared keys, so the
+  // annotation is what lets a test add or drop a variable dbcli reads.
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    NODE_ENV: 'test',
+    DBCLI_NO_UPDATE_CHECK: '1',
+  }
   delete env.DBCLI_CONNECTION
   const child = Bun.spawn({
     cmd: ['bun', 'run', CLI, '--config', configDir, '--use', 'missing', 'query', ...args],

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -8,6 +8,7 @@
     "tests/gherkin/**/*.ts",
     "tests/graft/**/*.ts",
     "tests/helpers/**/*.ts",
+    "tests/integration/**/*.ts",
     "tests/perf/**/*.ts",
     "tests/unit/*.ts",
     "tests/unit/adapters/**/*.ts",


### PR DESCRIPTION
#97 第二步的第二批。**堆在 #101 上面**（base 是 `fix/typecheck-tests-batch-1`），#101 合併後這個 PR 的 base 會自動變成 `main`。

37 個錯誤歸零，`tests/integration` 加進 `tsconfig.tests.json`。CI 涵蓋的測試檔從 151 增為 230，剩餘從 326 降為 289。

## 大半是同一個根因

`audit` 是 `DbcliConfig` / `DbcliConfigV2` 的必要欄位，但測試裡到處手寫 config literal 而漏掉它。runtime 靠 zod 預設補上，所以測試一直是綠的——型別層從來沒人看。這批補在 v1 三處、v2 base 一處（v2 那一處修好四個錯誤）。

## 不是「加個驚嘆號」能了事的

**`tests/integration/commands/query.test.ts` 的 `_config` 只有賦值、沒有任何人讀。** 底線前綴讓 ESLint 也不吭聲。刪掉整塊而不是補欄位——補欄位等於為一個沒人讀的值維護正確性。

**`audit-concurrent` / `audit-readonly` 對 `logger.write()` 傳的根本不是 `AuditEntry`。** `{ src: 'a', i }`、`{ i: 1 }`、`{ beforeRestore: true }` 這些會被序列化進 log 的頂層。改成 `markedEntry()` 產生合法 entry，標記走 `metadata`——那才是任意鍵該待的地方——斷言跟著改成讀 `metadata`。

**`tests/integration/elasticsearch.test.ts` 的三個 `@ts-expect-error` 是化石。** 註解寫著「accessing private request() for test setup」，但 `request` 早就是 public 了。因為測試檔從不 typecheck，沒有東西會告訴你這個抑制已經沒有作用——`TS2578: Unused '@ts-expect-error' directive` 正是打開之後才會出現的診斷。

**`{ ...process.env, ... }` 展開後只剩宣告過的鍵**，於是 `delete env.DBCLI_CONNECTION` 不合法（5 處）。補上 `Record<string, string | undefined>` 註記。

其餘是陣列索引、`child.stdin` 在 `stdin: 'pipe'` 分支下的窄化、以及 mongo driver 的 `$push` 對未宣告文件型別的檢查。

## 剩餘

```
211  tests/unit/core
 48  tests/unit/commands
 30  tests/docs
```

## Test plan

- `bun run typecheck` / `typecheck:tests` — 綠
- `bun run typecheck:tests:all` — 289（原 326）
- `bun test` — 5499 通過、0 失敗。`markedEntry` 改寫了實際寫進 log 的內容，audit-readonly 有一條斷言跟著從讀頂層 `recovered` 改成讀 `metadata.recovered`
- `bun run lint` / `prettier --check .` — 綠

Refs #97
