### PR TITLE
docs: [ plans ] evidence 子系統的交付狀態與驗收證據對帳

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,18 @@ relevant changes, tests, documentation checks, and known risks.
 An intentionally postponed choice with an explicit condition for reopening it;
 it is not an unspecified future TODO.
 
+**Known deviation**:
+A named part of delivered work that intentionally does not satisfy its own
+acceptance criterion, recorded with what it deviates from and what would make
+it worth revisiting. It is neither a TODO nor an unreported defect: work
+carrying one is delivered, not complete.
+
+**Unverified**:
+An acceptance criterion whose implementation exists but which no test asserts.
+It is a statement about proof, not about correctness, and it is distinct from a
+known deviation: nobody has decided the criterion is unmet, nobody has shown it
+is met. A partially asserted criterion is unverified, not covered.
+
 ## Semantic query-drafting language
 
 **QueryDraft**:

--- a/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
+++ b/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+date: 2026-08-16
+review_by: 2026-09-16
+---
+
+# The evidence subsystem waits for a user before it is repaired
+
+The Agent Data Evidence and Change Intelligence subsystem shipped in v1.53.0 on
+2026-08-09: `src/core/evidence-pack`, `src/core/evidence-receipt`,
+`src/core/contracts`, `src/core/impact`, `src/core/data-access`, and
+`src/core/workload-impact`, with their commands, tests, and four-language user
+documentation. As of this record nobody has composed an evidence pack outside
+the test suite. A review of the shipped code found four defects, two of which
+contradict acceptance criteria the tickets were closed against.
+
+## Decision
+
+Do not change the behavior of those modules until a real evidence pack has been
+composed and read. The known defects listed below stay as they are, recorded
+rather than repaired.
+
+The trigger is deliberately attached to work that already happens: the next time
+`dbcli verify` or `dbcli assert` runs against a real database, compose a pack
+from it and read the result. If that has not happened by **2026-09-16**, the
+subsystem is frozen — marked experimental in the user documentation, removed
+from the recommended workflow, and given no further investment.
+
+## Known deviations
+
+These are deliberate, not undiscovered:
+
+- `coverage.gaps` is a dead schema surface. Both writers hard-code an empty
+  array (`src/core/evidence-pack/index.ts:363,399`) and the parser rejects a
+  non-empty one (`:380-388`), so the expired-reference gap that EVD-01 promised
+  can only appear in the transient `validate` output.
+- Pack digests are not reproducible. The digest covers a random UUID id and a
+  millisecond `createdAt` (`:302-308,357-364`), so equivalent claim and
+  reference sets cannot produce an identical digest, which EVD-01 required.
+  `canonicalizeWithoutDigest` is also a bare `JSON.stringify` with no key
+  sorting; canonical ordering is maintained by hand across the build and parse
+  paths.
+- Blacklist matching over claim prose is unbounded case-insensitive substring
+  matching with no minimum term length (`src/commands/evidence.ts:57-72`), and
+  the keys of `blacklist.columns` are never added to the term list. Short
+  column names block ordinary prose; `validate` and `render` re-check against
+  current settings, so a stored pack can become unrenderable later.
+- `observation.fingerprint` is an unsalted SHA-256 over a low-entropy value
+  (`src/core/evidence-receipt/index.ts:154-187`); the verify variant has eight
+  possible preimages. The values it covers already appear in plaintext in
+  `outcome`, so the only additional exposure is the per-check pass bit pattern.
+
+## Why not repair them now
+
+An unused subsystem cannot tell us which of its defects matter. Reproducible
+digests are worth real effort if someone diffs packs across runs and worthless
+if nobody composes a second one; the blacklist false-positive rate is a bug or
+a non-event depending entirely on which identifiers a real user has blacklisted.
+Repairing all four now spends effort at the moment we know least, and produces
+a subsystem whose acceptance criteria finally hold and that still has no users.
+
+## Why not delete it instead
+
+The code is written, tested, and published. Deleting it costs a major version
+bump and breaks an API surface whose consumers we cannot enumerate, and buys
+back only maintenance we are choosing not to spend. Freezing achieves the same
+saving without the breaking change, which is why the 2026-09-16 fallback is a
+freeze rather than a removal.
+
+## Consequences
+
+- A reader who finds these defects should not fix them; this record is the
+  reason they are still there.
+- The affected tickets in
+  `docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md`
+  are marked delivered with named known deviations rather than completed.
+- Repair work becomes authorized by evidence of use, not by the defect list.
+- The freeze path, if taken, changes documentation and recommendation only. It
+  removes no command and breaks no published interface.
+
+**Falsified if:** `src/core/evidence-pack/index.ts`,
+`src/core/evidence-receipt/index.ts`, `src/core/contracts/index.ts`,
+`src/core/impact/index.ts`, `src/core/data-access/index.ts`, or
+`src/core/workload-impact/index.ts` gains a behavioral change before a real
+evidence pack has been composed and read, or 2026-09-16 passes with neither
+that record nor the freeze.

