### PR TITLE
docs: [ adr ] 0005 收尾——deferred 是功能的狀態，不是這份決策的狀態

### DIFF
--- a/docs/adr/0005-provider-driven-query-drafts-remain-deferred.md
+++ b/docs/adr/0005-provider-driven-query-drafts-remain-deferred.md
@@ -1,6 +1,7 @@
 ---
-status: deferred
+status: accepted
 date: 2026-08-07
+accepted: 2026-08-16
 reopen_trigger: Explicit product and security approval recorded against the checklist below.
 ---
 
@@ -11,6 +12,11 @@ an explicit draft and `dbcli semantic draft validate` checks it locally. No
 provider-driven generation is authorized in dbcli at this time.
 
 ## Decision
+
+`status: accepted` here means the policy below is settled, not that
+provider-driven generation is approved. What stays deferred is the feature —
+SQD-05 and SQD-06 — and it stays deferred until a superseding record clears the
+reopen checklist. This ADR is not an open question awaiting an answer.
 
 Do not add a provider SDK, provider configuration, credential lookup, outbound
 transport, or `semantic draft generate` command. No provider or model is


### PR DESCRIPTION
## 背景

盤點專案未決事項時，`docs/adr/` 十份 ADR 裡只有 0005 不是 `accepted`，看起來是唯一懸而未決的決策。實際讀內容，它已經是一個完整定案的政策：fail-closed、不加 provider SDK／設定／憑證／outbound transport／`semantic draft generate`，並附有 reopen checklist 和 falsified-if 條件。真正 deferred 的是功能（SQD-05／SQD-06），不是這份決策本身。

frontmatter 的 `status: deferred` 讓兩者混在一起，結果是每次盤點都會把它當成待答問題重新撿起來。

## 變更

只動 `docs/adr/0005-provider-driven-query-drafts-remain-deferred.md`：

- `status: deferred` → `accepted`，新增 `accepted: 2026-08-16`，`reopen_trigger` 保持原樣
- Decision 段開頭補一段，明確區分「政策定案」與「provider generation 獲准」——後者沒有發生。沒有這段，後人看到標題寫 remain deferred、狀態卻是 accepted，很可能當成筆誤去「修正」

政策內容、reopen checklist、falsified-if 一字未改。

## 影響範圍

功能狀態不變，下游敘述全部仍然成立，無須連帶修改：

- `docs/plans/2026-08-06-semantic-query-draft-ticket-backlog.md` — SQD-04 標的是「已記錄一個 deferred 決策」；SQD-05／SQD-06 維持 Deferred
- `docs/specs/2026-08-06-wren-inspired-semantic-roadmap.md` — 3b 標「Deferred by ADR-0005」
- `docs/research/wrenai-integration-assessment.md` — 同上

`docs/adr/` 沒有索引檔，CI 與 `scripts/` 也沒有讀取 ADR status 的工具，因此沒有其他連帶效應。

## Test plan

純文件變更，不涉及程式碼。改動前在 main 上跑過完整驗證作為基準：

- `bun test` — 5495 pass / 27 skip / 0 fail（509 檔）
- `tsc --noEmit` — 乾淨
- `eslint src tests scripts --max-warnings=0` — 乾淨

Reviewer 請確認的是判斷而非測試：把「政策定案」記為 accepted、同時讓功能維持 deferred，這個區分是否正確表達了現況。