### PR TITLE
fix: [ test ] happy-dom 的 fetch 帶同源政策，ES 整合測試整份靜默 skip

### DIFF
--- a/tests/helpers/setup-happy-dom.ts
+++ b/tests/helpers/setup-happy-dom.ts
@@ -1,10 +1,38 @@
+/**
+ * Registers happy-dom's browser globals for the test run, without letting its
+ * `fetch` govern real network calls.
+ *
+ * happy-dom's `fetch` enforces a same-origin policy. Elasticsearch is the only
+ * adapter that speaks HTTP, and its server answers `GET /` with no CORS
+ * headers, so `connect()` threw `Cross-Origin Request Blocked` inside
+ * `bun test` while `curl` and a plain `bun -e` script reached the same
+ * container without trouble. `tests/integration/elasticsearch.test.ts` caught
+ * that in a `try`/`catch` and reported "container not running", so the whole
+ * file silently asserted nothing on every machine and in CI for as long as this
+ * registration existed (#109).
+ *
+ * Scoping the registration to the one file that needs a DOM does not fix it:
+ * Bun runs test files in a shared process, so the globals leak into whatever
+ * else lands in that process and the outcome depends on file order. A preload
+ * is at least deterministic, so what changed is the `fetch`, not the timing.
+ *
+ * Only `fetch` is restored. Everything else happy-dom installs (`window`,
+ * `document`, `Element`, …) has no runtime counterpart to shadow, and the
+ * remaining request globals are unused: no adapter constructs `Request` or
+ * `XMLHttpRequest` directly.
+ */
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+/** The runtime's `fetch`, captured before happy-dom can replace it. */
+export const runtimeFetch = globalThis.fetch
 
 // Bun loads `preload` files once per test process. Guard against double
 // registration when individual test files import this helper directly.
 if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
   GlobalRegistrator.register()
 }
+
+globalThis.fetch = runtimeFetch
 
 // Recharts' ResponsiveContainer relies on ResizeObserver; happy-dom does not
 // implement it. Provide a no-op shim so the smoke test does not crash. We

