### PR TITLE
refactor: [ core ] 拆開 evidence 底下三套不能互換的結果詞彙

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,3 +94,23 @@ coverage rather than claiming to find every application dependency.
 **Coverage gap**:
 An explicit statement that an impact assessment lacks a source needed to rule
 out an effect. It is a warning, never a clean result.
+
+## Outcome vocabularies
+
+Three vocabularies describe how something turned out. They are not
+interchangeable, and none of them may be mapped onto another.
+
+**Verification status**:
+The verdict a verification artifact records about its subject — `verified`,
+`not_verified`, `indeterminate`, or `blocked`. Alone among the three it is a
+judgment about the database, and it is part of a published JSON contract.
+
+**Report finding**:
+How one diagnostic snippet in a report snapshot turned out — `ok`, `no-data`,
+`skipped`, `error`, or `timeout`. It says whether a diagnostic ran, not whether
+anything was verified.
+
+**Workload source**:
+Whether an explicit proxy event file offered to an impact assessment could be
+used — `available`, `absent`, `invalid`, or `unavailable`. It describes the
+source, not a finding about the database, and it is always advisory.

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -33,7 +33,7 @@ import { loadOrmSchema, parseAgainstOrmValues } from '@/commands/diff'
 import { listSnippetKeys } from '@/core/saved-queries/loader'
 import { resolveSnippetDirs } from '@/core/saved-queries/snippet-paths'
 import { readVerificationArtifacts } from '@/core/verification/reader'
-import { loadWorkloadEvidence, type WorkloadEvidence } from '@/core/workload-impact'
+import { loadWorkloadSource, type WorkloadSource } from '@/core/workload-impact'
 import { formatImpact, type ImpactFormat } from '@/formatters/impact'
 import { resolveConfigPath } from '@/utils/config-path'
 
@@ -145,7 +145,7 @@ impactCommand
         blockedIdentifiers
       )
       const verifications = await loadVerificationEvidence(workspaceRoot, blockedIdentifiers)
