### PR TITLE
fix: [ assert ] pg 的 bigint 是字串，value == count 永遠不成立

### DIFF
--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
+++ b/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
@@ -1,7 +1,7 @@
 ---
 status: accepted
 date: 2026-08-16
-review_by: 2026-09-16
+dogfooded: 2026-08-16
 ---
 
 # The evidence subsystem waits for a user before it is repaired
@@ -25,6 +25,44 @@ The trigger is deliberately attached to work that already happens: the next time
 from it and read the result. If that has not happened by **2026-09-16**, the
 subsystem is frozen — marked experimental in the user documentation, removed
 from the recommended workflow, and given no further investment.
+
+## The trigger fired on 2026-08-16
+
+`dbcli verify safe-backfill --after-write` ran against a PostgreSQL instance
+after an externally applied backfill, wrote a verification artifact and an
+evidence receipt, and `dbcli evidence compose` built a pack from both.
+`validate` reported `integrity: valid, references: valid, expired: []` and the
+Markdown render was read. **The freeze does not happen.** Repair of the
+deviations below is authorized from here, so each one now needs a reason to be
+worth doing rather than a reason to wait.
+
+The workflow held end to end. Claims rendered as
+`External claim — not a dbcli verification verdict.`, the receipt's `command`
+was redacted to `--table <redacted> --query <redacted>`, and no SQL or row
+reached either artifact.
+
+## What the first real use found
+
+The first run reported `not_verified` on data that was correct. Two assertions
+were tried and both failed for reasons unrelated to the database:
+
+- `rows == 0` counts rows in the result set. Against
+  `SELECT count(*) AS rows …` it reads as a column reference and is neither —
+  legal syntax, different meaning.
+- `value == 0` compared a PostgreSQL `bigint`, which arrives as a JavaScript
+  string, against a number under `===`. Every `value == <count>` assertion
+  failed on PostgreSQL, and because ordering operators coerce, `value > 5`
+  worked while `value == 6` did not. Fixed in `src/core/assert/evaluator.ts`;
+  the same command now reports `verified` against the same data.
+
+None of the four known deviations below was reached by this run, so none is
+repaired and none has yet cost anything. The finding that mattered was in the
+verification path, not the evidence path.
+
+The pack itself was honest but thin: every useful sentence in it was one a human
+wrote. The generated half recorded `not_verified` without recording why, and
+"why" was the only thing worth reading. That is the gap worth closing if this
+subsystem gets more investment.
 
 ## Known deviations
 
@@ -64,23 +102,24 @@ a subsystem whose acceptance criteria finally hold and that still has no users.
 The code is written, tested, and published. Deleting it costs a major version
 bump and breaks an API surface whose consumers we cannot enumerate, and buys
 back only maintenance we are choosing not to spend. Freezing achieves the same
-saving without the breaking change, which is why the 2026-09-16 fallback is a
-freeze rather than a removal.
+saving without the breaking change, which is why the fallback was a freeze
+rather than a removal. The trigger fired first, so neither was needed.
 
 ## Consequences
 
-- A reader who finds these defects should not fix them; this record is the
-  reason they are still there.
+- A reader who finds these defects should not assume they are undiscovered;
+  this record is the reason they are still there. Repairing one is now allowed,
+  but it should carry a use that reached it.
 - The affected tickets in
   `docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md`
-  are marked delivered with named known deviations rather than completed.
-- Repair work becomes authorized by evidence of use, not by the defect list.
-- The freeze path, if taken, changes documentation and recommendation only. It
-  removes no command and breaks no published interface.
+  are marked delivered with named known deviations rather than completed. A
+  repair updates that annotation in the same change.
+- The freeze path is spent and will not be taken.
+- What the first use actually proved is narrow: the workflow runs and the
+  output is safe. It did not prove anyone wants the output.
 
