### PR TITLE
fix: [ test ] 洩漏檢查掃字串，隨機 UUID 撞到 port 就假紅

### DIFF
--- a/tests/integration/inspect.test.ts
+++ b/tests/integration/inspect.test.ts
@@ -23,6 +23,55 @@ function run(
   })
 }
 
+/** What the fixture's config holds, and therefore what must never be published. */
+const FIXTURE_SECRETS = { host: 'localhost', port: 5432 }
+
+/**
+ * Credential leaks in a parsed inspect snapshot, described by where they sit.
+ *
+ * Walks the parsed document rather than scanning the serialized text. That is
+ * the whole point: a port is four digits, `audit_recent` carries UUIDs, and hex
+ * collides — so `stdout.includes('5432')` answers a question nobody asked. A
+ * leaf value that *is* the port, or a string that contains the host, is a leak;
+ * `435432` inside an id is not.
+ *
+ * Credential field names are reported wherever they appear, because a key called
+ * `password` in this output is a defect even when its value looks harmless — the
+ * fixture's password is the single character `p`, which no value check can find.
+ */
+const CREDENTIAL_KEYS = new Set(['host', 'port', 'password', 'user', 'uri', 'connectionstring'])
+
+function credentialLeaks(node: unknown, secrets: { host: string; port: number }): string[] {
+  const leaks: string[] = []
+
+  const walk = (value: unknown, path: string): void => {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => walk(item, path ? `${path}.${index}` : String(index)))
+      return
+    }
+    if (value !== null && typeof value === 'object') {
+      for (const [key, child] of Object.entries(value)) {
+        const childPath = path ? `${path}.${key}` : key
+        if (CREDENTIAL_KEYS.has(key.toLowerCase())) {
+          leaks.push(`${childPath} is a credential field`)
+        }
+        walk(child, childPath)
+      }
+      return
+    }
+    if (value === secrets.port || value === String(secrets.port)) {
+      leaks.push(`${path} is the port`)
+      return
+    }
+    if (typeof value === 'string' && value.includes(secrets.host)) {
+      leaks.push(`${path} contains the host`)
+    }
+  }
+
+  walk(node, '')
+  return leaks
+}
+
 beforeAll(async () => {
   // Copy fixture to a tmp dir so the cache-freshness mutation does not dirty
   // the committed fixture between test runs.
@@ -71,12 +120,48 @@ describe('dbcli inspect (CLI)', () => {
     expect(stdout).toContain('## Suggested commands')
   })
 
+  test('the leak criterion ignores a port that is only a substring of a random id', () => {
+    // The reason this criterion is structural. `not.toContain('5432')` over the
+    // whole document went red on CI once because an audit entry's UUID ended
+    // `...435432`; the same commit passed on a re-run. Three ids of 32 hex
+    // characters put that at roughly one run in 700 — rare enough to look like a
+    // regression, common enough to keep costing a CI run and an investigation.
+    const snapshot = {
+      connection: { name: 'default', database: 'app', version: '16.4' },
+      audit_recent: [
+        { id: 'd234ec76-8833-4413-9d02-7c35f8435432', target: 'users' },
+        { id: '3cfdce8a-378d-4d9e-a0a7-5ad8673d12a2', target: '*' },
+      ],
+    }
+    expect(credentialLeaks(snapshot, FIXTURE_SECRETS)).toEqual([])
+  })
+
+  test('the leak criterion still catches a real leak, wherever it sits', () => {
+    expect(
+      credentialLeaks(
+        { connection: { name: 'default', database: 'app', host: 'localhost' } },
+        FIXTURE_SECRETS
+      )
+    ).toEqual(['connection.host is a credential field', 'connection.host contains the host'])
+
+    expect(
+      credentialLeaks({ hints: ['try dbcli query --host localhost'] }, FIXTURE_SECRETS)
+    ).toEqual(['hints.0 contains the host'])
+
+    expect(credentialLeaks({ objects: { count: 5432 } }, FIXTURE_SECRETS)).toEqual([
+      'objects.count is the port',
+    ])
+  })
+
   test('NEVER leaks host / port / password into stdout', async () => {
     const { stdout } = await run(['inspect', '--format', 'json', '--no-connect'])
-    expect(stdout).not.toContain('localhost')
-    expect(stdout).not.toContain('5432')
-    expect(stdout).not.toContain('"password"')
-    expect(stdout).not.toContain('"host"')
+    const snapshot = JSON.parse(stdout)
+
+    // The connection section is the only place a credential could legitimately
+    // be near, so it is pinned by its whole key set: anything added to it fails
+    // here until someone decides it is safe to publish.
+    expect(Object.keys(snapshot.connection).sort()).toEqual(['database', 'name', 'version'])
+    expect(credentialLeaks(snapshot, FIXTURE_SECRETS)).toEqual([])
   })
 
   test('no-config workspace exits 0 with degraded snapshot', async () => {


### PR DESCRIPTION
`tests/integration/inspect.test.ts` 的洩漏測試用 `expect(stdout).not.toContain('5432')` 掃整份輸出。#91 的 CI 上假紅過一次（[job](https://github.com/CarlLee1983/dbcli/actions/runs/31861948171/job/94956772351)）：`--no-connect` 的輸出根本沒有 port 欄位，但 `audit_recent` 的 UUID 是 `d234ec76-8833-4413-9d02-7c35f8435432`，結尾含 `5432`。同一個 commit 重跑就過——不是回歸，是判準本身會誤判。

輸出裡三個 UUID、每個 32 個 hex 字元，估計每 700 次跑撞一次。低到不像常態問題，高到每隔一陣子浪費一次 CI 與一輪追查。

## 改成問對的問題

判準從「序列化文字裡有沒有這串字」換成「解析後的結構裡有沒有這個值」。

新的 `credentialLeaks()` 遞迴走每個葉節點：值**是** port 才算洩漏，字串**含** host 才算洩漏。`435432` 這種夾在 id 裡的四位數不算——它從來就不是 port，只是恰好長得像。

另外把 `connection` 的整組 key 釘死成 `name` / `database` / `version`：

```ts
expect(Object.keys(snapshot.connection).sort()).toEqual(['database', 'name', 'version'])
```

這比原本**強**——`connection` 多出任何欄位都會失敗，直到有人明確決定它可以公開。原本的 `not.toContain('"host"')` 反而是連 `"host"` 這個 key 名出現在任何巢狀位置都會炸。

憑證欄位名（`host` / `port` / `password` / `user` / `uri` / `connectionString`）不論出現在哪裡都算洩漏，因為值檢查在這裡沒有用：fixture 的密碼是單一字元 `p`，任何值比對都找不到它。這也是原本那條寫成 `not.toContain('"password"')`（比對 key 名而不是值）的原因——舊判準其實已經在繞開自己的機制了。

## 有驗證新判準沒有比舊的弱

這是這個 PR 最該檢查的地方——把一個會誤報的守衛換成一個更安靜的守衛，很容易順手換成一個更沒用的守衛。

暫時讓 `src/core/inspect/collector.ts` 在 `connection` 裡多吐 `host` 與 `port`：

```
(fail) NEVER leaks host / port / password into stdout
- Expected  - 0
+ Received  + 2
```

回報 `connection.host is a credential field` 與 `connection.host contains the host` 兩筆，還原後全綠，`git diff src/` 沒有殘留。

## 新增的兩條測試把兩個方向都釘住

- 帶 `...435432` 這個 UUID 的合成 snapshot → 沒有洩漏（正是 CI 上假紅的那一份）
- `connection.host`、hint 裡嵌 host、以及某個計數剛好等於 5432 → 各自被指名回報

## Test plan

- `bun test tests/integration/inspect.test.ts` — 8 通過、0 失敗（原本 6 條，新增 2 條）
- `bun test` — 5501 通過、0 失敗
- `bun run typecheck` / `typecheck:tests` / `lint` / `prettier --check .` — 綠

Closes #92
