### PR TITLE
fix: [ typecheck ] tests/docs 清乾淨，測試檔全部進入 CI 型別把關

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      # Test files were never typechecked at all until #97. They are being
-      # cleared one directory at a time, and `tsconfig.tests.json` lists the ones
-      # already clean — so this is green today and stops them regressing while
-      # the rest catch up. `bun run typecheck:tests:all` shows what is left.
+      # Separate project because the test tree needs no declaration output and
+      # the build reads `tsconfig.json` directly. Test files went untypechecked
+      # for a long time — the main include used a brace glob TypeScript does not
+      # expand — so losing this step would put them back there (#97).
       - name: Typecheck tests
         run: bun run typecheck:tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,27 +75,19 @@ DBCLI_LANG=zh-TW ./dist/cli.mjs --help
 
 #### Typechecking
 
-`bun run typecheck` covers `src/` and `scripts/`. Test files are a separate project:
+`bun run typecheck` covers `src/` and `scripts/`; `bun run typecheck:tests` covers `tests/`.
+Both run in CI and both are in the pre-release checklist.
 
-| Command | Project | Covers | State |
-| :--- | :--- | :--- | :--- |
-| `bun run typecheck:tests` | `tsconfig.tests.json` | the test directories already clean | green, **enforced in CI** |
-| `bun run typecheck:tests:all` | `tsconfig.tests.all.json` | every test file | red — the remaining backlog |
+They are two projects rather than one because the test tree needs no declaration output and
+the build's `dts-bundle-generator` reads `tsconfig.json` directly. Keep new test directories
+inside `tests/` and they are covered automatically — the include is `tests/**/*.ts`.
 
-They are split because they are not all clean yet. The main `include` carried a
+A note on why this is worth stating at all: the main `include` carried a
 `tests/**/*.{ts,tsx}` pattern for a long time, and TypeScript does not expand braces in an