--- a/docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md
+++ b/docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md
@@ -2,7 +2,13 @@
 
 **Date:** 2026-08-08
 
-**Status:** Proposed — no ticket is implementation authorization by itself.
+**Status:** All eight tickets delivered in v1.53.0 (2026-08-09). Two carry known
+deviations; see each ticket. Whether those deviations get repaired is governed by
+[ADR-0011](../adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md).
+
+Every acceptance criterion below ends with either `— covered by: <test>` naming
+the test that asserts it, or `— known deviation: <reason>`. A drift guard that
+enforces this convention follows in a separate change.
 
 **Specification:**
 [`Agent Data Evidence and Change Intelligence`](../specs/2026-08-08-agent-data-evidence-and-change-intelligence.md)
@@ -35,7 +41,8 @@ useful without them and report their absence as coverage gaps.
 
 ## EVD-01 — Evidence Pack v1
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Known deviations: criterion 3 and
+the expired-reference coverage gap in Scope. Unverified: criteria 1, 2, and 5.
 
 **Depends on:** Existing verification artifact reader and audit/recovery reader
 
@@ -58,7 +65,10 @@ and safe audit/recovery reference projections.
   requested source fails composition; a reference that expires later through
   audit rotation/clear yields non-zero `source-expired` reference validation
   plus a coverage gap, while digest validation and forensic rendering remain
-  available.
+  available. — known deviation: the coverage gap is unreachable. Both writers
+  hard-code an empty `gaps` array (`src/core/evidence-pack/index.ts:363,399`)
+  and the parser rejects a non-empty one (`:380-388`), so expiry is visible only
+  in the transient `validate` output, never in the pack.
 - Update four-way user docs and generated skill/platform guidance. Claims must
   visibly remain external interpretation, not a dbcli verification verdict.
 
@@ -67,15 +77,36 @@ result export, archive/import support, signing, or authentication.
 
 **Acceptance criteria:**
 
-1. All three commands are offline and cause no adapter/database call.
+1. All three commands are offline and cause no adapter/database call. —
+   unverified: `tests/unit/core/execution-path-contract.test.ts` asserts
+   structurally that no unregistered adapter call exists, but no test asserts
+   that these commands attempt zero connections.
 2. Unknown keys, invalid digest, duplicate IDs, missing required source,
    unsafe/malformed reference, oversized input, and contained-path violation
-   fail closed.
+   fail closed. — unverified: unknown keys, invalid digest, and contained-path
+   violation are asserted in
+   `tests/unit/core/evidence-pack/evidence-pack.test.ts`; duplicate IDs, missing
+   required source, oversized input, and malformed reference objects have no
+   test.
 3. Equivalent claim/reference sets produce canonical identical JSON and digest.
+   — known deviation: unsatisfiable. The digest covers a random UUID id and a
+   millisecond `createdAt` (`src/core/evidence-pack/index.ts:302-308,357-364`),
+   and the command injects neither a fixed id nor a clock
+   (`src/commands/evidence.ts:301`). Only claim and reference ordering is
+   canonical.
 4. Tampering is detected; expired provenance is neither hidden nor misreported
