### PR TITLE
fix: [ typecheck ] tests/unit/core 清乾淨並納入護欄

### DIFF
--- a/tests/unit/core/audit/reader.test.ts
+++ b/tests/unit/core/audit/reader.test.ts
@@ -28,9 +28,10 @@ let auditFile: string
 let stderrSpy: Mock<typeof process.stderr.write> | null = null
 
 function makeEntry(overrides: Partial<AuditEntry> & { ts: string; id: string }): AuditEntry {
+  // `...overrides` comes last and wins, so naming `id` and `ts` above it set
+  // them twice and the first pair was dead. The two are required by the
+  // parameter type, which is what makes dropping them here safe.
   return {
-    id: overrides.id,
-    ts: overrides.ts,
     session_id: overrides.session_id ?? 'test-session',
     engine: overrides.engine ?? 'postgresql',
     command: overrides.command ?? 'query',

--- a/tests/unit/core/config-binding.test.ts
+++ b/tests/unit/core/config-binding.test.ts
@@ -34,6 +34,7 @@ const SAMPLE_V2_CONFIG = {
   schemas: {},
   metadata: { version: '2.0' },
   blacklist: { tables: [], columns: {} },
+  audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
 }
 
 describe('config binding layout', () => {

--- a/tests/unit/core/config-v2-mutations.test.ts
+++ b/tests/unit/core/config-v2-mutations.test.ts
@@ -86,9 +86,9 @@ describe('upsertConnection', () => {
       user: 'root',
       database: 'app2',
     })
-    expect(next.connections.primary.permission).toBe('read-write')
-    expect(next.connections.primary.host).toBe('newhost')
-    expect(next.connections.primary.port).toBe(3307)
+    expect(next.connections.primary!.permission).toBe('read-write')
+    expect(next.connections.primary!.host).toBe('newhost')
+    expect(next.connections.primary!.port).toBe(3307)
   })
 })
 

