### PR TITLE
feat: [ ci ] 驗收條件必須說出自己有沒有被證明

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,4 @@ jobs:
           bun run plugin:check
           bun run docs:check
           bun run contract:check
+          bun run plan:check

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -60,7 +60,7 @@ These tiers mirror `SideEffectTier` in `src/adapters/capabilities.ts` and are us
 
 ## Required CI validation
 
-The release gate is 9 shell steps encoded in `scripts/release-check.sh`. The documentation/skill drift-guards (`skill:check`, `platform:check`, `plugin:check`, `docs:check`, plus the `reference.md` command-coverage test in `bun test`) run in CI on every push/PR via the `docs-parity` job; the full 9-step gate must pass locally via `bun run release:check` before tagging a release:
+The release gate is 9 shell steps encoded in `scripts/release-check.sh`. The documentation/skill drift-guards (`skill:check`, `platform:check`, `plugin:check`, `docs:check`, `contract:check`, `plan:check`, plus the `reference.md` command-coverage test in `bun test`) run in CI on every push/PR via the `docs-parity` job; the full 9-step gate must pass locally via `bun run release:check` before tagging a release:
 
 ```bash
 bun audit                                                              # 1/9

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "platform:check": "bun run scripts/check-platform-parity.ts",
     "agent-core:check": "bun run scripts/check-agent-core-purity.ts",
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
+    "plan:check": "bun run scripts/check-plan-acceptance.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",

--- a/scripts/check-plan-acceptance.ts
+++ b/scripts/check-plan-acceptance.ts
@@ -91,7 +91,12 @@ function readCriteria(lines: readonly string[], start: number): Criterion[] {
  * criterion, in document order.
  */
 export function findPlanAcceptanceViolations(source: string, relativePath: string): string[] {
-  const lines = source.split('\n')
+  // Split on either line ending. A trailing \r is a line terminator to a JS
+  // regex, so `.` will not match it and a non-multiline `$` will not sit before
+  // it: every pattern here anchored with `$` silently fails on a CRLF checkout,
+  // and the gate reports a clean file on Windows while finding violations
+  // everywhere else.
+  const lines = source.split(/\r?\n/)
   const violations: string[] = []
   let ticket = '(no ticket heading)'
 

--- a/scripts/check-plan-acceptance.ts
+++ b/scripts/check-plan-acceptance.ts
@@ -1,0 +1,186 @@
+/**
+ * Gate: every acceptance criterion in docs/plans states whether it is proven.
+ *
+ * The 2026-08-08 evidence backlog was closed and shipped in v1.53.0 while all
+ * eight of its tickets still read `Status: Proposed`, and two of its acceptance
+ * criteria described behavior the code cannot produce. Nothing caught either,
+ * because a plan document is prose and prose drifts silently. This gate makes
+ * the drift loud: each criterion must end with `— covered by:` naming the test
+ * that asserts it, `— unverified:` admitting nothing does, or
+ * `— known deviation:` recording that it is deliberately unmet.
+ *
+ * It enforces disclosure, not coverage. Annotating everything `— unverified:`
+ * passes, and that is the intended trade: a gate that demanded real tests would
+ * be argued down to a rubber stamp, while one that only demands an honest label
+ * survives contact and leaves the count visible in review. The one substantive
+ * check is that a cited test file exists — a fabricated citation is the failure
+ * this gate exists to prevent, and it is the half that can be checked cheaply.
+ * That a cited test actually asserts its criterion is not checkable here.
+ *
+ * PLAN_ACCEPTANCE_EXEMPTIONS is a ratchet, not an amnesty. Every entry is a
+ * plan that predates the convention. The list may shrink and never grow: a
+ * contract test fails if an entry no longer needs its exemption (annotate it,
+ * then delete the line), and this gate fails for any other plan.
+ *
+ * docs/plans/done/ is not scanned. It is an archive of finished work, and
+ * rewriting closed plans to satisfy a later convention would destroy the record
+ * this gate is trying to protect.
+ */
+
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = new URL('../docs/plans/', import.meta.url)
+const rootPath = fileURLToPath(root)
+const repoRoot = fileURLToPath(new URL('../', import.meta.url))
+
+/**
+ * Plans written before acceptance criteria had to declare their evidence.
+ *
+ * File names relative to docs/plans. Only ever remove entries.
+ */
+export const PLAN_ACCEPTANCE_EXEMPTIONS: readonly string[] = [
+  '2026-08-06-semantic-query-draft-ticket-backlog.md',
+]
+
+const MARKERS = ['covered by', 'unverified', 'known deviation'] as const
+
+const ACCEPTANCE_HEADING = /^\*\*Acceptance criteria:\*\*(.*)$/
+const BOLD_FIELD = /^\*\*[^*]+:\*\*/
+const TICKET_HEADING = /^##\s+(\S+)/
+const CRITERION_START = /^(\d+)\.\s+(.*)$/
+const CITED_TEST = /tests\/[A-Za-z0-9_\-./]+\.test\.ts/g
+
+const MISSING_ANNOTATION = MARKERS.map((marker) => `— ${marker}:`).join(' / ')
+
+type Criterion = { number: string; text: string }
+
+/**
+ * Collect the numbered criteria that follow an acceptance heading.
+ *
+ * The section ends at the next bold field, ticket heading, or rule, so a
+ * numbered list elsewhere in the ticket is not mistaken for a criterion.
+ */
+function readCriteria(lines: readonly string[], start: number): Criterion[] {
+  const criteria: Criterion[] = []
+
+  for (let index = start; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (
+      index > start &&
+      (BOLD_FIELD.test(line) || TICKET_HEADING.test(line) || /^---\s*$/.test(line))
+    ) {
+      break
+    }
+
+    const started = CRITERION_START.exec(line)
+    if (started) {
+      criteria.push({ number: started[1] ?? '', text: started[2] ?? '' })
+      continue
+    }
+
+    const current = criteria.at(-1)
+    if (current) current.text = `${current.text} ${line}`
+  }
+
+  return criteria
+}
+
+/**
+ * Report one violation per unannotated, emptily annotated, or unlisted
+ * criterion, in document order.
+ */
+export function findPlanAcceptanceViolations(source: string, relativePath: string): string[] {
+  const lines = source.split('\n')
+  const violations: string[] = []
+  let ticket = '(no ticket heading)'
+
+  for (const [index, line] of lines.entries()) {
+    const heading = TICKET_HEADING.exec(line)
+    if (heading) {
+      ticket = heading[1] ?? ticket
+      continue
+    }
+
+    const acceptance = ACCEPTANCE_HEADING.exec(line)
+    if (!acceptance) continue
+
+    const criteria = readCriteria(lines, index + 1)
+    if (criteria.length === 0) {
+      violations.push(
+        `${relativePath}: ${ticket} states acceptance criteria without a numbered list`
+      )
+      continue
+    }
+
+    for (const criterion of criteria) {
+      // The annotation is prose inside a wrapped list item, so its marker is
+      // routinely split by a line break. Compare on collapsed whitespace.
+      const normalized = criterion.text.replace(/\s+/g, ' ').trim()
+      const marker = MARKERS.find((candidate) => normalized.includes(`— ${candidate}:`))
+
+      if (!marker) {
+        violations.push(
+          `${relativePath}: ${ticket} criterion ${criterion.number} carries no ${MISSING_ANNOTATION} annotation`
+        )
+        continue
+      }
+
+      const said = normalized
+        .slice(normalized.indexOf(`— ${marker}:`) + `— ${marker}:`.length)
+        .trim()
+      if (said.length === 0) {
+        violations.push(
+          `${relativePath}: ${ticket} criterion ${criterion.number} has an empty — ${marker}: annotation`
+        )
+      }
+    }
+  }
+
+  return violations
+}
+
+/**
+ * Every test path cited anywhere in a plan, sorted and deduplicated.
+ */
+export function findCitedTestPaths(source: string): string[] {
+  return [...new Set(source.match(CITED_TEST) ?? [])].sort()
+}
+
+/**
+ * Scan docs/plans, skipping the exemption list and the done/ archive.
+ */
+export async function collectPlanAcceptanceViolations(): Promise<string[]> {
+  const exempt = new Set(PLAN_ACCEPTANCE_EXEMPTIONS)
+  const violations: string[] = []
+
+  for await (const scanned of new Bun.Glob('*.md').scan({ cwd: rootPath })) {
+    const name = scanned.replaceAll('\\', '/')
+    if (exempt.has(name)) continue
+
+    const source = await Bun.file(join(rootPath, name)).text()
+    violations.push(...findPlanAcceptanceViolations(source, name))
+
+    for (const cited of findCitedTestPaths(source)) {
+      if (!(await Bun.file(join(repoRoot, cited)).exists())) {
+        violations.push(`${name}: cites ${cited}, which does not exist`)
+      }
+    }
+  }
+
+  return violations.sort()
+}
+
+if (import.meta.main) {
+  const violations = await collectPlanAcceptanceViolations()
+
+  if (violations.length > 0) {
+    console.error(
+      `plan acceptance check failed:\n${violations.map((item) => `- ${item}`).join('\n')}\n\n` +
+        `Every acceptance criterion ends with ${MISSING_ANNOTATION} — say which, even when the answer is that nothing proves it.`
+    )
+    process.exit(1)
+  }
+
+  console.log('plan acceptance check passed')
+}

--- a/tests/contract/plan-acceptance.test.ts
+++ b/tests/contract/plan-acceptance.test.ts
@@ -44,6 +44,17 @@ describe('plan acceptance annotation gate', () => {
     expect(findPlanAcceptanceViolations(section(criterion), 'plan.md')).toEqual([])
   })
 
+  // A CRLF checkout leaves \r at every line end. That is a line terminator to a
+  // JS regex, so patterns anchored with `$` stop matching and the gate reports a
+  // clean file — which is how it passed on macOS and Linux while finding nothing
+  // at all on Windows.
+  test('reads a file checked out with CRLF line endings', () => {
+    const source = section('1. It works.').replaceAll('\n', '\r\n')
+    expect(findPlanAcceptanceViolations(source, 'plan.md')).toEqual([
+      'plan.md: TCK-01 criterion 1 carries no — covered by: / — unverified: / — known deviation: annotation',
+    ])
+  })
+
   test('rejects an annotation with no text after the marker', () => {
     expect(findPlanAcceptanceViolations(section('1. It works. — unverified:'), 'plan.md')).toEqual([
       'plan.md: TCK-01 criterion 1 has an empty — unverified: annotation',

--- a/tests/contract/plan-acceptance.test.ts
+++ b/tests/contract/plan-acceptance.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  PLAN_ACCEPTANCE_EXEMPTIONS,
+  collectPlanAcceptanceViolations,
+  findCitedTestPaths,
+  findPlanAcceptanceViolations,
+} from '../../scripts/check-plan-acceptance'
+
+const section = (...criteria: string[]): string =>
+  [
+    '## TCK-01 — A ticket',
+    '',
+    '**Acceptance criteria:**',
+    '',
+    ...criteria,
+    '',
+    '**Verification:** `bun test`',
+  ].join('\n')
+
+describe('plan acceptance annotation gate', () => {
+  test.each([
+    ['covered by', '1. It works. — covered by: `tests/unit/thing.test.ts` (`works`).'],
+    ['unverified', '1. It works. — unverified: nothing asserts the failure path.'],
+    ['known deviation', '1. It works. — known deviation: unreachable, see index.ts:12.'],
+  ])('accepts a criterion annotated with %s', (_label, criterion) => {
+    expect(findPlanAcceptanceViolations(section(criterion), 'plan.md')).toEqual([])
+  })
+
+  test('rejects a criterion with no annotation', () => {
+    expect(findPlanAcceptanceViolations(section('1. It works.'), 'plan.md')).toEqual([
+      'plan.md: TCK-01 criterion 1 carries no — covered by: / — unverified: / — known deviation: annotation',
+    ])
+  })
+
+  // The annotation is prose inside a wrapped Markdown list, so the marker is
+  // routinely split across a line break. A line-oriented gate would report
+  // every wrapped annotation as missing, which is the failure mode that would
+  // get this gate switched off within a week.
+  test('accepts an annotation whose marker wraps across lines', () => {
+    const criterion = [
+      '1. It works and the sentence runs long enough to wrap. —',
+      '   covered by: `tests/unit/thing.test.ts`.',
+    ].join('\n')
+    expect(findPlanAcceptanceViolations(section(criterion), 'plan.md')).toEqual([])
+  })
+
+  test('rejects an annotation with no text after the marker', () => {
+    expect(findPlanAcceptanceViolations(section('1. It works. — unverified:'), 'plan.md')).toEqual([
+      'plan.md: TCK-01 criterion 1 has an empty — unverified: annotation',
+    ])
+  })
+
+  test('reports each unannotated criterion separately', () => {
+    const source = section(
+      '1. First thing.',
+      '2. Second thing. — unverified: no test.',
+      '3. Third thing.'
+    )
+    expect(findPlanAcceptanceViolations(source, 'plan.md')).toEqual([
+      'plan.md: TCK-01 criterion 1 carries no — covered by: / — unverified: / — known deviation: annotation',
+      'plan.md: TCK-01 criterion 3 carries no — covered by: / — unverified: / — known deviation: annotation',
+    ])
+  })
+
+  // Without this rule the gate is escapable by reformatting: prose acceptance
+  // criteria yield no numbered items and would pass while asserting nothing.
+  test('rejects an acceptance section written as prose instead of numbered criteria', () => {
+    const source = [
+      '## TCK-01 — A ticket',
+      '',
+      '**Acceptance criteria:** It works offline.',
+      '',
+      '---',
+    ].join('\n')
+    expect(findPlanAcceptanceViolations(source, 'plan.md')).toEqual([
+      'plan.md: TCK-01 states acceptance criteria without a numbered list',
+    ])
+  })
+
+  test('reads criteria per ticket rather than per file', () => {
+    const source = [
+      section('1. First. — unverified: no test.'),
+      '',
+      '---',
+      '',
+      section('1. Second.'),
+    ].join('\n')
+    expect(findPlanAcceptanceViolations(source, 'plan.md')).toHaveLength(1)
+  })
+
+  test('stops reading criteria at the next bold field', () => {
+    const source = [
+      '## TCK-01 — A ticket',
+      '',
+      '**Acceptance criteria:**',
+      '',
+      '1. It works. — unverified: no test.',
+      '',
+      '**Verification:** Focused tests, then the release gate.',
+      '',
+      '1. Not a criterion.',
+    ].join('\n')
+    expect(findPlanAcceptanceViolations(source, 'plan.md')).toEqual([])
+  })
+
+  test('collects every cited test path, including several in one annotation', () => {
+    const source = section(
+      '1. It works. — covered by: `tests/unit/a.test.ts` and `tests/integration/b.test.ts`.',
+      '2. It also works. — unverified: partly `tests/unit/c.test.ts`.'
+    )
+    expect(findCitedTestPaths(source)).toEqual([
+      'tests/integration/b.test.ts',
+      'tests/unit/a.test.ts',
+      'tests/unit/c.test.ts',
+    ])
+  })
+
+  test('the exemption list only shrinks: every entry still needs the exemption', async () => {
+    const stale: string[] = []
+    for (const name of PLAN_ACCEPTANCE_EXEMPTIONS) {
+      const source = await Bun.file(new URL(`../../docs/plans/${name}`, import.meta.url)).text()
+      if (findPlanAcceptanceViolations(source, name).length === 0) stale.push(name)
+    }
+    expect(stale).toEqual([])
+  })
+
+  test('docs/plans has no violations outside the exemption list', async () => {
+    expect(await collectPlanAcceptanceViolations()).toEqual([])
+  })
+})


### PR DESCRIPTION
> 疊在 #112 之上（base 設為 `docs/evidence-subsystem-disposition`）。#112 合併後 GitHub 會自動改指向 main。這支 gate 需要 #112 的標注才會綠。

## 為什麼

2026-08-08 那份 backlog 的八張票結案並隨 v1.53.0 出貨，票上卻還寫著 `Status: Proposed`，其中兩條驗收條件描述的是程式碼結構上做不出來的行為。兩件事都沒有被任何機制攔下來，因為計畫文件是散文，而散文會靜默漂移——要靠人定期盤點才會發現，而盤點本身也會盤錯。

`scripts/check-plan-acceptance.ts` 讓這種漂移變吵。`docs/plans/*.md` 每條驗收條件必須以三者之一結尾：

| 標注 | 意思 |
|---|---|
| `— covered by:` | 指名斷言它的測試 |
| `— unverified:` | 承認沒有東西證明它 |
| `— known deviation:` | 刻意不滿足，附原因 |

## 刻意的取捨

**強制揭露，不強制覆蓋。** 全部標成 `unverified` 也會通過。這是有意的：要求真實測試的 gate 會被吵到變成橡皮圖章，只要求誠實標籤的 gate 活得下來，而數量留在 review 裡看得見（目前這份 backlog 是 30 條裡 18 條 unverified，這個數字本身就是壓力）。

**唯一實質檢查是被引用的測試檔要存在。** 捏造引用正是這支 gate 要防的失敗模式，也是唯一便宜可查的那一半。引用的測試是否真的斷言了該條件，這裡查不到，doc comment 有寫明。

**標注會被 Markdown 換行拆開**，所以比對前先收斂空白。逐行比對會把每個換行的標注都報成缺漏——那種 gate 一週內就會被關掉。

**散文式驗收條件（沒有編號清單）本身算違規**，否則改個格式就能繞過整支 gate。

**`docs/plans/done/` 不掃。** 那是已完成工作的檔案；為了迎合後來的慣例去改寫已結案的計畫，會毀掉這支 gate 想保護的那份紀錄。

`PLAN_ACCEPTANCE_EXEMPTIONS` 是 ratchet 而非特赦，形狀照抄 `check-core-no-stdout.ts`：目前只有 2026-08-06 那份早於慣例的 backlog，清單只能變短，contract test 會在某個例外不再需要時失敗。

## 變更

`scripts/check-plan-acceptance.ts`（新增）、`tests/contract/plan-acceptance.test.ts`（新增，13 個測試）、`package.json` 加 `plan:check`、`.github/workflows/ci.yml` 掛進 `docs-parity` job、`docs/feature-matrix.md` 補上 `plan:check` 與先前漏列的 `contract:check`。

## Test plan

測試先寫、確認 RED（模組不存在）再實作。

- `bun test tests/contract/plan-acceptance.test.ts` — 13 pass。涵蓋三種標注各自被接受、缺標注被拒、空標注被拒、跨行標注被接受、多條各自回報、散文式被拒、以 ticket 為單位、遇到下一個粗體欄位停止、引用路徑收集，以及兩個實檔檢查（例外清單仍必要、`docs/plans` 無違規）
- `bun run plan:check` — passed
- `bun test` — 5508 pass / 27 skip / 0 fail（510 檔）
- `bun run typecheck`、`bun run lint`、`bunx prettier --check` — 皆乾淨