-   as a valid reference.
+   as a valid reference. — covered by:
+   `tests/unit/core/evidence-pack/evidence-pack.test.ts` (`canonicalizes claims
+   and produces a tamper-evident pack`) and
+   `tests/integration/evidence-command.test.ts` (`reports source-expired after
+   audit retention while rendering remains available`).
 5. JSON/Markdown never exposes rows, raw SQL, credentials, raw error body, or
-   unredacted argv; it labels claims as external.
+   unredacted argv; it labels claims as external. — unverified: rows, raw SQL,
+   audit metadata, Markdown injection, and the external-claim label are asserted
+   in `tests/integration/evidence-command.test.ts` and
+   `tests/unit/core/evidence-pack/evidence-pack.test.ts`; credentials, raw error
+   body, and unredacted argv are asserted only at claim input, never on rendered
+   output.
 
 **Verification:** Focused core/integration/security tests, `bun test`, `bun
 run typecheck`, `bun run lint`, `bun run docs:check`, `bun run skill:check`,
@@ -86,7 +117,7 @@ run typecheck`, `bun run lint`, `bun run docs:check`, `bun run skill:check`,
 
 ## CON-01 — Semantic Contracts v1
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Unverified: criteria 3 and 4.
 
 **Depends on:** Existing filtered semantic context and saved-query registry
 
@@ -115,14 +146,29 @@ defined assertion/verify DSL, contract file writes, or provider generation.
 **Acceptance criteria:**
 
 1. Unknown, duplicate, noncanonical, stale, and blacklisted subjects fail
-   closed without leaking protected names.
+   closed without leaking protected names. — covered by:
+   `tests/unit/core/contracts/contracts.test.ts` (`fails closed for strict shape
+   and unsafe semantic subjects without naming protected terms`, `fails closed
+   for unknown or noncanonical subjects and markdown-shaped text`, `classifies
+   offline drift without re-reading semantic sources`).
 2. Default context/search uses approved valid contracts only; draft,
-   deprecated, or stale contracts cannot silently influence agent context.
+   deprecated, or stale contracts cannot silently influence agent context. —
+   covered by: `tests/unit/commands/contracts.test.ts` (`context and search
+   expose only approved valid contracts`) and
+   `tests/unit/core/context/context.test.ts` (`gatherContext exposes only
+   approved valid semantic contracts`, `gatherContext fails closed when
+   contracts exist without semantic evidence`).
 3. Missing contract file leaves existing semantic and skill-context behavior
    unchanged; contract drift runs offline and distinguishes valid/stale/invalid/
-   unavailable inputs.
+   unavailable inputs. — unverified: valid, stale, and both unavailable cases
+   are asserted in `tests/unit/core/contracts/contracts.test.ts`; the `invalid`
+   drift branch (`src/core/contracts/index.ts:104,116`) has no test, and no test
+   asserts that an absent contract file leaves skill context unchanged.
 4. No command introduces a database connection or widens `QueryDraft` or
-   execution permission.
+   execution permission. — unverified: only the repo-wide
+   `tests/unit/core/execution-path-contract.test.ts` covers this structurally;
+   no contract-specific test asserts that the commands stay offline, and no test
+   relates contracts to `QueryDraft` at all.
 
 **Verification:** Focused core/command tests, then EVD-01's completion gate.
 
@@ -130,7 +176,9 @@ defined assertion/verify DSL, contract file writes, or provider generation.
 
 ## IMP-01 — Normalize a physical proposed change
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Every acceptance criterion is
+asserted. Implemented in `src/core/orm-drift/change-set.ts`, not under
+`src/core/impact/`, which only imports its types.
 
 **Depends on:** Existing Design Assistant, normalized schema, and ORM drift
 comparison
@@ -154,11 +202,20 @@ execution, semantic lookup, or source-code analysis.
 **Acceptance criteria:**
 
 1. Equivalent design/cache/ORM inputs produce deterministic change identity
-   and order.
+   and order. — covered by: `tests/unit/core/orm-drift/change-set.test.ts`
+   (`orders equivalent shuffled inputs deterministically`).
 2. A design-only missing object is never misclassified as a removal; reverse
-   direction and modified-field cases have focused regression coverage.
+   direction and modified-field cases have focused regression coverage. —
+   covered by: `tests/unit/core/orm-drift/change-set.test.ts` (`labels a
+   declared-only table as a proposed addition with its declared origin`,
+   `reversing declared and baseline labels the object as a removal`, `emits a
+   directional column modification with before and after values`).
 3. Ambiguous qualified/cross-connection identities cannot collapse into the
-   same change subject.
+   same change subject. — covered by:
+   `tests/unit/core/orm-drift/change-set.test.ts` (`uses every declared scope
+   component in the identity so changes cannot collapse`, `keeps
+   schema-qualified table identities separate`, `rejects identities that collide
+   after the baseline default schema is applied`).
 
 **Verification:** Focused normalization tests, `bun run typecheck`, `bun run
 lint`, and `git diff --check`.
@@ -167,7 +224,8 @@ lint`, and `git diff --check`.
 
 ## IMP-02 — Baseline impact assessment and CLI
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Known deviation: the `declared`
+coverage level in Scope. Unverified: all four criteria.
 
 **Depends on:** CON-01 and IMP-01
 