--- a/tests/integration/elasticsearch.test.ts
+++ b/tests/integration/elasticsearch.test.ts
@@ -15,21 +15,26 @@ describe('Elasticsearch Integration', () => {
 
   const adapter = new ElasticsearchAdapter(options)
 
+  // Why the reason is reported rather than assumed: this file spent months
+  // printing "container not running" while the container was running and
+  // healthy — a global happy-dom registration was giving `fetch` a same-origin
+  // policy, so `connect()` threw `Cross-Origin Request Blocked` and the skip
+  // branch swallowed it (#109). A skip that states its cause can be checked.
+  let unreachable: string | null = null
+
   beforeAll(async () => {
-    // Skip if Elasticsearch is not running
     try {
       await adapter.connect()
-    } catch {
-      console.warn('Skipping Elasticsearch integration tests (container not running on port 9201)')
+    } catch (error) {
+      unreachable = error instanceof Error ? error.message : String(error)
+      console.warn(
+        `Skipping Elasticsearch integration tests — ${ES_HOST}:${ES_PORT} unreachable: ${unreachable}`
+      )
     }
   })
 
   test('can create index, insert document, and query it', async () => {
-    try {
-      await adapter.connect()
-    } catch {
-      return // skip
-    }
+    if (unreachable) return
 
     const index = 'test-index-' + Date.now()
 

--- a/tests/unit/build/test-env-globals.test.ts
+++ b/tests/unit/build/test-env-globals.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Guards the one property of the test environment that a network-speaking
+ * adapter depends on: `fetch` is the runtime's, not happy-dom's.
+ *
+ * happy-dom is preloaded for every test process so that the UI render smoke
+ * test has a DOM, and Bun shares a process across test files, so its globals
+ * are visible everywhere regardless of who asked. Its `fetch` enforces a
+ * same-origin policy, which made every Elasticsearch integration assertion
+ * silently skip for months behind a "container not running" message while the
+ * container was running (#109).
+ *
+ * `window` is deliberately not asserted on: it is still registered, and
+ * shadowing it is harmless. The `fetch` identity is the whole contract.
+ */
+import { test, expect } from 'bun:test'
+import { runtimeFetch } from '../../helpers/setup-happy-dom'
+
+test("fetch is the runtime implementation, not happy-dom's same-origin one", () => {
+  expect(globalThis.fetch).toBe(runtimeFetch)
+})
+
+test('a cross-origin response is readable rather than blocked', async () => {
+  // The shape that broke: a server answering with no CORS headers. Skipped
+  // when nothing is listening, since this asserts about the fetch in use, not
+  // about the container being up.
+  const response = await fetch('http://localhost:9201/').catch((error: Error) => error)
+
+  if (response instanceof Error) {
+    expect(response.message).not.toContain('Cross-Origin')
+    return
+  }
+
+  expect(response.status).toBe(200)
+})


### PR DESCRIPTION
Closes #109

## 問題

`tests/integration/elasticsearch.test.ts` 在任何機器與 CI 上都沒有斷言過。它印的理由是「container not running on port 9201」，而容器是 healthy 的：

```
$ curl -s -o /dev/null -w '%{http_code}' http://localhost:9201        → 200
$ bun -e '… new ElasticsearchAdapter(…).connect()'                    → CONNECT OK
$ bun test ./tests/integration/elasticsearch.test.ts
  Cross-Origin Request Blocked: The Same Origin Policy disallows reading
  the remote resource at "http://localhost:9201/".
  1 pass  0 fail  （0 個 expect）
```

ES 的 `GET /` 不帶 CORS 標頭，happy-dom 的 fetch 照同源政策擋掉沒有標頭的回應。`beforeAll` 的 catch 吞掉它、每個 test 再自己 `return`，整份檔案就這樣安靜地什麼都沒驗。ES 是唯一走 HTTP 的 adapter（MySQL / PG / Mongo / Redis 走各自的 TCP driver），所以只有它中彈。

## 試過但不成立的兩條路

issue 裡列的方向一（拿掉全域 preload）我實際做了，兩次都被事實擋回來：

1. **刪掉 preload** — 先前判斷「沒有消費者」是錯的。`grep --include="*.test.ts"` 把 `tests/integration/ui-render-smoke.test.tsx` 排除掉了，刪掉之後它的五條 render 測試全紅。
2. **改成只讓那一個檔案自己 import** — 也不成立。Bun 把多個測試檔跑在同一個行程，全域註冊會洩漏到同行程的其他檔案，於是 ES 連不連得上取決於檔案順序。實測把 guard、ES、ui-render-smoke、docs 放在同一次 `bun test`，ES 又被汙染。

preload 至少是確定的，所以留著它——改的是 `fetch`，不是時機。

## 改法

`tests/helpers/setup-happy-dom.ts` 在 `GlobalRegistrator.register()` 之前存下 runtime 的 `fetch`，註冊後寫回去，並 `export const runtimeFetch` 讓測試釘得住契約。只還原 `fetch`：happy-dom 裝的其他東西（`window` / `document` / `Element`）沒有 runtime 對應物會被遮住，`Request` / `XMLHttpRequest` 則沒有任何 adapter 直接用。

順帶修掉那句說謊的 skip 訊息：現在印實際的錯誤與 `host:port`，而且只在 `beforeAll` 連一次，不是每個 test 再連一次。

## Test plan

本機 2026-08-16，六個 docker 測試服務全 healthy：

- [x] `bun test` — **5509 pass / 0 fail**（修之前 5507；多的兩條是 ES 那條真的跑起來，以及新的 guard）
- [x] ES 那條實測跑 **5 個 expect**（修之前 0）
- [x] 突變檢查：`toHaveLength(1)` → `2` 會轉紅，證明它在執行路徑上而不是又一次靜默通過
- [x] 突變檢查：拿掉 `globalThis.fetch = runtimeFetch`，guard 與 ES 各轉紅一條
- [x] `ES_PORT=9999 bun test ./tests/integration/elasticsearch.test.ts` 走 skip 路徑，訊息說得出真正的原因（`localhost:9999 unreachable: Could not connect to Elasticsearch: …`）
- [x] guard / ES / ui-render-smoke / tests/docs 同一次 `bun test` 一起跑：50 pass / 0 fail
- [x] `typecheck` / `typecheck:tests` / `lint` / `format:check` 全綠

## 對 v2.1.0 的意義

`v2.1.0` 發佈時的「5507 pass / 0 fail」不包含 ES 的斷言，PR #108 的 `integration` job 也一樣。這個 PR 之後那些斷言才第一次真的跑。程式碼本身沒有動，所以不需要補發版本。