-include glob — so it matched nothing and no test file had ever been typechecked (#97).
-Turning it on reported 339 errors across 174 files, about six in ten an unchecked array index
-or optional field under `noUncheckedIndexedAccess`.
-
-**When you clean a directory, add it to `tsconfig.tests.json`'s `include`.** That list is the
-ratchet: everything in it is checked in CI and cannot regress, and the backlog shrinks as the
-list grows. When the two projects cover the same files, delete `tsconfig.tests.all.json` and
-add `typecheck:tests` to the pre-release checklist.
-
-A type-level assertion in a directory that is not on the list yet compiles but nothing runs
-it — `src/commands/audit.ts` has one and a note explaining why it lives there rather than
-beside the code it guards.
+include glob. It matched nothing, so no test file had ever been typechecked, and a
+type-level assertion written in one guarded nothing. Turning it on surfaced 339 errors across
+174 files — among them an import from a module that does not exist, a helper call missing a
+required argument, and fixtures missing fields their types had gained (#97).
 
 ### 5. Commit
 
@@ -332,6 +324,7 @@ The release gate is defined in [`docs/feature-matrix.md → Required CI validati
 Run all of these before pushing a `vX.Y.Z` tag and confirm green:
 
 - [ ] `bun run typecheck` — `tsc --noEmit` 無錯誤
+- [ ] `bun run typecheck:tests` — 測試檔同樣無型別錯誤（#97）
 - [ ] `bun test` — 單元 + 整合測試（含 `tests/integration/dist-smoke.test.ts` 守護 packaged assets path）綠燈
 - [ ] `bun run lint` — `--max-warnings=0`，任何新 ESLint warning 都會擋下 release
 - [ ] `bun run build` — `dist/cli.mjs` 與 `dist/assets/` 產出成功

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
-    "typecheck:tests:all": "tsc --noEmit --pretty false -p tsconfig.tests.all.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",
     "lint": "eslint src tests scripts --ext .ts --max-warnings=0",
     "format:check": "prettier --check .",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -48,12 +48,12 @@ import type { GateOutcome } from '@/commands/write-gate-guard'
  *
  * This layer may import both, so the tie is made here, in the direction the
  * layering allows. Each pair fails to compile on a member missing from the seed
- * list and on one invented there. (It is deliberately not in the summary's own
- * test file. `tsconfig.json`'s `include` used a brace pattern TypeScript does
- * not expand, so no test file was typechecked at all and a compile-time guard
- * put there would have guarded nothing; `tsconfig.tests.json` now covers them,
- * but nothing runs it in CI until the 339 errors it reports are cleared, so the
- * conclusion stands for now (#97).)
+ * list and on one invented there. (It sits here rather than in the summary's own
+ * test file for a reason that has since expired: the main `include` used a brace
+ * pattern TypeScript does not expand, so no test file was typechecked and a
+ * guard put there would have guarded nothing. `tsconfig.tests.json` now covers
+ * every test file and CI runs it, so either location would work — this one is
+ * kept because the guard belongs with the two unions it ties together (#97).)
  */
 type Covers<A, B> = [A] extends [B] ? true : false
 const _noInventedReason: Covers<(typeof GATE_REASONS)[number], WriteGateReason> = true

--- a/tests/docs/guides-pages.test.ts
+++ b/tests/docs/guides-pages.test.ts
@@ -9,7 +9,8 @@ const guideSlugs = [
   'orm-schema-drift',
   'slow-endpoint',
   'why-dbcli',
-] as const
+  // Not `as const`, for the same reason as `locales` below.
+]
 
 const locales = [
   {
@@ -26,7 +27,9 @@ const locales = [
     docs: '../../user/en/',
     counterpartPrefix: '../',
   },
-] as const
+  // Not `as const`: bun-types' object-table overload for `each` takes a mutable
+  // array, and nothing here needs the literal types.
+]
 
 async function loadPage(path: string) {
   const html = (await Bun.file(path).text()).replace(/\r\n/g, '\n')
@@ -81,12 +84,13 @@ test('safe-backfill pages clearly state that verification never runs the update'
 test('why-dbcli uses its local illustration and a complete story arc in both languages', async () => {
   expect(await Bun.file('docs/assets/why-dbcli-hero.png').exists()).toBe(true)
 
-  for (const [path, asset] of [
+  const heroPages: Array<[path: string, asset: string]> = [
     ['docs/guides/why-dbcli.html', '../assets/why-dbcli-hero.png'],
     ['docs/guides/en/why-dbcli.html', '../../assets/why-dbcli-hero.png'],
-  ]) {
+  ]
+  for (const [path, asset] of heroPages) {
     const { document } = await loadPage(path)
-    const image = document.querySelector<HTMLImageElement>('.story-hero-art img')
+    const image = document.querySelector('.story-hero-art img')
     expect(image?.getAttribute('src')).toBe(asset)
     expect(document.querySelectorAll('.story-timeline .story-moment').length).toBe(3)
     expect(document.querySelectorAll('.contrast-grid .contrast-panel').length).toBe(2)
@@ -128,7 +132,7 @@ test('all local guide links and documentation fragments resolve', async () => {
 
   for (const path of pages) {
     const { document } = await loadPage(path)
-    for (const link of document.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+    for (const link of document.querySelectorAll('a[href]')) {
       const href = link.getAttribute('href')!
       const resolved = new URL(href, pathToFileURL(resolve(path)))
       if (resolved.protocol !== 'file:') continue
@@ -147,7 +151,7 @@ test('all local guide links and documentation fragments resolve', async () => {
 test('English guide pages contain no residual Traditional Chinese copy', async () => {
   for (const slug of ['index', ...guideSlugs]) {
     const { document } = await loadPage(`docs/guides/en/${slug}.html`)
-    const clone = document.documentElement.cloneNode(true) as HTMLElement
+    const clone = document.documentElement.cloneNode(true)
     clone.querySelectorAll('.locale-link').forEach((node) => node.remove())
     expect(clone.textContent).not.toMatch(/[\u3400-\u9fff]/)
   }

--- a/tests/docs/intro-pages.test.ts
+++ b/tests/docs/intro-pages.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from 'bun:test'
 import { Window } from 'happy-dom'
 
+/**
+ * happy-dom's `Document`, not the one `lib.dom` declares.
+ *
+ * The two are unrelated classes with the same name, and the helpers below were
+ * annotated with the global — which typechecked as long as nothing typechecked
+ * this file. Deriving it from `Window` keeps the two in step whatever happy-dom
+ * does next (#97).
+ */
+type PageDocument = Window['document']
+
 const pages = [
   { locale: 'zh-TW', path: 'docs/dbcli-intro.html', counterpart: 'dbcli-intro.en.html' },
   { locale: 'en', path: 'docs/dbcli-intro.en.html', counterpart: 'dbcli-intro.html' },
-] as const
+  // Not `as const`: bun-types' object-table overload for `each` takes a mutable
+  // array, and nothing here needs the literal types.
+]
 
 async function loadIntroPage(path: string) {
   const html = await Bun.file(path).text()
@@ -13,11 +25,11 @@ async function loadIntroPage(path: string) {
   return { html, document: window.document }
 }
 
-function cssText(document: Document) {
+function cssText(document: PageDocument) {
   return [...document.querySelectorAll('style')].map((style) => style.textContent).join('\n')
 }
 
-function quickstartCommands(document: Document): string[] {
+function quickstartCommands(document: PageDocument): string[] {
   return [...document.querySelectorAll('#quickstart .command-box code')]
     .flatMap((code) => (code.textContent ?? '').split(/\r?\n/).map((line) => line.trim()))
     .filter(Boolean)
@@ -40,12 +52,12 @@ function contrastRatio(foreground: string, background: string) {
   return (lighter! + 0.05) / (darker! + 0.05)
 }
 
-function rootTokens(document: Document) {
+function rootTokens(document: PageDocument) {
   const root = cssText(document).match(/:root\s*\{([^}]+)\}/)?.[1] ?? ''
   return Object.fromEntries(
     [...root.matchAll(/--([\w-]+):\s*(#[\da-f]{6})/gi)].map((match) => [
       match[1],
-      match[2].toLowerCase(),
+      match[2]!.toLowerCase(),
     ])
   )
 }
@@ -104,7 +116,7 @@ describe.each(pages)('$locale intro page', ({ path, counterpart }) => {
 
   test('all internal fragment links have targets', async () => {
     const { document } = await loadIntroPage(path)
-    for (const link of document.querySelectorAll<HTMLAnchorElement>('a[href^="#"]')) {
+    for (const link of document.querySelectorAll('a[href^="#"]')) {
       const target = link.getAttribute('href')!.slice(1)
       expect(target.length).toBeGreaterThan(0)
       expect(document.getElementById(target)).not.toBeNull()
@@ -130,7 +142,7 @@ describe.each(pages)('$locale intro page', ({ path, counterpart }) => {
 test('locale pages expose the same section and component contract', async () => {
   const zh = await loadIntroPage('docs/dbcli-intro.html')
   const en = await loadIntroPage('docs/dbcli-intro.en.html')
-  const ids = (document: Document) =>
+  const ids = (document: PageDocument) =>
     [...document.querySelectorAll('main section[id]')].map((section) => section.id)
   expect(ids(zh.document)).toEqual(ids(en.document))
   expect(zh.document.querySelectorAll('.workflow-step').length).toBe(
@@ -180,14 +192,14 @@ test.each(pages)('$locale uses the real interactive-report command labels', asyn
 
 test('English interface contains no residual Traditional Chinese copy', async () => {
   const { document } = await loadIntroPage('docs/dbcli-intro.en.html')
-  const clone = document.documentElement.cloneNode(true) as HTMLElement
+  const clone = document.documentElement.cloneNode(true)
   clone.querySelectorAll('.locale-link').forEach((node) => node.remove())
   expect(clone.textContent).not.toMatch(/[\u3400-\u9fff]/)
 })
 
 test.each(pages)('$locale local assets exist', async ({ path }) => {
   const { document } = await loadIntroPage(path)
-  for (const element of document.querySelectorAll<HTMLImageElement>('img[src]')) {
+  for (const element of document.querySelectorAll('img[src]')) {
     const src = element.getAttribute('src')!
     if (/^(https?:|data:)/.test(src)) continue
     const resolved = new URL(src, `file://${process.cwd()}/${path}`).pathname

--- a/tsconfig.tests.all.json
+++ b/tsconfig.tests.all.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
-}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,31 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "tests/commands/**/*.ts",
-    "tests/contract/**/*.ts",
-    "tests/core/**/*.ts",
-    "tests/fixtures/**/*.ts",
-    "tests/gherkin/**/*.ts",
-    "tests/graft/**/*.ts",
-    "tests/helpers/**/*.ts",
-    "tests/integration/**/*.ts",
-    "tests/perf/**/*.ts",
-    "tests/unit/*.ts",
-    "tests/unit/adapters/**/*.ts",
-    "tests/unit/agent-core/**/*.ts",
-    "tests/unit/agent-tasks/**/*.ts",
-    "tests/unit/build/**/*.ts",
-    "tests/unit/commands/**/*.ts",
-    "tests/unit/core/**/*.ts",
-    "tests/unit/formatters/**/*.ts",
-    "tests/unit/i18n/**/*.ts",
-    "tests/unit/program/**/*.ts",
-    "tests/unit/proxy/**/*.ts",
-    "tests/unit/querylens/**/*.ts",
-    "tests/unit/recovery/**/*.ts",
-    "tests/unit/scripts/**/*.ts",
-    "tests/unit/skill-assets/**/*.ts",
-    "tests/unit/ui-template/**/*.ts",
-    "tests/unit/utils/**/*.ts"
-  ]
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"]
 }