@@ -180,7 +238,11 @@ its known governed dependencies, with honest coverage and CI-safe exit rules.
   joins `NormalizedChangeSet` with semantic/contracts, saved-query metadata,
   and safely available verification metadata.
 - Emit stable source-located findings, recommended verification, and
-  `partial`/`declared` coverage only. Never report `complete` in v1.
+  `partial`/`declared` coverage only. Never report `complete` in v1. — known
+  deviation: `declared` is unreachable. It requires an empty gap list
+  (`src/core/impact/index.ts:219`), but the data-access join always adds a gap
+  (`:262-263`), so the level is always `partial`. `complete` is excluded by the
+  type, not by a test.
 - Add `impact assess --design … (--against-cache | --against-orm …)` with
   explicit output path, JSON/Markdown format, and `--fail-on error|warn|never`.
 - Reuse existing design/ORM/cache normalization; do not connect, refresh schema,
@@ -196,13 +258,31 @@ migration execution, or safety certification from an empty finding list.
 **Acceptance criteria:**
 
 1. Removed/modified visible schema objects deterministically trace to known
-   semantic contracts, saved-query metadata, and safe verification metadata.
+   semantic contracts, saved-query metadata, and safe verification metadata. —
+   unverified: the removal path is asserted in
+   `tests/unit/core/impact/impact.test.ts` (`traverses physical changes through
+   approved contracts to known saved queries`); the `modify` operation has no
+   test.
 2. Direct/transitive traversal is cycle-safe and ordered; every omission has an
-   explicit source or coverage explanation.
+   explicit source or coverage explanation. — unverified: cycle safety is
+   asserted in `tests/unit/core/impact/impact.test.ts` (`is cycle-safe and
+   deterministic across semantic input order`), but that test compares one
+   report against its own sorted ids rather than two input orders, and
+   `SAVED_QUERY_REFERENCE_UNAVAILABLE` (`src/core/impact/index.ts:185`) has no
+   test.
 3. `--fail-on` changes only process exit code, never report findings; required
-   option/path errors fail before any local DB activity.
+   option/path errors fail before any local DB activity. — unverified:
+   `tests/unit/commands/impact.test.ts` asserts the `warn` and `never` paths
+   (`writes identical findings before --fail-on changes only the exit code`);
+   the `error` branch has no test, and nothing asserts that option validation
+   precedes local reads — it does not (`src/commands/impact.ts:161-165` runs
+   after `:104-110`).
 4. Output contains no protected identifier, SQL body, row, credential, or raw
-   error and all unavailable inputs remain visible as gaps.
+   error and all unavailable inputs remain visible as gaps. — unverified:
+   protected identifiers, SQL bodies, and gap visibility are asserted across
+   `tests/unit/core/impact/impact.test.ts` and
+   `tests/unit/commands/impact.test.ts`; credentials and raw error bodies have
+   no test.
 
 **Verification:** Focused core/integration tests, then EVD-01's completion
 gate.
@@ -211,7 +291,7 @@ gate.
 
 ## IMP-03 — Declared data-access manifest
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Unverified: criteria 2 and 3.
 
 **Depends on:** IMP-02
 