-      const observedWorkload = await loadObservedWorkloadEvidence(
+      const observedWorkload = await loadObservedWorkloadSource(
         options.events as string | undefined,
         workspaceRoot,
         blockedIdentifiers
@@ -401,11 +401,11 @@ function semanticSchema(
   return result
 }
 
-async function loadObservedWorkloadEvidence(
+async function loadObservedWorkloadSource(
   path: string | undefined,
   workspaceRoot: string,
   blocked: readonly string[]
-): Promise<WorkloadEvidence> {
+): Promise<WorkloadSource> {
   if (path === undefined) {
     return {
       state: 'absent',
@@ -415,7 +415,7 @@ async function loadObservedWorkloadEvidence(
       issues: [],
     }
   }
-  return loadWorkloadEvidence({ path: resolve(workspaceRoot, path), blockedIdentifiers: blocked })
+  return loadWorkloadSource({ path: resolve(workspaceRoot, path), blockedIdentifiers: blocked })
 }
 
 export function shouldFail(

--- a/src/core/audit/lock.ts
+++ b/src/core/audit/lock.ts
@@ -1,7 +1,7 @@
 /**
  * AuditLockManager - short-budget file lock for audit writes.
  *
- * Decisions (see .planning/phases/21-audit-writer-foundation/21-CONTEXT.md):
+ * Decisions (the record they pointed to is gone; they are the record now):
  * - D-05: NOT a reuse of ConcurrentLockManager; tunings differ.
  * - D-06: one lock per audit file (`<auditFilePath>.lock`).
  * - D-07: total retry budget ~200ms; on exhaustion RETURN false (do NOT throw).

--- a/src/core/audit/logger.ts
+++ b/src/core/audit/logger.ts
@@ -1,7 +1,7 @@
 /**
  * AuditLogger — append-only JSONL writer with rotation + fail-soft semantics.
  *
- * Decisions implemented (see 21-CONTEXT.md):
+ * Decisions implemented (the record they pointed to is gone; they are the record now):
  * - D-01: lives under src/core/audit/
  * - D-02: class instance, one per process; stateful (counters, sticky lastError)
  * - D-03: async write(); awaited by callers (engines in Phase 23)

--- a/src/core/audit/rotation.ts
+++ b/src/core/audit/rotation.ts
@@ -4,7 +4,7 @@
  * The implementation is the shared, feature-neutral JSONL rotation utility in
  * `src/utils/jsonl-rotation.ts` (also used by the observability proxy). This
  * module re-exports it to preserve the audit-local import surface and the
- * decisions recorded in 21-CONTEXT.md:
+ * decisions recorded here:
  * - D-08: Single OS-level rename; no flush-to-disk syscall, no tmp+rename for the .jsonl itself.
  * - D-09: Rename current -> .1, overwriting any existing .1.
  * - D-10: Keep exactly one rolling segment.

--- a/src/core/audit/session-id.ts
+++ b/src/core/audit/session-id.ts
@@ -1,7 +1,7 @@
 /**
  * SessionIdService — resolves and persists the per-process audit session id.
  *
- * Decisions (see .planning/phases/21-audit-writer-foundation/21-CONTEXT.md):
+ * Decisions (the record they pointed to is gone; they are the record now):
  * - D-02: the DBCLI session-id env wins; otherwise `<pid>-<unix-ts-ms>-<6charHex>`.
  * - D-04: independent module (not embedded in AuditLogger); constructor-injected.
  * - D-13: persisted JSON includes pid; mismatch -> regenerate. No POSIX signal

--- a/src/core/impact/index.ts
+++ b/src/core/impact/index.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/core/orm-drift/change-set'
 import type { VerificationStatus, VerificationSubject } from '@/core/verification/types'
 import type { DataAccessOperation } from '@/core/data-access'
-import type { WorkloadEvidence } from '@/core/workload-impact'
+import type { WorkloadSource } from '@/core/workload-impact'
 
 export type ImpactEvidenceState = 'available' | 'absent' | 'invalid' | 'unavailable'
 export type ImpactEvidenceReason = 'missing' | 'invalid' | 'unavailable'
@@ -38,7 +38,7 @@ export interface ImpactAssessmentInput {
   savedQueries: ImpactEvidenceSource<readonly string[]>
   verifications: ImpactEvidenceSource<readonly SafeVerificationMetadata[]>
   dataAccess: ImpactEvidenceSource<readonly DataAccessOperation[]>
-  observedWorkload: WorkloadEvidence
+  observedWorkload: WorkloadSource
   blockedIdentifiers: readonly string[]
 }
 
@@ -111,10 +111,10 @@ export interface ImpactReport {
   coverage: { level: 'declared' | 'partial'; gaps: ImpactCoverageGap[] }
   summary: { errors: number; warns: number; infos: number }
   observedWorkload: {
-    state: WorkloadEvidence['state']
+    state: WorkloadSource['state']
     tableReferenceCount: number
     malformedLines: number
-    timeframe?: WorkloadEvidence['timeframe']
+    timeframe?: WorkloadSource['timeframe']
   }
 }
 
@@ -512,7 +512,7 @@ function dataAccessFindings(
 
 function observedWorkloadFindings(
   change: NormalizedChange,
-  workload: WorkloadEvidence,
+  workload: WorkloadSource,
   blocked: readonly string[]
 ): ImpactFinding[] {
   if (workload.state !== 'available') return []

--- a/src/core/report/collector.ts
+++ b/src/core/report/collector.ts
@@ -21,7 +21,7 @@ import {
   type ReportSectionId,
   type ReportSnapshot,
   type ReportWarning,
-  type EvidenceItem,
+  type ReportFinding,
 } from './types'
 
 const DEFAULT_PER_SNIPPET_TIMEOUT_MS = 3000
@@ -90,7 +90,7 @@ export async function collectReport(opts: ReportOptions): Promise<ReportSnapshot
   // user-writable directories, so the blacklist has to reach this path.
   const blacklistValidator = new BlacklistValidator(new BlacklistManager(config))
 
-  const sectionEvidence = new Map<ReportSectionId, EvidenceItem[]>()
+  const sectionEvidence = new Map<ReportSectionId, ReportFinding[]>()
   for (const id of sections) sectionEvidence.set(id, [])
 
   try {

--- a/src/core/report/render-markdown.ts
+++ b/src/core/report/render-markdown.ts
@@ -1,4 +1,4 @@
-import type { EvidenceItem, ReportSnapshot } from './types'
+import type { ReportFinding, ReportSnapshot } from './types'
 import type { RenderOptions } from './render-json'
 
 const MAX_ROWS_IN_MD = 10
@@ -64,7 +64,7 @@ export function renderMarkdown(snap: ReportSnapshot, options: RenderOptions = {}
   return lines.join('\n')
 }
 
-function renderRowTable(ev: EvidenceItem): string[] {
+function renderRowTable(ev: ReportFinding): string[] {
   const rows = ev.rows.slice(0, MAX_ROWS_IN_MD)
   const cols = Array.from(
     rows.reduce((set, r) => {

--- a/src/core/report/run-diagnostic.ts
+++ b/src/core/report/run-diagnostic.ts
@@ -16,7 +16,7 @@ const ENGINE_DIALECT: Record<string, SqlTablesDialect | undefined> = {
 }
 import type { BlacklistValidator } from '@/core/blacklist-validator'
 import { BlacklistError } from '@/types/blacklist'
-import type { EvidenceItem } from './types'
+import type { ReportFinding } from './types'
 
 export interface RunDiagnosticInput {
   snippet: ResolvedSnippet
@@ -33,13 +33,13 @@ export interface RunDiagnosticInput {
 }
 
 /**
- * Runs a single snippet and always returns an EvidenceItem — never throws.
+ * Runs a single snippet and always returns an ReportFinding — never throws.
  * Statuses: ok / no-data / skipped (engine mismatch, prepare error) / error /
  * timeout. Rows are truncated to `maxRows`; `rowCount` reports the true count.
  */
-export async function runDiagnostic(input: RunDiagnosticInput): Promise<EvidenceItem> {
+export async function runDiagnostic(input: RunDiagnosticInput): Promise<ReportFinding> {
   const meta = input.snippet.query.meta
-  const base: Pick<EvidenceItem, 'snippet' | 'intent' | 'description'> = {
+  const base: Pick<ReportFinding, 'snippet' | 'intent' | 'description'> = {
     snippet: meta.key,
     intent: meta.intent ?? '',
     description: meta.description ?? '',

--- a/src/core/report/types.ts
+++ b/src/core/report/types.ts
@@ -10,7 +10,7 @@ export type EvidenceStatus = 'ok' | 'no-data' | 'skipped' | 'error' | 'timeout'
 
 export type Severity = 'info' | 'warn' | 'error'
 
-export interface EvidenceItem {
+export interface ReportFinding {
   /** Snippet key, e.g. `@diag/db-size`. */
   snippet: string
   /** Snippet `intent` taxonomy slot, e.g. `capacity.size`. */
@@ -29,7 +29,7 @@ export interface EvidenceItem {
 
 export interface ReportSection {
   id: ReportSectionId
-  evidence: EvidenceItem[]
+  evidence: ReportFinding[]
 }
 
 export interface ReportWarning {

--- a/src/core/workload-impact/index.ts
+++ b/src/core/workload-impact/index.ts
@@ -8,7 +8,7 @@ const MAX_EVENT_LOG_BYTES = 2 * 1024 * 1024
 const MAX_EVENT_LINES = 10_000
 const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
-export type WorkloadEvidenceState = 'available' | 'absent' | 'invalid' | 'unavailable'
+export type WorkloadSourceState = 'available' | 'absent' | 'invalid' | 'unavailable'
 export type WorkloadIssue =
   | 'malformed'
   | 'stale'
@@ -24,8 +24,8 @@ export interface WorkloadTimeframe {
   to: string
 }
 
-export interface WorkloadEvidence {
-  state: WorkloadEvidenceState
+export interface WorkloadSource {
+  state: WorkloadSourceState
   /** A logical origin only. The supplied path is never retained. */
   origin: 'proxy-workload'
   observations: readonly ObservedWorkload[]
@@ -34,7 +34,7 @@ export interface WorkloadEvidence {
   timeframe?: WorkloadTimeframe
 }
 
-export interface LoadWorkloadEvidenceOptions {
+export interface LoadWorkloadSourceOptions {
   path: string
   blockedIdentifiers: readonly string[]
   now?: Date
@@ -45,9 +45,9 @@ export interface LoadWorkloadEvidenceOptions {
  * workload evidence. It deliberately never delegates to the general event
  * reader because that reader retains unbounded event bodies for QueryLens.
  */
-export async function loadWorkloadEvidence(
-  options: LoadWorkloadEvidenceOptions
-): Promise<WorkloadEvidence> {
+export async function loadWorkloadSource(
+  options: LoadWorkloadSourceOptions
+): Promise<WorkloadSource> {
   const now = options.now ?? new Date()
   let info: Awaited<ReturnType<typeof lstat>>
   try {
@@ -142,7 +142,7 @@ export async function loadWorkloadEvidence(
   }
 }
 
-function sourceFailure(state: Exclude<WorkloadEvidenceState, 'available'>): WorkloadEvidence {
+function sourceFailure(state: Exclude<WorkloadSourceState, 'available'>): WorkloadSource {
   return { state, origin: 'proxy-workload', observations: [], malformedLines: 0, issues: [] }
 }
 

--- a/tests/unit/core/audit/session-id.test.ts
+++ b/tests/unit/core/audit/session-id.test.ts
@@ -4,8 +4,8 @@
  * Covers AUDIT-02 (env-first + `<pid>-<unix-ts-ms>-<6charHex>` fallback) and
  * AUDIT-03 (in-process cache reuse + `.dbcli/last-session-id` persistence).
  *
- * Tests 1–7 correspond exactly to the seven behavior cases defined in
- * `.planning/phases/21-audit-writer-foundation/21-02-session-id-service-PLAN.md`.
+ * Tests 1–7 were written against seven behavior cases in a plan document that
+ * no longer exists; the cases survive only as these tests.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'

--- a/tests/unit/core/workload-impact/workload-impact.test.ts
+++ b/tests/unit/core/workload-impact/workload-impact.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { loadWorkloadEvidence } from '@/core/workload-impact'
+import { loadWorkloadSource } from '@/core/workload-impact'
 
 const now = new Date('2026-08-08T12:00:00.000Z')
 
@@ -25,7 +25,7 @@ function event(overrides: Record<string, unknown> = {}): Record<string, unknown>
   }
 }
 
-describe('loadWorkloadEvidence', () => {
+describe('loadWorkloadSource', () => {
   let workspace = ''
 
   beforeEach(async () => {
@@ -43,7 +43,7 @@ describe('loadWorkloadEvidence', () => {
       `${JSON.stringify(event({ type: 'query_errored', error: { message: 'private-error', code: 'x' } }))}\n`
     )
 
-    const evidence = await loadWorkloadEvidence({ path, blockedIdentifiers: [], now })
+    const evidence = await loadWorkloadSource({ path, blockedIdentifiers: [], now })
 
     expect(evidence).toMatchObject({
       state: 'available',
@@ -67,7 +67,7 @@ describe('loadWorkloadEvidence', () => {
   })
 
   test('makes missing, malformed, stale, and protected input non-clean without retaining source content', async () => {
-    const missing = await loadWorkloadEvidence({
+    const missing = await loadWorkloadSource({
       path: join(workspace, 'missing.jsonl'),
       blockedIdentifiers: [],
       now,
@@ -84,7 +84,7 @@ describe('loadWorkloadEvidence', () => {
         JSON.stringify(event({ tables: ['not a canonical table'] })),
       ].join('\n')
     )
-    const evidence = await loadWorkloadEvidence({
+    const evidence = await loadWorkloadSource({
       path,
       blockedIdentifiers: ['restricted_accounts'],
       now,
@@ -112,7 +112,7 @@ describe('loadWorkloadEvidence', () => {
       ].join('\n')
     )
 
-    const evidence = await loadWorkloadEvidence({ path, blockedIdentifiers: [], now })
+    const evidence = await loadWorkloadSource({ path, blockedIdentifiers: [], now })
 
     expect(evidence.observations).toEqual([{ tables: ['accounts'] }])
     expect(evidence.malformedLines).toBe(0)
@@ -126,7 +126,7 @@ describe('loadWorkloadEvidence', () => {
       `${JSON.stringify(event({ tables: ['accounts', 'restricted_accounts'] }))}\n`
     )
 
-    const evidence = await loadWorkloadEvidence({
+    const evidence = await loadWorkloadSource({
       path,
       blockedIdentifiers: ['restricted_accounts'],
       now,
@@ -141,7 +141,7 @@ describe('loadWorkloadEvidence', () => {
     const path = join(workspace, 'events.jsonl')
     await writeFile(path, `${JSON.stringify(event({ timestamp: '2026-07-01T11:00:00.000Z' }))}\n`)
 
-    const evidence = await loadWorkloadEvidence({ path, blockedIdentifiers: [], now })
+    const evidence = await loadWorkloadSource({ path, blockedIdentifiers: [], now })
 
     expect(evidence.observations).toEqual([])
     expect(evidence.issues).toEqual(['stale'])
@@ -151,7 +151,7 @@ describe('loadWorkloadEvidence', () => {
     const path = join(workspace, 'events.jsonl')
     await writeFile(path, 'x'.repeat(2 * 1024 * 1024 + 1))
 
-    const evidence = await loadWorkloadEvidence({ path, blockedIdentifiers: [], now })
+    const evidence = await loadWorkloadSource({ path, blockedIdentifiers: [], now })
 
     expect(evidence).toEqual({
       state: 'invalid',


### PR DESCRIPTION
## 問題

專案裡有三套描述「結果如何」的詞彙，全都掛在 `evidence` 這個字下面：

| 型別 | 值域 | 實際在講 |
|---|---|---|
| `VerificationStatus` | `verified` / `not_verified` / `indeterminate` / `blocked` | 對驗證主體下的判決 |
| `EvidenceItem.status` | `ok` / `no-data` / `skipped` / `error` / `timeout` | 某段診斷有沒有跑完 |
| `WorkloadEvidence.state` | `available` / `absent` / `invalid` / `unavailable` | 來源檔能不能用 |

三者互不相容，名字卻讓它們看起來是同一族。讀程式碼的人有機會把其中一套的判斷寫到另一套上，而型別系統擋不住——它們都是字串聯集，只是值不同。

## 沒有做的事

**沒有把三套值統一。** 它們是三件不同的事：一個是對資料庫下的判決，一個是某段診斷的執行結果，一個是來源可得性。強行統一會把三件事壓成一件，比現在更糟。

**沒有動 `VerificationStatus`。** 它是已發布 JSON 契約的一部分。

## 做的事

改名，只改識別字：

- `EvidenceItem` → `ReportFinding`
- `WorkloadEvidence` → `WorkloadSource`（連帶 `WorkloadEvidenceState`、`LoadWorkloadEvidenceOptions`、`loadWorkloadEvidence`，以及命令層的 `loadObservedWorkloadEvidence`）

`CONTEXT.md` 新增「Outcome vocabularies」一節，把三套詞彙並排定義並寫明不可互相映射。只寫進 CONTEXT.md 是不夠的——讀程式碼的人不會去讀 CONTEXT.md，改名才會在使用現場擋住誤用。

順帶清掉 `src/core/audit/{lock,session-id,logger,rotation}.ts` 與 `tests/unit/core/audit/session-id.test.ts` 裡指向已刪除 `.planning/` 目錄的失效指標。D-01..D-11 那些決策內容留著並改寫措辭——它們現在就是紀錄本身，不再是別處紀錄的摘要。

## 兩個安全性確認

**ADR-0011 不受影響。** 它的 falsified-if 點名了 `src/core/workload-impact/index.ts` 與 `src/core/impact/index.ts`，條件是「行為性變更」。這個 PR 只改識別字，沒有動任何 JSON 欄位、輸出形狀或控制流程——`observedWorkload`、`state`、`evidence` 這些資料欄位一字未改。

**不是破壞性變更。** 兩個型別都不在 `src/core/public.ts` 或 `src/agent-core/public.ts` 的公開介面上（已 grep 確認），`package.json` 的 `./core` 與 `./agent-core` 匯出不含它們。

## Test plan

- `bun test` — 5509 pass / 27 skip / 0 fail（510 檔）
- `bun run typecheck`、`bun run lint`、`bunx prettier --check` — 皆乾淨
- 改名前先確認過沒有字串字面值或 JSON 鍵含這兩個名字，所以純識別字替換不會漏改或誤改