### PR DESCRIPTION
#97 收尾。最後 30 個錯誤歸零，**519 個測試檔全數納入 `typecheck:tests`**。

## 這批與前四批性質不同

不是索引存取，是**兩套同名型別打架**：helper 標的是 `lib.dom` 的 `Document`，實際傳進去的是 happy-dom 的——兩者是毫不相干的 class，只是名字一樣。

修法是從 happy-dom 自己推出型別，而不是在每個呼叫點硬轉：

```ts
type PageDocument = Window['document']
```

這樣 happy-dom 之後怎麼改都跟得上，也不必在測試裡散佈 `as unknown as`。

另外兩類：

**`querySelectorAll<HTMLAnchorElement>` 的型別參數在 happy-dom 是「標籤名」而不是元素型別。** 寫成元素型別不只報 `TS2344`，還會讓結果變成 `unknown`——後面每一次 `.getAttribute()` 都跟著壞，一個誤用產生一串下游錯誤。移除型別參數，讓 happy-dom 自己的選擇器多載生效即可。

**`describe.each` / `test.each` 的物件表格多載（bun-types 的 `each<const T>(table: T[])`）收的是可變陣列**，而這些表格寫了 `as const` 變成 readonly tuple，於是三個多載都不匹配。這裡不需要字面型別，拿掉 `as const`（有註解說明為什麼）。