@@ -234,11 +314,21 @@ call-graph inference, or `complete` coverage.
 **Acceptance criteria:**
 
 1. Path traversal/symlink escape, duplicate operation, unknown/blacklisted
-   subject, and missing declared coverage fail safely.
+   subject, and missing declared coverage fail safely. — covered by:
+   `tests/unit/core/data-access/data-access.test.ts` (`rejects traversal and
+   source symlinks outside the workspace`, `rejects a manifest symlink before
+   reading an external file`, `rejects duplicate names, unknown references, and
+   missing declared coverage without exposing protected text`).
 2. Affected operations produce stable source-located warnings; no manifest can
-   grant database or verification authority.
+   grant database or verification authority. — unverified: the warning shape is
+   asserted in `tests/unit/core/impact/impact.test.ts` (`emits one stable
+   warning for each affected declared access operation`); nothing asserts that a
+   manifest cannot grant database or verification authority.
 3. Absent/invalid optional manifest is reported as coverage, never clean
-   analysis.
+   analysis. — unverified: the invalid case is asserted in
+   `tests/unit/commands/impact.test.ts` (`records an invalid optional
+   data-access manifest as coverage without leaking its path`); no test asserts
+   the `DATA_ACCESS_ABSENT` or `DATA_ACCESS_UNAVAILABLE` gaps reach a report.
 
 **Verification:** Focused parser/adapter tests plus IMP-02 command checks.
 
@@ -246,7 +336,7 @@ call-graph inference, or `complete` coverage.
 
 ## IMP-04 — Advisory proxy-workload impact adapter
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Unverified: criteria 1 and 3.
 
 **Depends on:** IMP-02 and existing proxy/querylens redaction
 
@@ -266,10 +356,21 @@ performance tuning, auto-indexing, or blocking solely on workload.
 **Acceptance criteria:**
 
 1. Missing, malformed, stale, unreadable, or redaction-failed input produces a
-   coverage gap, never a clean report.
+   coverage gap, never a clean report. — unverified: missing, malformed, stale,
+   and redaction-failed inputs are asserted in
+   `tests/unit/core/workload-impact/workload-impact.test.ts` and mapped to gaps
+   in `tests/unit/core/impact/impact.test.ts`; the unreadable case
+   (`state: 'unavailable'`, `src/core/workload-impact/index.ts:57,115,121`) and
+   the `WORKLOAD_UNAVAILABLE` and `WORKLOAD_INVALID` gaps have no test.
 2. No literal, parameter, error body, or protected identifier reaches the
-   impact report.
-3. Existing proxy/querylens behavior and output remain unchanged.
+   impact report. — covered by:
+   `tests/unit/core/workload-impact/workload-impact.test.ts` (`returns only
+   bounded redacted metadata from recent completed events`) and
+   `tests/unit/commands/impact.test.ts` (`joins explicit proxy workload metadata
+   as advisory evidence without leaking event contents`).
+3. Existing proxy/querylens behavior and output remain unchanged. — unverified:
+   no test asserts this. The adapter builds its own reader and only imports
+   `applyRedaction`, which is an argument from structure, not an assertion.
 
 **Verification:** Focused adapter/security tests and IMP-02 command checks.
 
@@ -277,7 +378,8 @@ performance tuning, auto-indexing, or blocking solely on workload.
 
 ## EVD-02 — Assert evidence receipts
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Unverified: all four criteria.
+No test runs `dbcli assert --evidence-receipt`.
 
 **Depends on:** EVD-01 and existing assert/audit/verification contracts
 
@@ -301,14 +403,25 @@ receipt import, or new adapter path.
 **Acceptance criteria:**
 
 1. Without the option, assert output and audit/verification lifecycle are
-   unchanged.
+   unchanged. — unverified: no test exercises `assert --evidence-receipt` at
+   all, so nothing asserts what its absence preserves. The nearest test covers
+   `--write-verification-artifact`, a different option.
 2. A receipt cannot misreport assert success if its write fails; audit
    best-effort unavailability is explicit safe provenance metadata, never a