--- a/tests/unit/core/config-v2.test.ts
+++ b/tests/unit/core/config-v2.test.ts
@@ -82,6 +82,7 @@ describe('config-v2', () => {
       schemas: {},
       metadata: { version: '1.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
 
     test('should resolve default connection when no name given', () => {
@@ -149,6 +150,7 @@ describe('config-v2', () => {
         schemas: {},
         metadata: { version: '1.0' },
         blacklist: { tables: [], columns: {} },
+        audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
       }
 
       await writeV2Config(configPath, config)
@@ -188,6 +190,7 @@ describe('config-v2', () => {
       schemas: {},
       metadata: { version: '2.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
 
     test('writes schema to correct connection slot', async () => {

--- a/tests/unit/core/config.test.ts
+++ b/tests/unit/core/config.test.ts
@@ -167,6 +167,7 @@ describe('configModule', () => {
       schema: { table1: 'data' },
       metadata: { version: '1.0', createdAt: '2026-01-01T00:00:00Z' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
 
     test('應該返回新對象（不修改輸入）', () => {
@@ -210,6 +211,7 @@ describe('configModule', () => {
       const config: DbcliConfig = {
         ...baseConfig,
         metadata: { version: '1.0' },
+        audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
       }
 
       const result = configModule.merge(config, {})
@@ -548,6 +550,7 @@ describe('configModule', () => {
         schema: {},
         metadata: { version: '1.0' },
         blacklist: { tables: [], columns: {} },
+        audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
       }
 
       await configModule.write(TEST_CONFIG_PATH, config)
@@ -573,6 +576,7 @@ describe('configModule', () => {
         schema: {},
         metadata: { version: '1.0' },
         blacklist: { tables: [], columns: {} },
+        audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
       }
 
       await configModule.write(TEST_CONFIG_PATH, config)
@@ -633,6 +637,7 @@ describe('configModule', () => {
           schemaTableCount: 12,
         },
         blacklist: { tables: [], columns: {} },
+        audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
       }
 
       await configModule.write(TEST_CONFIG_PATH, config)

--- a/tests/unit/core/connection-credential.test.ts
+++ b/tests/unit/core/connection-credential.test.ts
@@ -109,7 +109,7 @@ describe('setConnectionPassword — v2 connection still holding a literal passwo
     })
 
     const config = await readV2Config(projectPath)
-    expect(config.connections.primary.password).toEqual({ $env: 'DBCLI_PRIMARY_PASSWORD' })
+    expect(config.connections.primary!.password).toEqual({ $env: 'DBCLI_PRIMARY_PASSWORD' })
 
     const envText = await Bun.file(join(getProjectStoragePath(projectPath), '.env.local')).text()
     expect(envText).toContain('DBCLI_PRIMARY_PASSWORD="rotated-pw"')

--- a/tests/unit/core/context/context.test.ts
+++ b/tests/unit/core/context/context.test.ts
@@ -119,12 +119,12 @@ SELECT * FROM users WHERE id >= :min_id AND active = true`
     // Verify schema loading & filters
     expect(payload.schema.audit_logs).toBeUndefined() // completely blacklisted table
     expect(payload.schema.users).toBeDefined()
-    expect(payload.schema.users.name).toBe('users')
-    expect(payload.schema.users.rowCount).toBe(120)
-    expect(payload.schema.users.primaryKey).toEqual(['id'])
+    expect(payload.schema.users!.name).toBe('users')
+    expect(payload.schema.users!.rowCount).toBe(120)
+    expect(payload.schema.users!.primaryKey).toEqual(['id'])
 
     // Check that blacklisted columns inside active tables are filtered out
-    const userColumns = payload.schema.users.columns.map((c) => c.name)
+    const userColumns = payload.schema.users!.columns.map((c) => c.name)
     expect(userColumns).toContain('id')
     expect(userColumns).toContain('username')
     expect(userColumns).not.toContain('password')
@@ -132,13 +132,13 @@ SELECT * FROM users WHERE id >= :min_id AND active = true`
 
     // Check order columns & default values & foreign keys
     expect(payload.schema.orders).toBeDefined()
-    expect(payload.schema.orders.rowCount).toBe(450)
-    const orderTotalCol = payload.schema.orders.columns.find((c) => c.name === 'total')
+    expect(payload.schema.orders!.rowCount).toBe(450)
+    const orderTotalCol = payload.schema.orders!.columns.find((c) => c.name === 'total')
     expect(orderTotalCol?.default).toBe('0.00')
 
-    const orderUserIdCol = payload.schema.orders.columns.find((c) => c.name === 'user_id')
+    const orderUserIdCol = payload.schema.orders!.columns.find((c) => c.name === 'user_id')
     expect(orderUserIdCol?.foreignKey).toEqual({ table: 'users', column: 'id' })
-    expect(payload.schema.orders.foreignKeys).toEqual([
+    expect(payload.schema.orders!.foreignKeys).toEqual([
       {
         columns: ['user_id'],
         refTable: 'users',

--- a/tests/unit/core/contracts/contracts.test.ts
+++ b/tests/unit/core/contracts/contracts.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import {
   filterApprovedSemanticContracts,
+  type SemanticContract,
   inspectSemanticContractDrift,
   loadSemanticContracts,
   renderSemanticContractsMarkdown,
@@ -27,7 +28,10 @@ async function writeContracts(value: unknown): Promise<string> {
 
 const references = new Set(['metric:paid-orders-30d', 'model:customers'])
 
-const contractFile = {
+// Typed rather than inferred: the filtering seam below takes
+// `SemanticContract[]`, and an inferred literal widens `status` and
+// `evidencePolicy` to `string`, which is not one.
+const contractFile: { version: number; contracts: SemanticContract[] } = {
   version: 1,
   contracts: [
     {
@@ -239,9 +243,9 @@ A customer with a paid order in the trailing 30 days.
 
   test('sorts approved contracts at the public filtering seam', () => {
     const approved = filterApprovedSemanticContracts([
-      { ...contractFile.contracts[0], name: 'zebra', aliases: [] },
-      { ...contractFile.contracts[0], name: 'archer', aliases: [] },
-      { ...contractFile.contracts[0], status: 'deprecated', aliases: [] },
+      { ...contractFile.contracts[0]!, name: 'zebra', aliases: [] },
+      { ...contractFile.contracts[0]!, name: 'archer', aliases: [] },
+      { ...contractFile.contracts[0]!, status: 'deprecated', aliases: [] },
     ])
 
     expect(approved.map((contract) => contract.name)).toEqual(['archer', 'zebra'])

--- a/tests/unit/core/elasticsearch-destructive-scope.test.ts
+++ b/tests/unit/core/elasticsearch-destructive-scope.test.ts
@@ -28,7 +28,7 @@ import type { Permission } from '@/types'
 const CASES: Array<{
   method: string
   apiPath: string
-  type: string
+  type: ReturnType<typeof classifyElasticsearchRequest>['type']
   lowest: Permission
   why: string
 }> = [

--- a/tests/unit/core/error-recovery.test.ts
+++ b/tests/unit/core/error-recovery.test.ts
@@ -8,21 +8,9 @@ import { ErrorRecoveryManager } from '@/core/error-recovery'
 import type { DbcliConfig } from '@/utils/validation'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { makeTestConfig } from '../../helpers/test-config'
 
-const mockConfig: DbcliConfig = {
-  connection: {
-    system: 'postgresql',
-    host: 'localhost',
-    port: 5432,
-    user: 'test',
-    password: 'test',
-    database: 'testdb',
-  },
-  permission: 'query-only',
-  schema: {},
-  metadata: { version: '1.0' },
-  blacklist: { tables: [], columns: {} },
-}
+const mockConfig = makeTestConfig({ connection: { database: 'testdb' } })
 
 test('ErrorRecoveryManager - initialize creates recovery dir', async () => {
   const testDir = join(tmpdir(), `recovery-test-${Date.now()}`)

--- a/tests/unit/core/guide/build-plan.test.ts
+++ b/tests/unit/core/guide/build-plan.test.ts
@@ -60,6 +60,7 @@ const PG_CONTEXT: InspectSnapshot = {
   snippets: { count: 5, engines: ['postgres'], intents: [] },
   suggestedCommands: [],
   warnings: [],
+  hints: [],
 }
 
 const NULL_CONTEXT: InspectSnapshot = {

--- a/tests/unit/core/guide/missing-index/analyzer.test.ts
+++ b/tests/unit/core/guide/missing-index/analyzer.test.ts
@@ -39,8 +39,8 @@ function deps(over: Partial<MissingIndexDeps> = {}): MissingIndexDeps {
 test('happy path produces a scored candidate + functional warning', async () => {
   const report = await analyzeMissingIndex('SELECT ...', deps(), {})
   expect(report.candidates).toHaveLength(1)
-  expect(report.candidates[0].confidence).toBe('high')
-  expect(report.candidates[0].columns).toEqual(['user_id', 'settled_at'])
+  expect(report.candidates[0]!.confidence).toBe('high')
+  expect(report.candidates[0]!.columns).toEqual(['user_id', 'settled_at'])
   expect(report.warnings.find((w) => w.rule === 'functional-expression')).toBeDefined()
 })
 
@@ -55,7 +55,7 @@ test('parse failure → fallback: no candidates, parser-limit warning', async ()
     {}
   )
   expect(report.candidates).toEqual([])
-  expect(report.warnings[0].rule).toBe('parser-limit')
+  expect(report.warnings[0]!.rule).toBe('parser-limit')
 })
 
 test('--min-confidence filters out lower-confidence candidates', async () => {

--- a/tests/unit/core/guide/missing-index/candidate-builder.test.ts
+++ b/tests/unit/core/guide/missing-index/candidate-builder.test.ts
@@ -22,17 +22,17 @@ test('orders columns equality → range → order', () => {
     }),
     []
   )
-  expect(out[0].columns).toEqual(['user_id', 'settled_at', 'created_at'])
+  expect(out[0]!.columns).toEqual(['user_id', 'settled_at', 'created_at'])
 })
 
 test('join columns count as equality and lead the prefix', () => {
   const out = buildCandidates(usage({ joinColumns: ['user_id'], rangeColumns: ['settled_at'] }), [])
-  expect(out[0].columns).toEqual(['user_id', 'settled_at'])
+  expect(out[0]!.columns).toEqual(['user_id', 'settled_at'])
 })
 
 test('dedups a column used in both join and where', () => {
   const out = buildCandidates(usage({ joinColumns: ['user_id'], equalityColumns: ['user_id'] }), [])
-  expect(out[0].columns).toEqual(['user_id'])
+  expect(out[0]!.columns).toEqual(['user_id'])
 })
 
 test('drops candidate already fully covered by an existing index prefix', () => {
@@ -52,8 +52,8 @@ test('marks collision when an existing index shares the leftmost column', () => 
     usage({ equalityColumns: ['user_id'], rangeColumns: ['settled_at'] }),
     existing
   )
-  expect(out[0].columns).toEqual(['user_id', 'settled_at'])
-  expect(out[0].existingIndexCollision).toBe('idx_user')
+  expect(out[0]!.columns).toEqual(['user_id', 'settled_at'])
+  expect(out[0]!.existingIndexCollision).toBe('idx_user')
 })
 
 test('returns no candidate when table has no indexable columns', () => {

--- a/tests/unit/core/guide/missing-index/sql-extractor.test.ts
+++ b/tests/unit/core/guide/missing-index/sql-extractor.test.ts
@@ -49,7 +49,7 @@ test('extracts GROUP BY / ORDER BY columns', () => {
 test('records functional columns separately (DATE(x))', () => {
   const u = usageFor('SELECT 1 FROM betting_logs b GROUP BY DATE(b.settled_at)', 'betting_logs')
   expect(u.functionalColumns.map((f) => f.column)).toContain('settled_at')
-  expect(u.functionalColumns[0].expr.toUpperCase()).toContain('DATE')
+  expect(u.functionalColumns[0]!.expr.toUpperCase()).toContain('DATE')
   // functional column must NOT also be counted as a plain order column
   expect(u.orderColumns).not.toContain('settled_at')
 })

--- a/tests/unit/core/guide/missing-index/types.test.ts
+++ b/tests/unit/core/guide/missing-index/types.test.ts
@@ -28,6 +28,6 @@ test('MissingIndexReport shape is constructable', () => {
     candidates: [candidate],
     warnings: [{ rule: 'parser-limit', detail: 'window function ignored' }],
   }
-  expect(report.candidates[0].columns).toEqual(['user_id', 'settled_at'])
+  expect(report.candidates[0]!.columns).toEqual(['user_id', 'settled_at'])
   expect(usage.table).toBe('betting_logs')
 })

--- a/tests/unit/core/guide/missing-index/warnings.test.ts
+++ b/tests/unit/core/guide/missing-index/warnings.test.ts
@@ -24,7 +24,7 @@ test('emits functional-expression warning per functional column', () => {
 test('fallback (parsed=false) emits a single parser-limit warning', () => {
   const out = collectWarnings({ parsed: false, tables: [] })
   expect(out).toHaveLength(1)
-  expect(out[0].rule).toBe('parser-limit')
+  expect(out[0]!.rule).toBe('parser-limit')
 })
 
 test('clean analysis emits no warnings', () => {

--- a/tests/unit/core/guide/render-json.test.ts
+++ b/tests/unit/core/guide/render-json.test.ts
@@ -18,6 +18,7 @@ const CONTEXT: InspectSnapshot = {
   snippets: { count: 5, engines: ['postgres'], intents: [] },
   suggestedCommands: ['dbcli list --format json'],
   warnings: [],
+  hints: [],
 }
 
 const SNAP: GuideSnapshot = {

--- a/tests/unit/core/guide/render-markdown.test.ts
+++ b/tests/unit/core/guide/render-markdown.test.ts
@@ -14,6 +14,7 @@ const CONTEXT: InspectSnapshot = {
   snippets: { count: 5, engines: ['postgres'], intents: [] },
   suggestedCommands: ['dbcli list --format json'],
   warnings: [],
+  hints: [],
 }
 
 const SNAP: GuideSnapshot = {

--- a/tests/unit/core/lint/rules-schema-aware.test.ts
+++ b/tests/unit/core/lint/rules-schema-aware.test.ts
@@ -63,10 +63,10 @@ describe('implicit-cast', () => {
     const findings = implicitCastRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('warn')
-    expect(findings[0].schemaVerified).toBe(true)
-    expect(findings[0].rewrite?.sql).toContain('id = 42')
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe("id = '42'")
+    expect(findings[0]!.severity).toBe('warn')
+    expect(findings[0]!.schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite?.sql).toContain('id = 42')
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe("id = '42'")
   })
 
   test('flags number literal compared to string column', () => {
@@ -75,7 +75,7 @@ describe('implicit-cast', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('ref_code')
+    expect(findings[0]!.message).toContain('ref_code')
   })
 
   for (const system of ['postgresql', 'mysql', 'mariadb'] as const) {
@@ -84,17 +84,17 @@ describe('implicit-cast', () => {
       const findings = implicitCastRule.check(ctxFor(sql, schema, system))
 
       expect(findings).toHaveLength(1)
-      expect(findings[0].rewrite?.sql).toBe('SELECT id FROM users WHERE 42 < id')
-      expect(findings[0].rewrite?.confidence).toBe('high')
-      expect(findings[0].message).toContain("'id'")
-      expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe("'42' < id")
+      expect(findings[0]!.rewrite?.sql).toBe('SELECT id FROM users WHERE 42 < id')
+      expect(findings[0]!.rewrite?.confidence).toBe('high')
+      expect(findings[0]!.message).toContain("'id'")
+      expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe("'42' < id")
     })
   }
 
   test('literal-left rewrite preserves the original comparison operator', () => {
     const findings = implicitCastRule.check(ctxFor("SELECT id FROM users WHERE '42' >= id", schema))
 
-    expect(findings[0].rewrite?.sql).toBe('SELECT id FROM users WHERE 42 >= id')
+    expect(findings[0]!.rewrite?.sql).toBe('SELECT id FROM users WHERE 42 >= id')
   })
 
   test('withholds literal-left rewrites when targeting is ambiguous', () => {
@@ -163,7 +163,7 @@ describe('implicit-cast', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite?.sql).toBe("SELECT '42' AS marker, id FROM users WHERE id = 42")
+    expect(findings[0]!.rewrite?.sql).toBe("SELECT '42' AS marker, id FROM users WHERE id = 42")
   })
 
   test('omits a rewrite when identical comparisons cannot be targeted unambiguously', () => {
@@ -184,8 +184,8 @@ describe('implicit-cast', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('shared_id')
-    expect(findings[0].message).toContain('varchar(32)')
+    expect(findings[0]!.message).toContain('shared_id')
+    expect(findings[0]!.message).toContain('varchar(32)')
   })
 
   test('skips an ambiguous unqualified column across joined tables', () => {
@@ -204,8 +204,8 @@ describe('implicit-cast', () => {
     const findings = implicitCastRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain("'id'")
-    expect(findings[0].rewrite).toBeUndefined()
+    expect(findings[0]!.message).toContain("'id'")
+    expect(findings[0]!.rewrite).toBeUndefined()
   })
 
   test('never rewrites a matching JOIN comparison for a diagnosed WHERE node', () => {
@@ -214,8 +214,8 @@ describe('implicit-cast', () => {
     const findings = implicitCastRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain("'id'")
-    expect(findings[0].rewrite).toBeUndefined()
+    expect(findings[0]!.message).toContain("'id'")
+    expect(findings[0]!.rewrite).toBeUndefined()
   })
 
   test('withholds rewrites when the WHERE contains a correlated subquery', () => {
@@ -224,9 +224,9 @@ describe('implicit-cast', () => {
     const findings = implicitCastRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain("'id'")
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].verifyCommand).toBeUndefined()
+    expect(findings[0]!.message).toContain("'id'")
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.verifyCommand).toBeUndefined()
   })
 
   test('resolves a named table alias after a derived table without shifting scope', () => {
@@ -238,7 +238,7 @@ describe('implicit-cast', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain("'id'")
+    expect(findings[0]!.message).toContain("'id'")
   })
 
   test('does not resolve a CTE-shadowed name through the physical schema cache', () => {
@@ -305,10 +305,10 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('warn')
-    expect(findings[0].message).toContain('NULL')
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(findings[0]!.severity).toBe('warn')
+    expect(findings[0]!.message).toContain('NULL')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('flags a subquery whose projected column is nullable in its own alias scope', () => {
@@ -320,10 +320,10 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('IS NOT NULL')
-    expect(findings[0].message).toContain('NOT EXISTS')
-    expect(findings[0].schemaVerified).toBe(true)
-    expect(findings[0].rewrite).toBeUndefined()
+    expect(findings[0]!.message).toContain('IS NOT NULL')
+    expect(findings[0]!.message).toContain('NOT EXISTS')
+    expect(findings[0]!.schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite).toBeUndefined()
   })
 
   test('suppresses a nullable projected column null-rejected through a table alias', () => {
@@ -376,7 +376,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('right-hand')
+    expect(findings[0]!.message).toContain('right-hand')
   })
 
   test('flags a null-propagating RHS expression over a nullable column', () => {
@@ -385,7 +385,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('right-hand')
+    expect(findings[0]!.message).toContain('right-hand')
   })
 
   for (const system of ['postgresql', 'mysql', 'mariadb'] as const) {
@@ -459,8 +459,8 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('b.id')
-    expect(findings[0].rewrite).toBeUndefined()
+    expect(findings[0]!.message).toContain('b.id')
+    expect(findings[0]!.rewrite).toBeUndefined()
   })
 
   test('flags a declared non-null column on the nullable side of a RIGHT JOIN', () => {
@@ -472,7 +472,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('source.id')
+    expect(findings[0]!.message).toContain('source.id')
   })
 
   test('flags a declared non-null column on either nullable side of a FULL JOIN', () => {
@@ -484,7 +484,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('b.id')
+    expect(findings[0]!.message).toContain('b.id')
   })
 
   test('suppresses an outer-join null extension guarded directly with IS NOT NULL', () => {
@@ -529,9 +529,9 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('nullable expression')
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(findings[0].rewrite).toBeUndefined()
+    expect(findings[0]!.message).toContain('nullable expression')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
   })
 
   test('does not flag a CASE projection with non-null branches and ELSE', () => {
@@ -588,9 +588,9 @@ describe('not-in-nullable', () => {
       )
 
       expect(findings).toHaveLength(1)
-      expect(findings[0].message).toContain(aggregate)
-      expect(findings[0].schemaVerified).toBe(false)
-      expect(findings[0].rewrite).toBeUndefined()
+      expect(findings[0]!.message).toContain(aggregate)
+      expect(findings[0]!.schemaVerified).toBe(false)
+      expect(findings[0]!.rewrite).toBeUndefined()
     })
   }
 
@@ -604,8 +604,8 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('CORR')
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.message).toContain('CORR')
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('flags an unrecognized parser aggregate node conservatively', () => {
@@ -618,7 +618,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('GROUP_CONCAT')
+    expect(findings[0]!.message).toContain('GROUP_CONCAT')
   })
 
   test('does not treat an arbitrary function AST node as an aggregate', () => {
@@ -807,7 +807,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('marks CAST of a schema-nullable column as schema verified', () => {
@@ -816,7 +816,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   for (const system of ['mysql', 'mariadb'] as const) {
@@ -857,7 +857,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('b.email')
+    expect(findings[0]!.message).toContain('b.email')
   })
 
   test('skips an ambiguous unqualified RHS column across joined tables', () => {
@@ -898,9 +898,9 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(findings[0].message).toContain('WHERE id IS NOT NULL')
-    expect(findings[0].message).not.toContain('WHERE NULL IS NOT NULL')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(findings[0]!.message).toContain('WHERE id IS NOT NULL')
+    expect(findings[0]!.message).not.toContain('WHERE NULL IS NOT NULL')
   })
 
   test('does not flag an unambiguous CTE output that projects a non-null literal', () => {
@@ -923,9 +923,9 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(findings[0].message).toContain('WHERE d.id IS NOT NULL')
-    expect(findings[0].message).not.toContain('WHERE NULL IS NOT NULL')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(findings[0]!.message).toContain('WHERE d.id IS NOT NULL')
+    expect(findings[0]!.message).not.toContain('WHERE NULL IS NOT NULL')
   })
 
   test('does not flag an unambiguous derived-table output that projects a non-null literal', () => {
@@ -1012,8 +1012,8 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('projected expression itself')
-    expect(findings[0].message).not.toContain('WHERE a IS NOT NULL')
+    expect(findings[0]!.message).toContain('projected expression itself')
+    expect(findings[0]!.message).not.toContain('WHERE a IS NOT NULL')
   })
 
   test('recursively detects explicit NULL in a nested query predicate', () => {
@@ -1022,8 +1022,8 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('recursively analyzes HAVING predicates', () => {
@@ -1031,7 +1031,7 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('recursively analyzes JOIN predicates', () => {
@@ -1039,7 +1039,7 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('does not resolve a nested NOT IN expression with the outer table scope', () => {
@@ -1059,8 +1059,8 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, {}))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(findings[0].message).toContain('WHERE b.id IS NOT NULL')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(findings[0]!.message).toContain('WHERE b.id IS NOT NULL')
   })
 
   test('detects null extension from a qualified derived relation without schema metadata', () => {
@@ -1072,8 +1072,8 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(findings[0].message).toContain('WHERE b.id IS NOT NULL')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(findings[0]!.message).toContain('WHERE b.id IS NOT NULL')
   })
 
   test('does not treat a qualified INNER JOIN source as null-extended without schema metadata', () => {
@@ -1129,7 +1129,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('applies null extension from a completed join inside a later join ON predicate', () => {
@@ -1141,7 +1141,7 @@ describe('not-in-nullable', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('keeps lexical spans aligned after a safe projected NOT IN expression', () => {
@@ -1149,7 +1149,7 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].span.start).toBe(sql.lastIndexOf('NOT IN'))
+    expect(findings[0]!.span.start).toBe(sql.lastIndexOf('NOT IN'))
   })
 
   test('recursively analyzes CTE predicates in lexical order', () => {
@@ -1168,8 +1168,8 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].schemaVerified).toBe(false)
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(findings[0]!.schemaVerified).toBe(false)
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('maps nested infix findings to their own lexical NOT IN operators', () => {
@@ -1188,8 +1188,8 @@ describe('not-in-nullable', () => {
     const findings = notInNullableRule.check(ctxFor(sql, schema))
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].span.start).toBe(sql.lastIndexOf('NOT IN'))
-    expect(sql.slice(findings[0].span.start, findings[0].span.end)).toBe('NOT IN')
+    expect(findings[0]!.span.start).toBe(sql.lastIndexOf('NOT IN'))
+    expect(sql.slice(findings[0]!.span.start, findings[0]!.span.end)).toBe('NOT IN')
   })
 
   test('assigns successive spans to successive top-level NOT IN findings', () => {

--- a/tests/unit/core/lint/rules-static-basic.test.ts
+++ b/tests/unit/core/lint/rules-static-basic.test.ts
@@ -24,9 +24,9 @@ describe('select-star', () => {
   test('flags SELECT *', () => {
     const findings = selectStarRule.check(ctxFor('SELECT * FROM users'))
     expect(findings).toHaveLength(1)
-    expect(findings[0].rule).toBe('select-star')
-    expect(findings[0].severity).toBe('warn')
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rule).toBe('select-star')
+    expect(findings[0]!.severity).toBe('warn')
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('with schema + single table, offers explicit-column rewrite', () => {
@@ -38,10 +38,10 @@ describe('select-star', () => {
       ],
     }
     const findings = selectStarRule.check(ctxFor('SELECT * FROM users', { users }))
-    expect(findings[0].rewrite?.sql).toBe('SELECT id, email FROM users')
-    expect(findings[0].rewrite?.confidence).toBe('high')
-    expect(findings[0].verifyCommand).toContain('dbcli explain --analyze')
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite?.sql).toBe('SELECT id, email FROM users')
+    expect(findings[0]!.rewrite?.confidence).toBe('high')
+    expect(findings[0]!.verifyCommand).toContain('dbcli explain --analyze')
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('withholds a schema rewrite when a CTE shadows a cached physical table', () => {
@@ -56,9 +56,9 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].verifyCommand).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.verifyCommand).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('withholds a schema rewrite for a derived relation', () => {
@@ -73,9 +73,9 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].verifyCommand).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.verifyCommand).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('keeps the schema rewrite for one unambiguous physical table', () => {
@@ -85,9 +85,9 @@ describe('select-star', () => {
     }
     const findings = selectStarRule.check(ctxFor('SELECT * FROM x', { x: physicalX }))
 
-    expect(findings[0].rewrite?.sql).toBe('SELECT physical_only FROM x')
-    expect(findings[0].rewrite?.confidence).toBe('high')
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite?.sql).toBe('SELECT physical_only FROM x')
+    expect(findings[0]!.rewrite?.confidence).toBe('high')
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('withholds a PostgreSQL schema rewrite for a schema-qualified table', () => {
@@ -100,9 +100,9 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].verifyCommand).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.verifyCommand).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   for (const system of ['mysql', 'mariadb'] as const) {
@@ -116,9 +116,9 @@ describe('select-star', () => {
       )
 
       expect(findings).toHaveLength(1)
-      expect(findings[0].rewrite).toBeUndefined()
-      expect(findings[0].verifyCommand).toBeUndefined()
-      expect(findings[0].schemaVerified).toBe(false)
+      expect(findings[0]!.rewrite).toBeUndefined()
+      expect(findings[0]!.verifyCommand).toBeUndefined()
+      expect(findings[0]!.schemaVerified).toBe(false)
     })
   }
 
@@ -136,8 +136,8 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('withholds an unquoted mixed-case table rewrite when its folded bucket collides', () => {
@@ -154,8 +154,8 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('withholds a quoted mixed-case table rewrite when quote provenance is unavailable', () => {
@@ -172,8 +172,8 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('keeps a unique case-insensitive select-star schema lookup', () => {
@@ -183,8 +183,8 @@ describe('select-star', () => {
     }
     const findings = selectStarRule.check(ctxFor('SELECT * FROM USERS', { users }, 'postgresql'))
 
-    expect(findings[0].rewrite?.sql).toBe('SELECT id FROM USERS')
-    expect(findings[0].rewrite?.confidence).toBe('high')
+    expect(findings[0]!.rewrite?.sql).toBe('SELECT id FROM USERS')
+    expect(findings[0]!.rewrite?.confidence).toBe('high')
   })
 
   test('rewrites the projection wildcard instead of a star in a leading comment', () => {
@@ -199,9 +199,9 @@ describe('select-star', () => {
       ctxFor('/* retain * marker */ SELECT * FROM users', { users })
     )
 
-    expect(findings[0].rewrite?.sql).toBe('/* retain * marker */ SELECT id, email FROM users')
-    expect(findings[0].rewrite?.confidence).toBe('high')
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite?.sql).toBe('/* retain * marker */ SELECT id, email FROM users')
+    expect(findings[0]!.rewrite?.confidence).toBe('high')
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('withholds rewrite for a mixed projection containing multiplication and a wildcard', () => {
@@ -217,9 +217,9 @@ describe('select-star', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].rewrite).toBeUndefined()
-    expect(findings[0].verifyCommand).toBeUndefined()
-    expect(findings[0].schemaVerified).toBe(false)
+    expect(findings[0]!.rewrite).toBeUndefined()
+    expect(findings[0]!.verifyCommand).toBeUndefined()
+    expect(findings[0]!.schemaVerified).toBe(false)
   })
 
   test('quotes and escapes unsafe PostgreSQL schema column identifiers', () => {
@@ -233,10 +233,10 @@ describe('select-star', () => {
     }
     const findings = selectStarRule.check(ctxFor('SELECT * FROM users', { users }))
 
-    expect(findings[0].rewrite?.sql).toBe(
+    expect(findings[0]!.rewrite?.sql).toBe(
       'SELECT "select", "full name", "display""name" FROM users'
     )
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('quotes and escapes unsafe MySQL schema column identifiers', () => {
@@ -250,8 +250,8 @@ describe('select-star', () => {
     }
     const findings = selectStarRule.check(ctxFor('SELECT * FROM users', { users }, 'mysql'))
 
-    expect(findings[0].rewrite?.sql).toBe('SELECT `select`, `full name`, `tick``name` FROM users')
-    expect(findings[0].schemaVerified).toBe(true)
+    expect(findings[0]!.rewrite?.sql).toBe('SELECT `select`, `full name`, `tick``name` FROM users')
+    expect(findings[0]!.schemaVerified).toBe(true)
   })
 
   test('does not flag a backtick-quoted asterisk column in MySQL', () => {
@@ -281,7 +281,7 @@ describe('unanchored-like', () => {
       ctxFor("SELECT id FROM users WHERE email LIKE '%@x.com'")
     )
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('warn')
+    expect(findings[0]!.severity).toBe('warn')
   })
 
   test("does not flag anchored LIKE 'abc%'", () => {
@@ -297,8 +297,8 @@ describe('missing-limit-offset', () => {
       ctxFor('SELECT id FROM users ORDER BY id LIMIT 20 OFFSET 5000')
     )
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('info')
-    expect(findings[0].message).toContain('keyset')
+    expect(findings[0]!.severity).toBe('info')
+    expect(findings[0]!.message).toContain('keyset')
   })
 
   test('does not flag small offsets or no offset', () => {

--- a/tests/unit/core/lint/rules-static-structure.test.ts
+++ b/tests/unit/core/lint/rules-static-structure.test.ts
@@ -13,7 +13,7 @@ function ctxFor(sql: string, system: SqlDatabaseSystem = 'postgresql'): LintRule
     system,
     sql,
     ast: parseSingleStatement(sql, system),
-    schema: buildSchemaContext(),
+    schema: buildSchemaContext(undefined),
   }
 }
 
@@ -24,10 +24,10 @@ describe('non-sargable-where', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('warn')
-    expect(findings[0].message).toContain('LOWER')
-    expect(findings[0].message).toContain('may prevent use of a conventional index')
-    expect(findings[0].message).toContain('expression index')
+    expect(findings[0]!.severity).toBe('warn')
+    expect(findings[0]!.message).toContain('LOWER')
+    expect(findings[0]!.message).toContain('may prevent use of a conventional index')
+    expect(findings[0]!.message).toContain('expression index')
   })
 
   test('flags arithmetic on a column in a comparison', () => {
@@ -58,11 +58,11 @@ describe('or-to-union', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('info')
-    expect(findings[0].message).toContain('UNION ALL')
-    expect(findings[0].message).toContain('mutually exclusive')
-    expect(findings[0].message).toContain('row identity and multiplicity')
-    expect(findings[0].message).toContain('Verify')
+    expect(findings[0]!.severity).toBe('info')
+    expect(findings[0]!.message).toContain('UNION ALL')
+    expect(findings[0]!.message).toContain('mutually exclusive')
+    expect(findings[0]!.message).toContain('row identity and multiplicity')
+    expect(findings[0]!.message).toContain('Verify')
   })
 
   test('flags top-level OR when one branch wraps a single column in a function', () => {
@@ -71,7 +71,7 @@ describe('or-to-union', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('email / name')
+    expect(findings[0]!.message).toContain('email / name')
   })
 
   test('does not guess a column identity from a multi-column function branch', () => {
@@ -96,7 +96,7 @@ describe('or-to-union', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('u.email / p.email')
+    expect(findings[0]!.message).toContain('u.email / p.email')
   })
 })
 
@@ -107,9 +107,9 @@ describe('subquery-to-join', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].message).toContain('JOIN')
-    expect(findings[0].message).toContain('semi-join')
-    expect(findings[0].message).toContain('unique or explicitly deduplicated')
+    expect(findings[0]!.message).toContain('JOIN')
+    expect(findings[0]!.message).toContain('semi-join')
+    expect(findings[0]!.message).toContain('unique or explicitly deduplicated')
   })
 
   test('does not flag IN over a literal list', () => {
@@ -126,7 +126,7 @@ describe('distinct-groupby-abuse', () => {
     )
 
     expect(findings).toHaveLength(1)
-    expect(findings[0].severity).toBe('warn')
+    expect(findings[0]!.severity).toBe('warn')
   })
 
   test('does not flag plain DISTINCT', () => {

--- a/tests/unit/core/migrate-v1-to-v2.test.ts
+++ b/tests/unit/core/migrate-v1-to-v2.test.ts
@@ -34,11 +34,11 @@ describe('migrateV1ToV2', () => {
     expect(out.version).toBe(2)
     expect(out.default).toBe('default')
     expect(Object.keys(out.connections)).toEqual(['default'])
-    expect(out.connections.default.system).toBe('mariadb')
-    expect(out.connections.default.host).toBe('localhost')
-    expect(out.connections.default.password).toEqual({ $env: 'DB_PASSWORD' })
-    expect(out.connections.default.envFile).toBe('.env.local')
-    expect(out.connections.default.permission).toBe('query-only')
+    expect(out.connections.default!.system).toBe('mariadb')
+    expect(out.connections.default!.host).toBe('localhost')
+    expect(out.connections.default!.password).toEqual({ $env: 'DB_PASSWORD' })
+    expect(out.connections.default!.envFile).toBe('.env.local')
+    expect(out.connections.default!.permission).toBe('query-only')
   })
 
   test('carries over blacklist / audit / metadata', () => {

--- a/tests/unit/core/orm-drift/ddl-adapter.test.ts
+++ b/tests/unit/core/orm-drift/ddl-adapter.test.ts
@@ -18,7 +18,7 @@ describe('parseDdl', () => {
     const byName = Object.fromEntries(users.columns.map((column) => [column.name, column]))
     expect(byName.id).toMatchObject({ type: 'integer', nullable: false, primaryKey: true })
     expect(byName.email).toMatchObject({ type: 'varchar(255)', nullable: false })
-    expect(byName.name.nullable).toBe(true)
+    expect(byName.name!.nullable).toBe(true)
   })
 
   test('collects CREATE INDEX statements onto their table', () => {
@@ -52,7 +52,7 @@ describe('parseDdl', () => {
   test('unparseable SQL becomes one unparsed entry, not a throw', () => {
     const out = parseDdl('CREATE GIBBERISH', 'postgresql')
     expect(out.tables).toHaveLength(0)
-    expect(out.unparsed[0].reason).toContain('blocked: parse failed')
+    expect(out.unparsed[0]!.reason).toContain('blocked: parse failed')
   })
 
   test('preserves a CREATE TABLE after a leading comment', () => {
@@ -97,7 +97,7 @@ describe('parseDdl', () => {
       'postgresql'
     )
     expect(tableNamed(out, 'checked_table').columns.map((column) => column.name)).toEqual(['id'])
-    expect(out.unparsed[0].reason).toContain('blocked: unsupported table definition')
+    expect(out.unparsed[0]!.reason).toContain('blocked: unsupported table definition')
   })
 
   test('blocks PostgreSQL partition semantics instead of emitting a regular table', () => {

--- a/tests/unit/core/orm-drift/drizzle-adapter.test.ts
+++ b/tests/unit/core/orm-drift/drizzle-adapter.test.ts
@@ -22,7 +22,7 @@ describe('parseDrizzleSnapshot', () => {
     expect(users.identity).toEqual({ schema: 'public', table: 'users' })
     const byName = Object.fromEntries(users.columns.map((c) => [c.name, c]))
     expect(byName.id).toMatchObject({ type: 'serial', nullable: false, primaryKey: true })
-    expect(byName.email.nullable).toBe(false)
+    expect(byName.email!.nullable).toBe(false)
     expect(byName.bio).toMatchObject({ nullable: true, default: "''" })
   })
 

--- a/tests/unit/core/orm-drift/prisma-adapter.test.ts
+++ b/tests/unit/core/orm-drift/prisma-adapter.test.ts
@@ -31,12 +31,12 @@ describe('parsePrismaSchema', () => {
       nullable: false,
       primaryKey: true,
     })
-    expect(byName.email.nullable).toBe(false)
-    expect(byName.name.nullable).toBe(true)
-    expect(byName.bio.type).toBe('text')
-    expect(byName.created_at.type).toBe('timestamp')
-    expect(byName.id.default).toBe('autoincrement()')
-    expect(byName.created_at.default).toBe('now()')
+    expect(byName.email!.nullable).toBe(false)
+    expect(byName.name!.nullable).toBe(true)
+    expect(byName.bio!.type).toBe('text')
+    expect(byName.created_at!.type).toBe('timestamp')
+    expect(byName.id!.default).toBe('autoincrement()')
+    expect(byName.created_at!.default).toBe('now()')
     expect(users.indexes).toContainEqual({ name: undefined, columns: ['email'], unique: true })
   })
 

--- a/tests/unit/core/permission-refusal-level.test.ts
+++ b/tests/unit/core/permission-refusal-level.test.ts
@@ -23,7 +23,9 @@ import {
 } from '@/core/permission-guard'
 import { enforceElasticsearchPermission } from '@/core/permission/elasticsearch'
 import type { Permission } from '@/types'
-import type { StatementType } from '@/types/permission'
+// `@/types/permission` does not exist. Bun strips a type-only import without
+// resolving it, so this ran green for as long as nothing typechecked the file.
+import type { StatementType } from '@/core/permission-guard'
 
 const PERMISSIONS: Permission[] = ['query-only', 'read-write', 'data-admin', 'admin']
 const TYPES: StatementType[] = ['INSERT', 'UPDATE', 'DELETE']

--- a/tests/unit/core/query-fanout.test.ts
+++ b/tests/unit/core/query-fanout.test.ts
@@ -50,15 +50,18 @@ describe('query fan-out orchestration', () => {
   })
 
   test('maps all-success, partial-failure, and all-failure exit codes', () => {
-    const ok = { connection: 'a', status: 'ok', result: result('a') } as const
-    const failed = {
+    // Annotated rather than `as const`: the latter makes `hints` a readonly
+    // tuple, which `ConnectionQueryOutcome` does not accept, and it was the
+    // reason the mixed array below needed a cast.
+    const ok: ConnectionQueryOutcome = { connection: 'a', status: 'ok', result: result('a') }
+    const failed: ConnectionQueryOutcome = {
       connection: 'b',
       status: 'error',
       error: { message: 'failed', hints: [] },
-    } as const
+    }
 
     expect(aggregateFanOutExitCode([ok])).toBe(0)
-    expect(aggregateFanOutExitCode([ok, failed] as ConnectionQueryOutcome[])).toBe(2)
+    expect(aggregateFanOutExitCode([ok, failed])).toBe(2)
     expect(aggregateFanOutExitCode([failed])).toBe(1)
   })
 

--- a/tests/unit/core/report/render-json.test.ts
+++ b/tests/unit/core/report/render-json.test.ts
@@ -18,6 +18,7 @@ const CONTEXT: InspectSnapshot = {
   snippets: { count: 5, engines: ['postgres'], intents: [] },
   suggestedCommands: ['dbcli list --format json'],
   warnings: [],
+  hints: [],
 }
 
 const SNAP: ReportSnapshot = {

--- a/tests/unit/core/report/render-markdown.test.ts
+++ b/tests/unit/core/report/render-markdown.test.ts
@@ -14,6 +14,7 @@ const CONTEXT: InspectSnapshot = {
   snippets: { count: 5, engines: ['postgres'], intents: [] },
   suggestedCommands: ['dbcli list --format json'],
   warnings: [],
+  hints: [],
 }
 
 const SNAP: ReportSnapshot = {

--- a/tests/unit/core/result-snapshot/fingerprint.test.ts
+++ b/tests/unit/core/result-snapshot/fingerprint.test.ts
@@ -36,7 +36,7 @@ describe('buildFingerprint', () => {
     const a = buildFingerprint(qr([{ id: 1 }, { id: 2 }], ['id']), {})
     const b = buildFingerprint(qr([{ id: 2 }, { id: 1 }], ['id']), {})
     expect(a.resultChecksum).toBe(b.resultChecksum)
-    expect(a.columns[0].checksum).toBe(b.columns[0].checksum)
+    expect(a.columns[0]!.checksum).toBe(b.columns[0]!.checksum)
   })
 
   it('omits rows by default and includes them with includeRows', () => {

--- a/tests/unit/core/schema-diff.test.ts
+++ b/tests/unit/core/schema-diff.test.ts
@@ -26,6 +26,7 @@ describe('SchemaDiffEngine', () => {
       schema: {},
       metadata: { version: '1.0' },
       blacklist: { tables: [], columns: {} },
+      audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
     }
   })
 

--- a/tests/unit/core/schema-updater.test.ts
+++ b/tests/unit/core/schema-updater.test.ts
@@ -68,6 +68,7 @@ test('SchemaUpdater - generates patch for added tables', async () => {
     schema: {},
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
 
   // Set up new table in adapter
@@ -181,6 +182,7 @@ test('SchemaUpdater - handles table deletion', async () => {
     },
     metadata: { version: '1.0' },
     blacklist: { tables: [], columns: {} },
+    audit: { enabled: true, rotation: { max_bytes: 10_485_760, max_entries: 1000 } },
   }
 
   // Adapter has no tables (simulating deletion)

--- a/tests/unit/core/semantic/query-draft.test.ts
+++ b/tests/unit/core/semantic/query-draft.test.ts
@@ -136,7 +136,7 @@ describe('validateQueryDraft', () => {
         ...semanticContext,
         models: [
           {
-            ...semanticContext.models[0],
+            ...semanticContext.models[0]!,
             fields: [{ column: 'created_at', aliases: [] }],
           },
         ],
@@ -223,10 +223,12 @@ describe('validateQueryDraft', () => {
   test('does not send a request or return an executable command while validating', () => {
     const originalFetch = globalThis.fetch
     let fetchCalls = 0
-    globalThis.fetch = async () => {
+    // Cast because `typeof fetch` carries `preconnect`, which a stand-in that
+    // exists only to fail on the first call has no reason to implement.
+    globalThis.fetch = (async () => {
       fetchCalls++
       throw new Error('network must not be used')
-    }
+    }) as unknown as typeof fetch
 
     try {
       const report = validateQueryDraft({ ...baseInput, draft: validDraft() })

--- a/tests/unit/core/verification/status.test.ts
+++ b/tests/unit/core/verification/status.test.ts
@@ -26,9 +26,12 @@ describe('verification status contract', () => {
     ['passed', 'verified'],
     ['failed', 'not_verified'],
     ['indeterminate', 'indeterminate'],
-  ] as Array<[VerifyStatus, string]>)('maps recovery %s to %s', (input, expected) => {
-    expect(recoveryVerifyToVerificationStatus(input)).toBe(expected)
-  })
+  ] as Array<[VerifyStatus, ReturnType<typeof recoveryVerifyToVerificationStatus>]>)(
+    'maps recovery %s to %s',
+    (input, expected) => {
+      expect(recoveryVerifyToVerificationStatus(input)).toBe(expected)
+    }
+  )
 
   test('maps skipped recovery verifier to blocked', () => {
     expect(

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -15,6 +15,7 @@
     "tests/unit/agent-core/**/*.ts",
     "tests/unit/agent-tasks/**/*.ts",
     "tests/unit/build/**/*.ts",
+    "tests/unit/core/**/*.ts",
     "tests/unit/formatters/**/*.ts",
     "tests/unit/i18n/**/*.ts",
     "tests/unit/program/**/*.ts",


### PR DESCRIPTION
#97 第二步的第四批，也是最大的一批：211 個錯誤歸零，`tests/unit/core` 加進 `tsconfig.tests.json`。

> **與 #104 會有一行衝突。** 兩個 PR 都在 `tsconfig.tests.json` 的 `include` 陣列加一行（這批加 `tests/unit/core`，#104 加 `tests/unit/commands`），合併時保留兩行即可。本分支基於 main，所以下面的「剩餘」還包含 #104 已經清掉的 48 個。

## 176 個是機械類

`noUncheckedIndexedAccess` 下的陣列索引與 optional 存取。測試資料是自己造的、前面多半已有 `toHaveLength` 斷言，一律用 `!` 而不是 `?.`——後者會讓值不存在時默默通過而不是失敗，等於用消除型別錯誤換掉一個真的斷言。

## 其餘 35 個要一個一個看

**`permission-refusal-level.test.ts` 從 `@/types/permission` import 型別，那個模組根本不存在。** Bun 把 type-only import 直接剝掉、不做解析，所以測試一直照跑。這是「測試檔裡的型別註記從來沒被檢查」最純粹的樣子——不是寫錯了什麼，是指向了一個不存在的地方，而且沒有任何東西會說。

**`rules-static-structure.test.ts` 呼叫 `buildSchemaContext()` 沒給參數，而它要一個。** runtime 收到 `undefined` 剛好能運作，於是沒人發現。

**`audit/reader.test.ts` 的 `makeEntry` 先寫 `id` / `ts` 再 `...overrides`**，後者會蓋掉前者——那兩行從來沒有作用。

**guide / report 的五個 `InspectSnapshot` fixture 少了 `hints` 欄位。** 型別加了欄位，fixture 沒跟上，而沒有東西會擋。

**`contracts.test.ts` 的 fixture 靠推論**，`status` 被放寬成 `string`，於是不是 `SemanticContract`。改成明確標注 `SemanticContract[]`——試過 `as const`，但那會讓 `subjects` 變成 readonly tuple，反而更不符。

**`query-fanout.test.ts` 的 fixture 用 `as const`**，`hints` 因此是 readonly tuple，所以下面那個混合陣列得加 cast 才過。改成標注 `ConnectionQueryOutcome` 之後，那個 cast 也跟著不需要了。

**`verification/status` 與 `elasticsearch-destructive-scope` 的 case table 把 union 寫成 `string`。** 改成 `ReturnType<typeof recoveryVerifyToVerificationStatus>` 這種從函式本身取的寫法，型別不會漂移。

## 分工

137 個 lint 目錄的機械類與後續 40 個機械類交給 implementer subagent 處理，規範是「用 `!` 不用 `?.`、不放寬任何斷言、不動 src、非機械類列出來回報」。兩批回報都沒有需要升級的問題，我自己重跑驗收指令確認過。非機械的 35 個我自己逐一處理。

## 結果

- CI 涵蓋 333 → 413 個測試檔（本分支基準；併入 #104 後再多 `tests/unit/commands`）
- `typecheck:tests:all` 剩 78：`tests/docs` 30 + `tests/unit/commands` 48（後者已在 #104 清掉）
- **#104 與這個 PR 都合併後，只剩 `tests/docs` 30 個**

## Test plan

- `bun run typecheck` / `typecheck:tests` — 綠
- `bun test` — 5499 通過、0 失敗（`tests/unit/core` 單獨 2364 通過）
- `bun run lint` / `prettier --check .` — 綠

Refs #97
