### PR TITLE
fix: [ typecheck ] tests/unit/commands 清乾淨並納入護欄

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -92,7 +92,9 @@ interface QueryExecutionContext {
   connectionName?: string
 }
 
-interface QueryExecutionOutput {
+/** What one connection's execution hands back. Exported so a caller substituting
+ * the `executeConnection` seam can type its stand-in against the real contract. */
+export interface QueryExecutionOutput {
   result: QueryResult<Record<string, unknown>>
   diagnostics: string[]
   notices: string[]

--- a/tests/unit/commands/delete-plan.test.ts
+++ b/tests/unit/commands/delete-plan.test.ts
@@ -81,7 +81,11 @@ describe('deleteCommand --plan', () => {
   })
 
   test('BLOCK on insufficient permission exits 0 (no admin gate before --plan)', async () => {
-    mockConfig = makeConfig({ permission: 'read-only' })
+    // `read-only` is not one of the four permission values; the plan blocked
+    // anyway because an unrecognised level grants nothing, so this asserted
+    // the right outcome for the wrong reason. `query-only` is the real level
+    // that cannot delete.
+    mockConfig = makeConfig({ permission: 'query-only' })
     configReadSpy.mockImplementation(async () => mockConfig)
     const exitSpy = spyOn(process, 'exit').mockImplementation((() => undefined) as never)
 

--- a/tests/unit/commands/dml-plan-nonsql.test.ts
+++ b/tests/unit/commands/dml-plan-nonsql.test.ts
@@ -31,6 +31,7 @@ function configFor(system: 'mongodb' | 'redis' | 'elasticsearch'): DbcliConfig {
       schema: baseSchema(),
       metadata: { version: '1.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     } as DbcliConfig
   }
   if (system === 'redis') {
@@ -47,6 +48,7 @@ function configFor(system: 'mongodb' | 'redis' | 'elasticsearch'): DbcliConfig {
       schema: baseSchema(),
       metadata: { version: '1.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     } as DbcliConfig
   }
   return {
@@ -62,6 +64,7 @@ function configFor(system: 'mongodb' | 'redis' | 'elasticsearch'): DbcliConfig {
     schema: baseSchema(),
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   } as DbcliConfig
 }
 

--- a/tests/unit/commands/evidence-receipt-context.test.ts
+++ b/tests/unit/commands/evidence-receipt-context.test.ts
@@ -4,22 +4,18 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { RuntimeDbcliConfig } from '@/core/config'
 import { buildEvidenceReceiptContext } from '@/commands/evidence-receipt-context'
+import { makeTestConfig } from '../../helpers/test-config'
 
 function config(schema: Record<string, unknown>): RuntimeDbcliConfig {
   return {
-    connection: {
-      system: 'postgresql',
-      host: 'localhost',
-      port: 5432,
-      user: 'postgres',
-      database: 'dbcli',
-    },
-    permission: 'query-only',
-    blacklist: { tables: ['private_accounts'], columns: { orders: ['secret'] } },
-    schema,
+    ...makeTestConfig({
+      connection: { user: 'postgres', database: 'dbcli' },
+      blacklist: { tables: ['private_accounts'], columns: { orders: ['secret'] } },
+      schema,
+    }),
     effectiveConnectionName: 'staging',
     effectiveEnvironment: 'staging',
-  } as RuntimeDbcliConfig
+  }
 }
 
 describe('evidence receipt context', () => {

--- a/tests/unit/commands/init-mongodb-fields.test.ts
+++ b/tests/unit/commands/init-mongodb-fields.test.ts
@@ -59,7 +59,7 @@ async function runInit(
   const selectSpy = spyOn(promptUser, 'select').mockImplementation(
     async (label: string, choices: string[]) => {
       const answer = answerFor(label)
-      return answer === '' ? choices[0] : String(answer)
+      return answer === '' ? (choices[0] ?? '') : String(answer)
     }
   )
   const confirmSpy = spyOn(promptUser, 'confirm').mockImplementation(async (label: string) => {

--- a/tests/unit/commands/lint.test.ts
+++ b/tests/unit/commands/lint.test.ts
@@ -45,7 +45,7 @@ describe('runLint', () => {
     )
 
     expect(reports).toHaveLength(1)
-    expect(reports[0].findings.map((finding) => finding.rule)).toContain('select-star')
+    expect(reports[0]!.findings.map((finding) => finding.rule)).toContain('select-star')
   })
 
   for (const system of ['postgresql', 'mysql', 'mariadb'] as const) {
@@ -63,7 +63,7 @@ describe('runLint', () => {
         }
       )
 
-      expect(reports[0].dialect).toBe(system)
+      expect(reports[0]!.dialect).toBe(system)
     })
   }
 
@@ -97,7 +97,7 @@ describe('runLint', () => {
       { config: baseConfig, schema, loadSavedQuery: noSnippets }
     )
 
-    expect(reports[0].skippedRules).toEqual(
+    expect(reports[0]!.skippedRules).toEqual(
       expect.arrayContaining([
         { rule: 'implicit-cast', reason: 'blocked: --no-schema' },
         { rule: 'not-in-nullable', reason: 'blocked: --no-schema' },
@@ -118,8 +118,8 @@ describe('runLint', () => {
       }
     )
 
-    expect(reports[0].label).toBe('perf/top')
-    expect(reports[0].findings.map((finding) => finding.rule)).toContain('select-star')
+    expect(reports[0]!.label).toBe('perf/top')
+    expect(reports[0]!.findings.map((finding) => finding.rule)).toContain('select-star')
   })
 
   test('resolves SQL files and comma-separated bulk inputs', async () => {
@@ -138,7 +138,7 @@ describe('runLint', () => {
       )
 
       expect(reports).toHaveLength(3)
-      expect(reports[0].label).toBe('queries.sql#1')
+      expect(reports[0]!.label).toBe('queries.sql#1')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -480,7 +480,7 @@ describe('lint command registration surface', () => {
 
       expect(await Bun.file(join(configPath, 'schemas')).exists()).toBe(false)
       expect(reports).toHaveLength(1)
-      expect(reports[0].skippedRules).toEqual(
+      expect(reports[0]!.skippedRules).toEqual(
         expect.arrayContaining([
           { rule: 'implicit-cast', reason: 'blocked: --no-schema' },
           { rule: 'not-in-nullable', reason: 'blocked: --no-schema' },
@@ -516,12 +516,12 @@ describe('executeLintCommand audit and recovery wiring', () => {
 
     expect(result.reports).toHaveLength(1)
     expect(auditCalls).toHaveLength(1)
-    expect(auditCalls[0][1]).toBe('lint')
-    expect(auditCalls[0][2]).toEqual(expect.objectContaining({ config: '/project/.dbcli' }))
-    expect(auditCalls[0][3]).toEqual({
+    expect(auditCalls[0]![1]).toBe('lint')
+    expect(auditCalls[0]![2]).toEqual(expect.objectContaining({ config: '/project/.dbcli' }))
+    expect(auditCalls[0]![3]).toEqual({
       success: true,
       target: '*',
-      metadata: { queries: 1, findings: result.reports[0].findings.length },
+      metadata: { queries: 1, findings: result.reports[0]!.findings.length },
     })
   })
 
@@ -533,7 +533,7 @@ describe('executeLintCommand audit and recovery wiring', () => {
         loadDeps: async () => loadedDeps,
         loadSavedQuery: noSnippets,
         writeAudit: async (_config, _command, _options, outcome) => {
-          outcomes.push(outcome as Record<string, unknown>)
+          outcomes.push(outcome as unknown as Record<string, unknown>)
           return 'failure-audit'
         },
       })

--- a/tests/unit/commands/mutation-outcome.test.ts
+++ b/tests/unit/commands/mutation-outcome.test.ts
@@ -61,7 +61,7 @@ describe('renderMutationOutcome', () => {
   test('a write that matched nothing says so rather than reporting zero rows', () => {
     const lines = renderMutationOutcome(result({ rows_affected: 0 }), 'users', 50)
 
-    expect(lines[0].toLowerCase()).toContain('no rows')
+    expect(lines[0]!.toLowerCase()).toContain('no rows')
     expect(lines[0]).toContain('users')
   })
 
@@ -72,14 +72,14 @@ describe('renderMutationOutcome', () => {
       5
     )
 
-    expect(lines[0].toLowerCase()).toContain('cancel')
+    expect(lines[0]!.toLowerCase()).toContain('cancel')
     expect(lines[0]).toContain('users')
   })
 
   test('a dry run states that nothing changed', () => {
     const lines = renderMutationOutcome(result({ status: 'dry_run', rows_affected: 0 }), 'users', 5)
 
-    expect(lines[0].toLowerCase()).toContain('preview')
+    expect(lines[0]!.toLowerCase()).toContain('preview')
   })
 
   test('a failure leads with the reason', () => {

--- a/tests/unit/commands/mutation-recovery-output.test.ts
+++ b/tests/unit/commands/mutation-recovery-output.test.ts
@@ -105,10 +105,11 @@ describe('SQL mutation recovery output', () => {
     }
     const envelopeId = emitOptions.envelopeId
     const auditRef = emitOptions.auditRef
-    expect(emitOptions).toMatchObject({
-      envelopeId: expect.any(String),
-      auditRef: expect.any(String),
-    })
+    // Asserted rather than matched, so the two reads below are strings to the
+    // typechecker as well as at runtime.
+    expect(envelopeId).toBeString()
+    expect(auditRef).toBeString()
+    if (envelopeId === undefined || auditRef === undefined) throw new Error('unreachable')
 
     const rawAudit = await Bun.file(join(workDir, '.dbcli', 'audit', 'default.jsonl')).text()
     const auditEntries = rawAudit

--- a/tests/unit/commands/no-limit-normalization.test.ts
+++ b/tests/unit/commands/no-limit-normalization.test.ts
@@ -13,19 +13,28 @@ import { normalizeLimitFlags } from '@/program'
 
 describe('normalizeLimitFlags', () => {
   test('--no-limit (limit: false) becomes noLimit', () => {
-    expect(normalizeLimitFlags({ limit: false })).toEqual({ limit: undefined, noLimit: true })
+    expect(normalizeLimitFlags({ limit: false }) as Record<string, unknown>).toEqual({
+      limit: undefined,
+      noLimit: true,
+    })
   })
 
   test('an omitted standalone flag (limit: true) is not noLimit', () => {
-    expect(normalizeLimitFlags({ limit: true })).toEqual({ limit: undefined, noLimit: false })
+    expect(normalizeLimitFlags({ limit: true }) as Record<string, unknown>).toEqual({
+      limit: undefined,
+      noLimit: false,
+    })
   })
 
   test('a real row count survives untouched', () => {
-    expect(normalizeLimitFlags({ limit: 500 })).toEqual({ limit: 500, noLimit: false })
+    expect(normalizeLimitFlags({ limit: 500 }) as Record<string, unknown>).toEqual({
+      limit: 500,
+      noLimit: false,
+    })
   })
 
   test('neither flag given leaves limit undefined', () => {
-    expect(normalizeLimitFlags({})).toEqual({ noLimit: false })
+    expect(normalizeLimitFlags({}) as Record<string, unknown>).toEqual({ noLimit: false })
   })
 
   test('a boolean limit never reaches the command as a row count', () => {
@@ -35,7 +44,12 @@ describe('normalizeLimitFlags', () => {
   })
 
   test('unrelated options are preserved', () => {
-    expect(normalizeLimitFlags({ format: 'json', collection: 'users', limit: false })).toEqual({
+    expect(
+      normalizeLimitFlags({ format: 'json', collection: 'users', limit: false }) as Record<
+        string,
+        unknown
+      >
+    ).toEqual({
       format: 'json',
       collection: 'users',
       limit: undefined,

--- a/tests/unit/commands/plan.test.ts
+++ b/tests/unit/commands/plan.test.ts
@@ -3,6 +3,7 @@ import { AdapterFactory } from '@/adapters'
 import { planCommand } from '@/commands/plan'
 import { configModule } from '@/core/config'
 import type { DbcliConfig } from '@/utils/validation'
+import { makeTestConfig } from '../../helpers/test-config'
 
 let mockConfig: DbcliConfig
 let configReadSpy: any
@@ -16,15 +17,8 @@ function lastLog(): string {
 
 describe('planCommand', () => {
   beforeEach(() => {
-    mockConfig = {
-      connection: {
-        system: 'postgresql',
-        host: 'localhost',
-        port: 5432,
-        user: 'test',
-        password: 'test',
-        database: 'testdb',
-      },
+    mockConfig = makeTestConfig({
+      connection: { database: 'testdb' },
       permission: 'admin',
       schema: {
         users: {
@@ -37,9 +31,7 @@ describe('planCommand', () => {
           ],
         },
       },
-      metadata: { version: '1.0' },
-      blacklist: { tables: [], columns: {} },
-    }
+    })
 
     configReadSpy = spyOn(configModule, 'read').mockImplementation(async () => mockConfig)
     logSpy = spyOn(console, 'log').mockImplementation(() => {})

--- a/tests/unit/commands/query-fanout.test.ts
+++ b/tests/unit/commands/query-fanout.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test, type Mock } from 'bun:test'
 import { AdapterFactory } from '@/adapters'
 import type { DatabaseAdapter, ExecutionResult, SqlConnectionOptions } from '@/adapters/types'
 import { queryCommand } from '@/commands/query'
@@ -6,6 +6,7 @@ import { configModule } from '@/core/config'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { QueryableAdapter } from '@/adapters/types'
 
 class FanOutAdapter implements DatabaseAdapter {
   connected = 0
@@ -68,13 +69,16 @@ function sqlConfig(name: string) {
 }
 
 describe('query command fan-out', () => {
-  let configReadSpy: ReturnType<typeof spyOn>
-  let createAdapterSpy: ReturnType<typeof spyOn>
-  let createMongoAdapterSpy: ReturnType<typeof spyOn>
-  let createRedisAdapterSpy: ReturnType<typeof spyOn>
-  let createElasticsearchAdapterSpy: ReturnType<typeof spyOn>
-  let logSpy: ReturnType<typeof spyOn>
-  let errorSpy: ReturnType<typeof spyOn>
+  // Declared against the real functions rather than as a bare
+  // `ReturnType<typeof spyOn>`, which erases every parameter and return type and
+  // left the mock implementations below inferring `any` for their arguments.
+  let configReadSpy: Mock<typeof configModule.read>
+  let createAdapterSpy: Mock<typeof AdapterFactory.createSqlAdapter>
+  let createMongoAdapterSpy: Mock<typeof AdapterFactory.createMongoDBAdapter>
+  let createRedisAdapterSpy: Mock<typeof AdapterFactory.createRedisAdapter>
+  let createElasticsearchAdapterSpy: Mock<typeof AdapterFactory.createElasticsearchAdapter>
+  let logSpy: Mock<typeof console.log>
+  let errorSpy: Mock<typeof console.error>
   let originalExitCode: number | string | null | undefined
 
   beforeEach(() => {
@@ -498,7 +502,13 @@ describe('query command fan-out', () => {
         }) as never
     )
     createMongoAdapterSpy.mockImplementation(
-      () => new FanOutAdapter('mongo', undefined, undefined, [{ id: 1, secret: 'hidden' }])
+      // The double implements `DatabaseAdapter`; the mongo factory promises the
+      // wider `QueryableAdapter`. Fan-out only ever calls the narrow half, and
+      // stubbing the other four methods would say nothing about this test.
+      () =>
+        new FanOutAdapter('mongo', undefined, undefined, [
+          { id: 1, secret: 'hidden' },
+        ]) as unknown as QueryableAdapter
     )
 
     await queryCommand('{}', {
@@ -541,7 +551,10 @@ describe('query command fan-out', () => {
         }) as never
     )
     createElasticsearchAdapterSpy.mockImplementation(
-      () => new FanOutAdapter('elasticsearch', undefined, undefined, [{ id: 1, secret: 'hidden' }])
+      () =>
+        new FanOutAdapter('elasticsearch', undefined, undefined, [
+          { id: 1, secret: 'hidden' },
+        ]) as unknown as QueryableAdapter
     )
 
     await queryCommand('{}', {

--- a/tests/unit/commands/query-runtime.test.ts
+++ b/tests/unit/commands/query-runtime.test.ts
@@ -1,23 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import { executeQueryCommand } from '@/commands/query'
-import type { DbcliConfig } from '@/utils/validation'
+import { executeQueryCommand, type QueryExecutionOutput } from '@/commands/query'
+import { makeTestConfig } from '../../helpers/test-config'
 
-const config: DbcliConfig = {
-  connection: {
-    system: 'postgresql',
-    host: 'localhost',
-    port: 5432,
-    user: 'test',
-    password: 'test',
-    database: 'test',
-  },
-  permission: 'query-only',
-  schema: {},
-  metadata: { version: '1.0' },
-  blacklist: { tables: [], columns: {} },
-}
+const config = makeTestConfig()
 
-const execution = {
+const execution: QueryExecutionOutput = {
   result: {
     rows: [{ id: 1 }],
     rowCount: 1,

--- a/tests/unit/commands/query.test.ts
+++ b/tests/unit/commands/query.test.ts
@@ -14,6 +14,7 @@ import { QueryExecutor } from '@/core/query-executor'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { makeTestConfig } from '../../helpers/test-config'
 
 // Mock adapter for testing
 class MockAdapter implements DatabaseAdapter {
@@ -107,20 +108,7 @@ describe('Query Command', () => {
         return `Table: ${result.rowCount} rows`
       }
     )
-    mockConfig = {
-      connection: {
-        system: 'postgresql',
-        host: 'localhost',
-        port: 5432,
-        user: 'test',
-        password: 'test',
-        database: 'testdb',
-      },
-      permission: 'query-only',
-      schema: {},
-      metadata: { version: '1.0' },
-      blacklist: { tables: [], columns: {} },
-    }
+    mockConfig = makeTestConfig({ connection: { database: 'testdb' } })
   })
 
   afterEach(() => {

--- a/tests/unit/commands/shell-write-gate.test.ts
+++ b/tests/unit/commands/shell-write-gate.test.ts
@@ -21,22 +21,15 @@ import { createShellWriteGate } from '@/commands/shell-write-gate'
 import { ReplEngine } from '@/core/repl/repl-engine'
 import type { ReplContext } from '@/core/repl/types'
 import type { DatabaseAdapter } from '@/adapters/types'
-import type { DbcliConfig } from '@/types'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { makeTestConfig } from '../../helpers/test-config'
 
-const config = {
-  connection: {
-    system: 'postgresql',
-    host: 'localhost',
-    port: 5432,
-    database: 'test',
-    user: 'user',
-    password: 'pass',
-  },
+const config = makeTestConfig({
+  connection: { user: 'user', password: 'pass' },
   permission: 'admin',
-} as unknown as DbcliConfig
+})
 
 describe('the write gate on the interactive shell', () => {
   let execute: ReturnType<typeof mock>

--- a/tests/unit/commands/verify-receipt.test.ts
+++ b/tests/unit/commands/verify-receipt.test.ts
@@ -5,18 +5,11 @@ import { join } from 'node:path'
 import type { RuntimeDbcliConfig } from '@/core/config'
 import type { VerificationArtifact, VerificationStatus } from '@/core/verification'
 import { writeVerifyEvidenceReceipt } from '@/commands/verify-receipt'
+import { makeTestConfig } from '../../helpers/test-config'
 
-const config = {
-  connection: {
-    system: 'postgresql',
-    host: 'localhost',
-    port: 5432,
-    user: 'postgres',
-    database: 'dbcli',
-  },
-  permission: 'query-only',
-  blacklist: { tables: [], columns: {} },
-} as RuntimeDbcliConfig
+const config: RuntimeDbcliConfig = makeTestConfig({
+  connection: { user: 'postgres', database: 'dbcli' },
+})
 
 function artifact(status: VerificationStatus): VerificationArtifact {
   return {

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -15,6 +15,7 @@
     "tests/unit/agent-core/**/*.ts",
     "tests/unit/agent-tasks/**/*.ts",
     "tests/unit/build/**/*.ts",
+    "tests/unit/commands/**/*.ts",
     "tests/unit/formatters/**/*.ts",
     "tests/unit/i18n/**/*.ts",
     "tests/unit/program/**/*.ts",


### PR DESCRIPTION
#97 第二步的第三批。48 個錯誤歸零，`tests/unit/commands` 加進 `tsconfig.tests.json`。CI 涵蓋 230 → 333 個測試檔，剩餘 289 → 241。

（這次直接對 `main` 開。上一批我開成 stacked PR，結果下游分支先合併，#102 併進了一個已經沒有下游的分支，內容沒進到 main，只好用 #103 補。）

## 兩個測試本身是錯的

**`delete-plan.test.ts` 用 `permission: 'read-only'` 表達「權限不足」，但那不是四個合法權限值之一。** 它一直判 BLOCK，是因為認不得的等級什麼都不給——結論對、理由錯。改成 `query-only`（真正不能寫的那一級），仍然 BLOCK。

**`query-fanout.test.ts` 的 spy 全部宣告成 `ReturnType<typeof spyOn>`。** 沒帶型別參數等於把參數與回傳型別整個抹掉，那 13 個 implicit any 全源自這裡。改成 `Mock<typeof configModule.read>` 這種對著真函式的寫法之後，又露出兩個原本被遮住的問題：mongo 與 elasticsearch 的測試替身少了 `QueryableAdapter` 要求的四個方法。fan-out 只會用到窄的那一半，所以維持 cast 但寫明理由，而不是補四個說不出任何東西的 stub。

## 缺 audit 的六處改走共用 helper

`query-runtime` / `query` / `plan` / `shell-write-gate` / `verify-receipt` / `evidence-receipt-context` 全部改用 `tests/helpers` 的 `makeTestConfig`，而不是再補一次 `audit` 欄位——那個 helper 存在的理由就是這個，而且這樣同一類錯誤不會再長回來。順帶刪掉每處 10～20 行重複的 config literal。

## 一處 src 改動

`QueryExecutionOutput` 從 `src/commands/query.ts` export 出來。`query-runtime.test.ts` 在驗證 `executeConnection` 這個公開 seam，卻拿不到那個 seam 的型別可以用來對齊替身——測試替身要能宣告成契約本身，契約就得看得見。

## 一個沒修、寫下來的

`normalizeLimitFlags` 宣告 `(options: T) => T`，但實作會把 `limit` 換掉又加上 `noLimit`——簽章在說謊，測試斷言的才是真相。修簽章要先決定 `limit` 允許什麼型別（Commander 依註冊方式給 number、boolean 或 string），那是共用 helper 的設計變更，不該混在測試 typecheck 的清理裡。測試維持斷言 runtime 真相，把結果當普通物件比對，並在檔頭註解寫清楚為什麼。

## 剩餘

```
211  tests/unit/core
 30  tests/docs
```

## Test plan

- `bun run typecheck` / `typecheck:tests` — 綠
- `bun run typecheck:tests:all` — 241（原 289）
- `bun test` — 5499 通過、0 失敗
- `bun run lint` / `prettier --check .` — 綠

Refs #97