-   fabricated audit ID.
+   fabricated audit ID. — unverified: the write-failure path
+   (`src/commands/assert.ts:205-207`) has no test;
+   `tests/unit/core/evidence-receipt/evidence-receipt.test.ts` passes a null
+   `auditRef` through a round trip without asserting it stays null.
 3. Receipt output contains no row, SQL, literal, credential, arbitrary path, or
-   raw error and is cross-linkable to existing artifacts.
+   raw error and is cross-linkable to existing artifacts. — unverified: path
+   stripping and argv redaction are asserted in
+   `tests/unit/core/evidence-receipt/evidence-receipt.test.ts` and
+   `tests/unit/utils/redaction.test.ts`; no test links an assert receipt back to
+   a real artifact or feeds one to `evidence compose`.
 4. Execution-path review proves the option adds no route to an adapter and does
-   not weaken query-only behavior.
+   not weaken query-only behavior. — unverified: the repo-wide
+   `tests/unit/core/execution-path-contract.test.ts` covers the adapter half; no
+   test runs this option under `query-only` permission.
 
 **Verification:** Focused unit/integration/security tests, execution-path
 contract tests, then EVD-01's completion gate.
@@ -317,7 +430,7 @@ contract tests, then EVD-01's completion gate.
 
 ## EVD-03 — Verify evidence receipts
 
-**Status:** Proposed
+**Status:** Delivered in v1.53.0 (2026-08-09). Unverified: criterion 3.
 
 **Depends on:** EVD-02 and existing built-in verify scenarios
 
@@ -341,12 +454,27 @@ write verification, or query/explain receipts.
 **Acceptance criteria:**
 
 1. Each supported built-in scenario produces a conforming receipt on explicit
-   request or fails safely and visibly as unsupported.
+   request or fails safely and visibly as unsupported. — covered by:
+   `tests/unit/commands/verify-receipt.test.ts` (`writes a receipt for every
+   built-in scenario and preserves all status distinctions`, `records an
+   artifact-write failure separately and rejects ambiguous audit provenance`)
+   and `tests/integration/verify-help.test.ts` (`preflight rejects an evidence
+   receipt before any database configuration is read`). End-to-end CLI coverage
+   exists for three of the four scenarios and is skipped without a database.
 2. Receipt outcome and scenario verification status remain separate through
-   `verified`, `not_verified`, `indeterminate`, and `blocked` paths.
+   `verified`, `not_verified`, `indeterminate`, and `blocked` paths. — covered
+   by: `tests/unit/core/evidence-receipt/evidence-receipt.test.ts` (`keeps each
+   verify status distinct from its coarse receipt outcome`).
 3. Option absence preserves existing verify output, artifact schema, registry
-   privacy, and plan-only semantics.
-4. Tests cover all built-in outcomes and redaction/path-containment failures.
+   privacy, and plan-only semantics. — unverified: no test asserts that no
+   receipt is written without the option; `tests/unit/core/verify/registry.test.ts`
+   imports `BUILTIN_VERIFY_SCENARIOS` directly rather than asserting the
+   registry stays private; nothing asserts plan-only semantics.
+4. Tests cover all built-in outcomes and redaction/path-containment failures. —
+   covered by: `tests/unit/commands/verify-receipt.test.ts` (all four outcomes,
+   redaction of a seeded `UPDATE private_orders …` argv, and `fails safely for
+   receipt collisions and symlink traversal after the artifact is
+   authoritative`).
 
 **Verification:** Scenario-focused tests, execution-path contract tests, then
 EVD-01's completion gate.

--- a/docs/specs/2026-08-08-agent-data-evidence-and-change-intelligence.md
+++ b/docs/specs/2026-08-08-agent-data-evidence-and-change-intelligence.md
@@ -1,8 +1,10 @@
 # Agent Data Evidence and Change Intelligence
 
 **Date:** 2026-08-08
-**Status:** Proposed — specification only; no implementation is authorized by
-this document
+**Status:** Delivered in v1.53.0 (2026-08-09). Disposition of the shipped code
+is governed by
+[ADR-0011](../adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md);
+see the ticket backlog for per-ticket known deviations
 **Depends on:** the semantic context roadmap, verification artifacts, audit and
 recovery contracts, and the Design Assistant
 **Supersedes:** nothing