-**Falsified if:** `src/core/evidence-pack/index.ts`,
-`src/core/evidence-receipt/index.ts`, `src/core/contracts/index.ts`,
-`src/core/impact/index.ts`, `src/core/data-access/index.ts`, or
-`src/core/workload-impact/index.ts` gains a behavioral change before a real
-evidence pack has been composed and read, or 2026-09-16 passes with neither
-that record nor the freeze.
+**Falsified if:** a deviation listed above is repaired while
+`docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md`
+still annotates it as a known deviation, or `src/core/evidence-pack/index.ts`
+stops hard-coding `gaps: []` without that annotation being removed in the same
+change.

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -492,7 +492,7 @@ dbcli diff --against-orm prisma/schema.prisma --recovery --format json</code></p
                 <li>Status follows assertion truth: <code>--no-fail</code> failures still record <code>not_verified</code> / evidence <code>exitCode: 1</code>.</li>
             </ul>
             <p class="mt-4 mb-4"><strong>Planned vs Result evidence.</strong> <code>dbcli skill tasks plan safe-backfill-verify</code> produces a plan JSON with a <code>verification</code> block whose <code>status</code> is <code>"planned"</code> — this is the <strong>planned</strong> evidence definition describing which check will run. The final <code>assert --write-verification-artifact</code> step produces <strong>result</strong> evidence (<code>status: verified</code> or <code>not_verified</code>). These are two different records; <code>"planned"</code> does <strong>not</strong> mean verification has run.</p>
-            <p class="mb-2 text-sm text-text-muted"><strong>Note:</strong> Cast bigint aggregates (<code>count(*)</code>, <code>sum()</code>) to <code>::int</code> so <code>value ==</code> compares numerically — Postgres returns bigint as a string, and <code>value ==</code> uses strict equality.</p>
+            <p class="mb-2 text-sm text-text-muted"><strong>Note:</strong> Bigint aggregates (<code>count(*)</code>, <code>sum()</code>) arrive from Postgres as strings and are compared numerically anyway, so <code>value == 0</code> works without a cast. Quote the expectation (<code>value == "0"</code>) when you mean a text comparison.</p>
             <pre><code># 1. plan the workflow (plan-only, planned evidence)
 dbcli skill tasks plan safe-backfill-verify \
   --param table=orders \

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -597,7 +597,7 @@ Persist a **result evidence record** (v1 VerificationArtifact JSON) to `.dbcli/v
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify` produces a plan JSON with a `verification` block whose `status` is `"planned"` — this is the **planned** evidence definition describing which check will run. The final `assert --write-verification-artifact` step produces **result** evidence (`status: verified` or `not_verified`). These are two different records; `"planned"` does **not** mean verification has run.
 