## 收尾

- `tsconfig.tests.json` 改回 `tests/**/*.ts` — ratchet 完成任務，不再需要逐目錄清單
- 刪除 `tsconfig.tests.all.json` 與 `typecheck:tests:all` — backlog 歸零，這兩個是過渡工具
- `typecheck:tests` 加進 pre-release checklist
- `CONTRIBUTING.md` 的說明從「為什麼分開、怎麼逐批清」改成「兩個專案各管什麼」，並保留這件事為何值得寫下來的紀錄
- `.github/workflows/ci.yml` 的註解不再描述進行中的 rollout
- `src/commands/audit.ts` 那段註解說「編譯期守衛不能放測試檔，因為測試檔不被 typecheck」——**那個理由到這個 PR 為止失效了**，改成說明它為何仍留在原處（守衛該跟它綁在一起的那兩個 union 放一起）

## 驗收（#97 訂的兩條）

```
$ bunx tsc --noEmit -p tsconfig.tests.json --listFiles | grep -c "/tests/"
519

$ # 在 tests/unit/ 放一個故意寫壞的 Covers 守衛
$ bun run typecheck:tests
tests/unit/_probe.test.ts(3,7): error TS2322: Type 'true' is not assignable to type 'false'.
```

第二條是這整條 issue 的重點：**測試檔裡的型別層級斷言從裝飾變成真的守衛**。

## 五批總計

| | |
| --- | --- |
| 起始錯誤 | 339（174 個檔案） |
| 涵蓋測試檔 | 0 → 519 |
| PR | #100 #101 #103 #104 #105 本 PR |

一路上被打開的 typecheck 抓到、runtime 完全看不出來的問題：從不存在的模組 import 型別、helper 呼叫漏傳必要參數、`makeEntry` 裡被 `...overrides` 蓋掉的死碼、五個 fixture 少了型別後來新增的欄位、`@ts-expect-error` 抑制一個早就不存在的錯誤、測試用不合法的權限值表達「權限不足」、以及一整塊只賦值沒人讀的 `_config`。

## Test plan

- `bun run typecheck` / `typecheck:tests` — 綠
- `bun test` — 5499 通過、0 失敗（`tests/docs` 單獨 42 通過）
- `bun run lint` / `prettier --check .` — 綠

Closes #97