### PR DESCRIPTION
## 起因

盤點專案未決事項時，`docs/plans/2026-08-08-…-ticket-backlog.md` 的八張票都寫著 `Status: Proposed`，spec 抬頭寫著「no implementation is authorized by this document」。實際上這批東西 **v1.53.0（2026-08-09）就全部出貨了**——`src/core/{evidence-pack,evidence-receipt,contracts,impact,data-access,workload-impact}`、五個 command、測試、四語系文件都在，`dbcli evidence compose|validate|render`、`contract`、`impact assess` 都跑得起來。

文件與事實反向，任何依據文件做的判斷都會錯。這個 PR 把帳對回來。

## 逐條核對的結果

30 條驗收條件，實際去讀測試檔核對：

| 狀態 | 數量 |
|---|---|
| 有測試真的斷言 | 11 |
| 沒有被證明（多數是斷言了一半） | 18 |
| 結構上不可能滿足 | 1 |

另有兩條 Scope 承諾同樣不可達。比較刺眼的幾處：`dbcli assert --evidence-receipt` 完全沒有任何指令級測試（EVD-02 四條全部落空）；EVD-01 列了七種 fail-closed 情境，duplicate ID、missing source、oversized input 三種零覆蓋；IMP-02 的 `modify` 操作、`--fail-on error` 分支都沒測。IMP-01 是唯一三條全綠的票，而且實作其實在 `src/core/orm-drift/change-set.ts`，不在票上寫的位置。

## 三個不可滿足的條件

1. **EVD-01 準則 3**（等價輸入產生相同 digest）：digest 涵蓋 `evp_${randomUUID()}` 與毫秒 `createdAt`（`src/core/evidence-pack/index.ts:302-308,357-364`），指令也沒注入固定 id 或時鐘。
2. **EVD-01 Scope 的 expired → coverage gap**：兩個 writer 硬寫空 `gaps`（`:363,399`），parser 拒絕非空（`:380-388`）。
3. **IMP-02 Scope 的 `declared` coverage level**：需要空 gap list（`src/core/impact/index.ts:219`），但 data-access join 必定加一個 gap（`:262-263`），所以恆為 `partial`。

## 變更

- **ADR-0011** — 處置決策：這個子系統沒有使用者（出貨一週，測試以外沒人組過 pack），在有人真的用它之前不投入實作修正。dogfood 觸發點綁在下一次真實的 `verify` / `assert`，期限 2026-09-16，到期未發生則凍結。四個已知缺陷逐條附 file:line，理由寫在裡面——**沒有這份記錄，後人會把 digest 不決定性當成 bug 順手修好**，而那個修動作會破壞既有 pack 相容性，還是花在一個沒人用的子系統上。
- **CONTEXT.md** — 新增 `Known deviation`（刻意不滿足）與 `Unverified`（沒人證明）兩個詞。這兩件事不能混：混了之後 Known deviation 會被稀釋成「所有不完美的東西」。
- **backlog** — 八張票的 Status 改為 Delivered 並列出各自的 known deviation / unverified；每條驗收條件加上 `— covered by:` / `— unverified:` / `— known deviation:` 標注，文字寫明哪半邊有測、哪半邊沒有。
- **spec** — 抬頭那句錯誤的授權聲明換成交付狀態與 ADR-0011 連結。

半覆蓋一律歸 `unverified`。若把 18 條半覆蓋算通過，文件會宣稱 30 條裡 27 條有證明——那是這次要根除的同一種謊，只是換個位置。

## 後續

`scripts/check-plan-acceptance.ts` 會在下一個 PR 進來，強制每條驗收條件都有標注。它的性質是**強制揭露而非強制覆蓋**——擋不住「全部標成 unverified」這種退化，但能擋住「什麼都不寫」。實作時注意標注會跨行，不能用單行 grep 比對。

## Test plan

純文件變更，無程式碼改動。`scripts/` 下沒有任何 guard 讀取 `docs/plans/`、`docs/adr/` 或 `CONTEXT.md`，九步 release gate 不受影響。

引用的每一個測試名稱都經過實際開啟檔案核對，不是從檔名推論——這正是這個 PR 在修的那類錯誤。