-> **Note:** Cast bigint aggregates (`count(*)`, `sum()`) to `::int` so `value ==` compares numerically — Postgres returns bigint as a string, and `value ==` uses strict equality.
+> **Note:** Bigint aggregates (`count(*)`, `sum()`) arrive from Postgres as strings and are compared numerically anyway, so `value == 0` works without a cast. Quote the expectation (`value == "0"`) when you mean a text comparison.
 
 ```bash
 # 1. plan the workflow (plan-only, planned evidence)

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -492,7 +492,7 @@ dbcli diff --against-orm prisma/schema.prisma --recovery --format json</code></p
                 <li>狀態跟隨斷言真值：<code>--no-fail</code> 失敗仍會記錄 <code>not_verified</code> / 佐證 <code>exitCode: 1</code>。</li>
             </ul>
             <p class="mt-4 mb-4"><strong>計畫佐證 vs 結果佐證的區別。</strong> <code>dbcli skill tasks plan safe-backfill-verify</code> 產生的計畫 JSON 包含一個 <code>verification</code> 區塊，其 <code>status</code> 為 <code>"planned"</code> — 這是<strong>計畫中</strong>的佐證定義，描述哪項檢查將在執行時進行。最後的 <code>assert --write-verification-artifact</code> 步驟才會產生<strong>結果</strong>佐證（<code>status: verified</code> 或 <code>not_verified</code>）。這兩者是不同的記錄；<code>"planned"</code> <strong>不代表</strong>驗證已執行。</p>
-            <p class="mb-2 text-sm text-text-muted"><strong>注意：</strong> 請將 bigint 聚合函數（<code>count(*)</code>、<code>sum()</code>）轉型為 <code>::int</code>，讓 <code>value ==</code> 做數值比較 — Postgres 回傳的 bigint 是字串，而 <code>value ==</code> 採嚴格相等。</p>
+            <p class="mb-2 text-sm text-text-muted"><strong>注意：</strong> Postgres 的 bigint 聚合函數（<code>count(*)</code>、<code>sum()</code>）回傳的是字串，但比較時會依數值進行，因此 <code>value == 0</code> 不必轉型也成立。若要比對文字，把期望值加引號（<code>value == "0"</code>）。</p>
             <pre><code># 1. 規劃工作流（plan-only，計畫佐證）
 dbcli skill tasks plan safe-backfill-verify \
   --param table=orders \

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -565,7 +565,7 @@ dbcli skill tasks plan migration-review \
 
 **計畫佐證 vs 結果佐證的區別。** `dbcli skill tasks plan safe-backfill-verify` 產生的計畫 JSON 包含一個 `verification` 區塊，其 `status` 為 `"planned"` — 這是**計畫中**的佐證定義，描述哪項檢查將在執行時進行。最後的 `assert --write-verification-artifact` 步驟才會產生**結果**佐證（`status: verified` 或 `not_verified`）。這兩者是不同的記錄；`"planned"` **不代表**驗證已執行。
 
-> **注意：** 請將 bigint 聚合函數（`count(*)`、`sum()`）轉型為 `::int`，讓 `value ==` 做數值比較 — Postgres 回傳的 bigint 是字串，而 `value ==` 採嚴格相等。
+> **注意：** Postgres 的 bigint 聚合函數（`count(*)`、`sum()`）回傳的是字串，但比較時會依數值進行，因此 `value == 0` 不必轉型也成立。若要比對文字，把期望值加引號（`value == "0"`）。
 
 ```bash
 # 1. 規劃工作流（plan-only，計畫佐證）

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -1573,7 +1573,7 @@ Opt-in flag trio that persists a **VerificationArtifact JSON** (schema v1) under
 
 **Planned vs Result evidence.** `dbcli skill tasks plan safe-backfill-verify --format json` returns a plan containing a `verification` block with `status: "planned"`. That block is the **planned** evidence definition — it describes which check will run. Running `assert --write-verification-artifact` on the actual data produces **result** evidence (`status: "verified"` or `status: "not_verified"`). The two records are distinct; `"planned"` does **not** indicate that verification has run or passed.
 
-> **Casting note:** Postgres returns `count(*)` and `sum()` as bigint (a string in the result set). `value ==` uses strict equality, so `"0" == 0` is false. Cast to `::int` (`count(*)::int`) to ensure numeric comparison works correctly.
+> **Numeric note:** Postgres returns `count(*)` and `sum()` as bigint, which arrives as a string. A numeric expectation is compared numerically, so `value == 0` matches it without a cast. A quoted expectation stays a text comparison: `value == "0"` matches the text, not the number. The `::int` casts in the examples below are harmless and no longer required.
 
 ```bash
 dbcli assert "SELECT count(*)::int FROM orders WHERE status IS NULL" \

--- a/src/core/assert/evaluator.ts
+++ b/src/core/assert/evaluator.ts
@@ -11,20 +11,60 @@ export class AssertShapeError extends Error {
   }
 }
 
+/**
+ * The number a value denotes, or null if it does not denote one.
+ *
+ * PostgreSQL hands back `bigint`, `int8`, and `numeric` as JavaScript strings,
+ * so the actual side of an assertion is routinely `'6'` where the expectation
+ * is `6`. Integers beyond `Number.MAX_SAFE_INTEGER` compare imprecisely; the
+ * expectation is already parsed into a JS number upstream, so nothing is lost
+ * here that survives parsing anyway.
+ */
+function numeric(value: number | string): number | null {
+  if (typeof value === 'number') return Number.isNaN(value) ? null : value
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const parsed = Number(trimmed)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+/**
+ * Compare an actual value against an expectation.
+ *
+ * A numeric expectation is compared numerically, so a count returned as a
+ * string matches the number it denotes. A quoted expectation stays a string
+ * comparison — `'006'` and `6` are equal as numbers and different as text, and
+ * asking for the text is the reason to quote it.
+ *
+ * `==` and `!=` were previously strict, which made every `value == <count>`
+ * assertion fail against PostgreSQL while `>` and `<` coerced and passed.
+ */
 function compare(a: number | string, op: Op, b: number | string): boolean {
+  let left: number | string = a
+  let right: number | string = b
+
+  if (typeof a !== typeof b) {
+    const na = numeric(a)
+    const nb = numeric(b)
+    if (na !== null && nb !== null) {
+      left = na
+      right = nb
+    }
+  }
+
   switch (op) {
     case '>':
-      return a > b
+      return left > right
     case '>=':
-      return a >= b
+      return left >= right
     case '<':
-      return a < b
+      return left < right
     case '<=':
-      return a <= b
+      return left <= right
     case '==':
-      return a === b
+      return left === right
     case '!=':
-      return a !== b
+      return left !== right
   }
 }
 
@@ -84,7 +124,10 @@ export function evaluateExpect(
     }
   }
   if (pred.type === 'between') {
-    const bad = nonNull.filter((v) => typeof v !== 'number' || v < pred.low || v > pred.high)
+    const bad = nonNull.filter((v) => {
+      const n = numeric(v as number | string)
+      return n === null || n < pred.low || n > pred.high
+    })
     return {
       name: `col:${column} between ${pred.low} and ${pred.high}`,
       expected: '0 out of range',
@@ -121,6 +164,6 @@ export function compareVs(
     name: 'vs:value',
     expected: String(bv),
     actual: String(av),
-    pass: av !== null && bv !== null && av === bv,
+    pass: av !== null && bv !== null && compare(av, '==', bv),
   }
 }

--- a/tests/unit/core/assert/evaluator.test.ts
+++ b/tests/unit/core/assert/evaluator.test.ts
@@ -25,6 +25,77 @@ describe('evaluateExpect', () => {
     expect(c.pass).toBe(true)
   })
 
+  // PostgreSQL returns bigint, numeric, and int8 as JavaScript strings, so the
+  // most ordinary assertion anyone writes — a count against a number — compared
+  // a string to a number under `===` and always failed. Ordering operators
+  // coerced and passed, which is why it stayed hidden: `value > 5` worked while
+  // `value == 6` did not.
+  it('compares a numeric string result against a numeric expectation', () => {
+    const c = evaluateExpect({ kind: 'value', op: '==', value: 6 }, qr([{ n: '6' }], ['n']))
+    expect(c.pass).toBe(true)
+    expect(c.actual).toBe('6')
+  })
+
+  it('compares a zero count returned as a string', () => {
+    const c = evaluateExpect({ kind: 'value', op: '==', value: 0 }, qr([{ n: '0' }], ['n']))
+    expect(c.pass).toBe(true)
+  })
+
+  it('treats != on a numeric string the same way', () => {
+    expect(
+      evaluateExpect({ kind: 'value', op: '!=', value: 6 }, qr([{ n: '6' }], ['n'])).pass
+    ).toBe(false)
+    expect(
+      evaluateExpect({ kind: 'value', op: '!=', value: 7 }, qr([{ n: '6' }], ['n'])).pass
+    ).toBe(true)
+  })
+
+  it('compares a scaled numeric string by value, not by text', () => {
+    const c = evaluateExpect({ kind: 'value', op: '==', value: 6 }, qr([{ n: '6.00' }], ['n']))
+    expect(c.pass).toBe(true)
+  })
+
+  // A quoted expectation asks for a string comparison, so it must not be
+  // coerced: '006' and 6 are equal as numbers and different as text.
+  it('keeps a quoted expectation a string comparison', () => {
+    expect(
+      evaluateExpect({ kind: 'value', op: '==', value: '006' }, qr([{ n: '6' }], ['n'])).pass
+    ).toBe(false)
+    expect(
+      evaluateExpect({ kind: 'value', op: '==', value: 'paid' }, qr([{ s: 'paid' }], ['s'])).pass
+    ).toBe(true)
+  })
+
+  it('does not turn a non-numeric string into a numeric comparison', () => {
+    const c = evaluateExpect({ kind: 'value', op: '==', value: 0 }, qr([{ s: 'paid' }], ['s']))
+    expect(c.pass).toBe(false)
+  })
+
+  it('compares col predicates against numeric strings', () => {
+    const c = evaluateExpect(
+      { kind: 'col', column: 'amount', pred: { type: 'cmp', op: '==', value: 10 } },
+      qr([{ amount: '10' }, { amount: '10.0' }], ['amount'])
+    )
+    expect(c.pass).toBe(true)
+  })
+
+  it('ranges a numeric-string column instead of calling every row out of range', () => {
+    const c = evaluateExpect(
+      { kind: 'col', column: 'amount', pred: { type: 'between', low: 0, high: 100 } },
+      qr([{ amount: '10' }, { amount: '99.5' }], ['amount'])
+    )
+    expect(c.pass).toBe(true)
+    expect(c.actual).toBe('0 out of range')
+  })
+
+  it('still reports a numeric-string column outside the range', () => {
+    const c = evaluateExpect(
+      { kind: 'col', column: 'amount', pred: { type: 'between', low: 0, high: 100 } },
+      qr([{ amount: '101' }], ['amount'])
+    )
+    expect(c.pass).toBe(false)
+  })
+
   it('throws AssertShapeError when value query has multiple columns', () => {
     expect(() =>
       evaluateExpect({ kind: 'value', op: '==', value: 1 }, qr([{ a: 1, b: 2 }], ['a', 'b']))
@@ -65,5 +136,26 @@ describe('compareVs', () => {
   it('compares scalar values', () => {
     const c = compareVs(qr([{ s: 100 }], ['s']), qr([{ s: 100 }], ['s']), 'value')
     expect(c.pass).toBe(true)
+  })
+
+  // Reconciling two engines, or a count against a literal, puts a string on one
+  // side and a number on the other.
+  it('reconciles the same number across a string and a number result', () => {
+    const c = compareVs(qr([{ s: '100' }], ['s']), qr([{ s: 100 }], ['s']), 'value')
+    expect(c.pass).toBe(true)
+  })
+
+  it('still separates genuinely different values', () => {
+    const c = compareVs(qr([{ s: '100' }], ['s']), qr([{ s: 101 }], ['s']), 'value')
+    expect(c.pass).toBe(false)
+  })
+
+  it('compares two non-numeric strings as text', () => {
+    expect(compareVs(qr([{ s: 'paid' }], ['s']), qr([{ s: 'paid' }], ['s']), 'value').pass).toBe(
+      true
+    )
+    expect(compareVs(qr([{ s: 'paid' }], ['s']), qr([{ s: 'pending' }], ['s']), 'value').pass).toBe(
+      false
+    )
   })
 })


### PR DESCRIPTION
## 怎麼發現的

執行 ADR-0011 的 dogfood：拿 `dbcli verify safe-backfill --after-write` 對真實 PostgreSQL 跑一次，再組出 evidence pack。第一次跑就回 `not_verified`——而資料是對的，六列 NULL region 全部被 backfill 成 `'TW'`，`psql` 確認 0 筆殘留。

失敗的不是資料，是比較。

## 根因

`src/core/assert/evaluator.ts` 的 `firstScalar` 把值原樣當 `number | string` 回傳，pg 的 `bigint` / `numeric` / `int8` 到 JS 都是字串；`compare` 的 `==` 用 `===`，所以 `"0" === 0` 永遠是 false。

隔離證據：

| 查詢 | `value == 6` |
|---|---|
| `SELECT 6 AS n`（int4） | pass |
| `SELECT 6::bigint AS n` | **fail** |
| `SELECT 6::text AS n` | **fail** |
| `SELECT count(*) AS n FROM orders`（6 列） | **fail** |

輸出自己就寫著 `expected: "value == 6"`、`actual: "6"`、`pass: false`。

**最難察覺的是不對稱**：`>` `<` 走 JS 隱式轉型會通過，只有 `==` 和 `!=` 壞掉。同一個欄位，`value > 5` 正常，`value == 6` 不會。

影響範圍不只 assert：`verify safe-backfill` 的 read-back 幾乎一定是個 count，所以整條 `--after-write` 流程在 PostgreSQL 上沒辦法回報 `verified`。

## 一個根因，三張臉

- `value == / !=` 的比較（本體）
- `compareVs` 的 value 比對，用的是同一個 `===`
- `col:x between` 以 `typeof v !== 'number'` 判定，numeric 欄位整批被算成 out of range

三處共用同一個數值化 helper 修好。

## 修法

只有在期望值是數字時才做數值比較。加引號的期望值維持文字比較——`'006'` 和 `6` 當數字相等、當文字不等，而使用者會加引號就是因為要比文字。非數字字串（`'paid'`）對數字期望值仍然不等。

精度限制寫在註解裡：超過 `Number.MAX_SAFE_INTEGER` 的整數比較不精確，但期望值在 `parseScalar` 就已經被 `Number()` 解析過，這裡沒有再多損失什麼。

## 文件不是漏寫，是把 bug 寫成規格

`assets/reference.md` 與 en/zh-TW 的 md/html 原本都有一段「Casting note」，教使用者把 `count(*)` 轉成 `::int` 來繞過。**這個 bug 不是沒被發現，是被當成規格記下來了。** 四份文件的說明一併更正，範例裡的 `::int` 留著——它們仍然正確，只是不再必要。plugin / skill 的六份複本用 `bun run plugin:sync` 同步。

## ADR-0011 同步更新

dogfood 觸發條件達成：pack 真的組出來、`validate` 回 `integrity: valid, references: valid, expired: []`、Markdown render 讀過了。**凍結路線取消**，deviation 的修復從此被授權。

但四個 known deviation 這次一個都沒被碰到，所以一個都沒修——真正踩到的問題在驗證路徑，不在 evidence 路徑。ADR 也誠實記下一件事：那個 pack 裡每一句有用的話都是人寫的，機器產生的部分只說了 `not_verified` 沒說為什麼，而「為什麼」是唯一值得讀的東西。

`falsified_if` 改成守護新的風險：修了 deviation 卻沒同步更新 backlog 的標注。

## Test plan

測試先寫、確認 RED（7 fail）再實作。

- `bun test tests/unit/core/assert/` — 25 pass（新增 12 條：數值字串的 `==` / `!=`、`6.00` 這種縮放值、加引號維持文字比較、非數字字串不被數值化、col cmp 與 between 的字串欄位、`compareVs` 跨型別比對）
- **真實資料庫端到端**：同一個指令、同一批資料，修改前 `not_verified`，修改後 `verified`
- `bun test` — 5521 pass / 27 skip / 0 fail（510 檔）
- `typecheck`、`lint`、`prettier`、`skill:check`、`docs:check`、`platform:check`、`plugin:check`、`plan:check` — 全部通過