### PR TITLE
fix: [ evidence-pack ] digest 蓋住隨機 UUID，同樣輸入永遠算不出同一個 pack

### DIFF
--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
+++ b/docs/adr/0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md
@@ -1,8 +1,13 @@
 ---
-status: accepted
+status: superseded
 date: 2026-08-16
 dogfooded: 2026-08-16
+superseded_by: 0012
 ---
+
+> The decision below — that repair waits for evidence of use — is superseded by
+> [ADR-0012](0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md).
+> The record of what the dogfood found is still current and still accurate.
 
 # The evidence subsystem waits for a user before it is repaired
 

--- a/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
+++ b/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+date: 2026-08-16
+supersedes: 0011
+---
+
+# Known defects get fixed whether or not anyone is using the code
+
+[ADR-0011](0011-evidence-subsystem-waits-for-a-user-before-it-is-repaired.md)
+made repair of the evidence subsystem's four known defects conditional on
+evidence that someone was using it. The condition was met on 2026-08-16 and the
+question became live rather than theoretical. It is now settled the other way,
+permanently: a defect that is known is repaired, and how many users it currently
+has is not part of the decision.
+
+## Decision
+
+Fix the four deviations recorded in ADR-0011, and treat "nobody is using this
+yet" as irrelevant to whether a known defect gets repaired. Usage may set
+priority. It does not decide whether the work happens.
+
+Where a deviation exists because a schema promises something the code cannot
+produce, the repair may change the schema. The evidence-pack format is amended
+in place rather than versioned forward: it has no users to keep compatible, and
+carrying a compatibility layer for a format nobody has stored would be the same
+speculative construction that produced these defects.
+
+## Why the earlier decision was wrong
+
+ADR-0011 argued that an unused subsystem cannot tell us which of its defects
+matter, and that repairing all four spends effort at the moment we know least.
+Both sentences are true and neither supports the conclusion drawn from them.
+
+A defect that is recorded and left in place does not stay neutral. It becomes
+documentation: the `value ==` comparison bug found during the same dogfood had
+been written into `assets/reference.md` as a casting note, teaching users to
+work around it. That is what a known-and-unrepaired defect turns into given
+enough time — not a tracked item, but a described feature. The cost of waiting
+is not zero, it is just deferred and disguised.
+
+The second failure was of framing. Deciding repair by usage assumes usage is
+observable and that "nobody uses it" is a stable fact rather than a snapshot of
+one afternoon. It also invites the reading that correctness is a service level
+offered to users who show up, which is not a position this project wants to
+hold for a tool whose entire promise is that its output can be trusted.
+
+## Consequences
+
+- Each of the four deviations gets its own change, with the ticket annotation in
+  `docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md`
+  updated in the same change, as ADR-0011's falsification condition requires.
+- `— known deviation:` in a plan is a statement about the present, not a
+  permanent exemption. A deviation that is not being repaired needs a reason
+  that is not "no one has hit it yet".
+- The evidence-pack schema changes without a version bump. Any pack written
+  before this change fails validation, which is correct: its digest was computed
+  under rules that no longer hold.
+- ADR-0011 keeps its record of what the dogfood found. Only its decision clause
+  is superseded.
+
+**Falsified if:** a defect in `docs/plans/` is annotated
+`— known deviation:` with a justification that rests on the code having no
+users, or ADR-0011's four deviations are still unrepaired when the backlog
+stops naming them.

--- a/docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md
+++ b/docs/plans/2026-08-08-agent-data-evidence-and-change-intelligence-ticket-backlog.md
@@ -41,8 +41,10 @@ useful without them and report their absence as coverage gaps.
 
 ## EVD-01 — Evidence Pack v1
 
-**Status:** Delivered in v1.53.0 (2026-08-09). Known deviations: criterion 3 and
-the expired-reference coverage gap in Scope. Unverified: criteria 1, 2, and 5.
+**Status:** Delivered in v1.53.0 (2026-08-09). Both known deviations were
+repaired on 2026-08-16 under
+[ADR-0012](../adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md).
+Unverified: criteria 1, 2, and 5.
 
 **Depends on:** Existing verification artifact reader and audit/recovery reader
 
@@ -65,10 +67,15 @@ and safe audit/recovery reference projections.
   requested source fails composition; a reference that expires later through
   audit rotation/clear yields non-zero `source-expired` reference validation
   plus a coverage gap, while digest validation and forensic rendering remain
-  available. — known deviation: the coverage gap is unreachable. Both writers
-  hard-code an empty `gaps` array (`src/core/evidence-pack/index.ts:363,399`)
-  and the parser rejects a non-empty one (`:380-388`), so expiry is visible only
-  in the transient `validate` output, never in the pack.
+  available. — covered by: `tests/integration/evidence-command.test.ts`
+  (`reports source-expired after audit retention while rendering remains
+  available`). The promised coverage gap was unreachable and the `coverage`
+  field is now removed rather than faked: a pack is immutable, so a reference
+  that expires after composition cannot be written back into it. Expiry is
+  reported by `evidence validate`, which is where a reader can act on it —
+  asserted by `tests/unit/core/evidence-pack/evidence-pack.test.ts` (`does not
+  carry a coverage field`, `rejects a pack that still carries the removed
+  coverage field`).
 - Update four-way user docs and generated skill/platform guidance. Claims must
   visibly remain external interpretation, not a dbcli verification verdict.
 
@@ -89,11 +96,12 @@ result export, archive/import support, signing, or authentication.
    required source, oversized input, and malformed reference objects have no
    test.
 3. Equivalent claim/reference sets produce canonical identical JSON and digest.
-   — known deviation: unsatisfiable. The digest covers a random UUID id and a
-   millisecond `createdAt` (`src/core/evidence-pack/index.ts:302-308,357-364`),
-   and the command injects neither a fixed id nor a clock
-   (`src/commands/evidence.ts:301`). Only claim and reference ordering is
-   canonical.
+   — covered by: `tests/unit/core/evidence-pack/evidence-pack.test.ts`
+   (`composing the same claims and references twice produces the same digest`,
+   `derives the pack id from its content digest`, `validates a pack whose keys
+   are stored in a different order`). The digest now covers content only and the
+   id is derived from it; `createdAt` is metadata outside the digest, which is
+   the one field a restamp can change undetected.
 4. Tampering is detected; expired provenance is neither hidden nor misreported
    as a valid reference. — covered by:
    `tests/unit/core/evidence-pack/evidence-pack.test.ts` (`canonicalizes claims

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -2729,8 +2729,11 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 | `--format <json\|markdown>` | Compose receipt format printed to stdout. | `json` |
 
 At least one `--verification`, `--audit`, or `--receipt` reference is required. The resulting pack
-contains a canonical SHA-256 integrity digest and `coverage.completeForDeclaredEvidence:
-true` for its explicitly selected references.
+carries a canonical SHA-256 digest over its content, and its `id` is derived from that digest, so
+composing the same claims and references twice produces the same pack. `createdAt` records when the
+pack was written and is deliberately outside the digest — it is the one field a restamp can change
+without breaking validation. Whether a referenced source is still resolvable is reported by
+`evidence validate`, not stored in the pack.
 
 #### `evidence validate`
 

--- a/src/core/evidence-pack/index.ts
+++ b/src/core/evidence-pack/index.ts
@@ -63,16 +63,23 @@ export interface EvidenceClaim extends EvidenceClaimInput {
   evidence: EvidenceReference[]
 }
 
-export interface EvidencePack {
+/**
+ * The part of a pack the digest and the id are derived from.
+ *
+ * `createdAt` is deliberately outside it. Including it made two composes of the
+ * same claims produce two unrelated digests, which left nothing to compare
+ * across runs; the cost is that a restamped `createdAt` is not detectable,
+ * which the render and the user documentation both say plainly.
+ */
+export interface EvidencePackContent {
   version: typeof EVIDENCE_PACK_VERSION
-  id: string
-  createdAt: string
   subject: EvidencePackSubject
   claims: EvidenceClaim[]
-  coverage: {
-    completeForDeclaredEvidence: true
-    gaps: string[]
-  }
+}
+
+export interface EvidencePack extends EvidencePackContent {
+  id: string
+  createdAt: string
   integrity: {
     algorithm: 'sha256'
     digest: string
@@ -299,12 +306,32 @@ function assertVerificationSubjects(subject: EvidencePackSubject, claims: Eviden
   }
 }
 
-function canonicalizeWithoutDigest(pack: Omit<EvidencePack, 'integrity'>): string {
-  return JSON.stringify(pack)
+/**
+ * Serialize with every object key sorted, at every depth.
+ *
+ * The previous implementation was a bare `JSON.stringify`, so "canonical" meant
+ * "whatever order the build and parse paths happened to insert keys in". Any
+ * edit to either one would have silently invalidated every stored digest.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, v]) => `${JSON.stringify(key)}:${canonicalize(v)}`)
+  return `{${entries.join(',')}}`
 }
 
-function digest(pack: Omit<EvidencePack, 'integrity'>): string {
-  return createHash('sha256').update(canonicalizeWithoutDigest(pack)).digest('hex')
+function digest(content: EvidencePackContent): string {
+  return createHash('sha256').update(canonicalize(content)).digest('hex')
+}
+
+/**
+ * Content-addressed id, so equivalent packs are recognisably the same pack.
+ */
+function packId(contentDigest: string): string {
+  return `evp_${contentDigest.slice(0, 32)}`
 }
 
 export function parseEvidenceClaimsInput(raw: unknown): EvidenceClaimsInput {
@@ -331,7 +358,7 @@ export function parseEvidenceClaimsInput(raw: unknown): EvidenceClaimsInput {
 export function buildEvidencePack(
   input: EvidenceClaimsInput,
   references: EvidenceReference[],
-  options: { now?: () => Date; idFactory?: () => string } = {}
+  options: { now?: () => Date } = {}
 ): EvidencePack {
   if (references.length === 0 || references.length > MAX_REFERENCES) {
     throw new EvidencePackValidationError(
@@ -354,57 +381,55 @@ export function buildEvidencePack(
       'verification evidence must match the claims subject kind'
     )
   }
-  const base: Omit<EvidencePack, 'integrity'> = {
+  const content: EvidencePackContent = {
     version: EVIDENCE_PACK_VERSION,
-    id: id(options.idFactory?.() ?? `evp_${randomUUID()}`, 'pack.id'),
-    createdAt: (options.now?.() ?? new Date()).toISOString(),
     subject: normalized.subject,
     claims: normalized.claims.map((claim) => ({ ...claim, evidence })),
-    coverage: { completeForDeclaredEvidence: true, gaps: [] },
   }
-  return { ...base, integrity: { algorithm: 'sha256', digest: digest(base) } }
+  const contentDigest = digest(content)
+  return {
+    ...content,
+    id: packId(contentDigest),
+    createdAt: (options.now?.() ?? new Date()).toISOString(),
+    integrity: { algorithm: 'sha256', digest: contentDigest },
+  }
 }
 
 export function parseEvidencePack(raw: unknown): EvidencePack {
   if (!isRecord(raw)) throw new EvidencePackValidationError('evidence pack must be an object')
   requireExactKeys(
     raw,
-    ['version', 'id', 'createdAt', 'subject', 'claims', 'coverage', 'integrity'],
+    ['version', 'id', 'createdAt', 'subject', 'claims', 'integrity'],
     'evidence pack'
   )
   if (raw.version !== EVIDENCE_PACK_VERSION) {
     throw new EvidencePackValidationError(`evidence pack version must be ${EVIDENCE_PACK_VERSION}`)
   }
-  if (!isRecord(raw.coverage)) throw new EvidencePackValidationError('coverage must be an object')
-  requireExactKeys(raw.coverage, ['completeForDeclaredEvidence', 'gaps'], 'coverage')
-  if (
-    raw.coverage.completeForDeclaredEvidence !== true ||
-    !Array.isArray(raw.coverage.gaps) ||
-    raw.coverage.gaps.length !== 0
-  ) {
-    throw new EvidencePackValidationError(
-      'v1 coverage must be complete for declared evidence with no gaps'
-    )
-  }
   if (!isRecord(raw.integrity)) throw new EvidencePackValidationError('integrity must be an object')
   requireExactKeys(raw.integrity, ['algorithm', 'digest'], 'integrity')
   if (raw.integrity.algorithm !== 'sha256')
     throw new EvidencePackValidationError('integrity.algorithm must be sha256')
-  const base: Omit<EvidencePack, 'integrity'> = {
+  const content: EvidencePackContent = {
     version: EVIDENCE_PACK_VERSION,
-    id: id(raw.id, 'pack.id'),
-    createdAt: iso(raw.createdAt, 'pack.createdAt'),
     subject: parseSubject(raw.subject),
     claims: parseClaims(raw.claims, true),
-    coverage: { completeForDeclaredEvidence: true, gaps: [] },
   }
-  assertVerificationSubjects(base.subject, base.claims)
+  assertVerificationSubjects(content.subject, content.claims)
   const actualDigest = text(raw.integrity.digest, 'integrity.digest', 128)
   if (!/^[a-f0-9]{64}$/.test(actualDigest))
     throw new EvidencePackValidationError('integrity.digest must be sha256 hex')
-  if (actualDigest !== digest(base))
+  const expectedDigest = digest(content)
+  if (actualDigest !== expectedDigest)
     throw new EvidencePackValidationError('evidence pack digest mismatch')
-  return { ...base, integrity: { algorithm: 'sha256', digest: actualDigest } }
+  const packIdentity = id(raw.id, 'pack.id')
+  if (packIdentity !== packId(expectedDigest))
+    throw new EvidencePackValidationError('evidence pack id does not match its content digest')
+  return {
+    ...content,
+    id: packIdentity,
+    createdAt: iso(raw.createdAt, 'pack.createdAt'),
+    integrity: { algorithm: 'sha256', digest: actualDigest },
+  }
 }
 
 function isInside(root: string, target: string): boolean {

--- a/tests/unit/core/evidence-pack/evidence-pack.test.ts
+++ b/tests/unit/core/evidence-pack/evidence-pack.test.ts
@@ -41,14 +41,94 @@ afterEach(async () => {
   outsideWorkspace = undefined
 })
 
+describe('evidence pack identity', () => {
+  // EVD-01 asked for equivalent inputs to produce an identical pack. They could
+  // not: the digest covered a random UUID id and a millisecond createdAt, so
+  // composing the same claims twice produced two unrelated digests and there
+  // was nothing to compare across runs.
+  test('composing the same claims and references twice produces the same digest', () => {
+    const first = buildEvidencePack(claims, references, {
+      now: () => new Date('2026-08-08T12:00:00.000Z'),
+    })
+    const second = buildEvidencePack(claims, references, {
+      now: () => new Date('2026-08-09T23:59:59.000Z'),
+    })
+    expect(second.integrity.digest).toBe(first.integrity.digest)
+    expect(second.id).toBe(first.id)
+    expect(second.createdAt).not.toBe(first.createdAt)
+  })
+
+  test('derives the pack id from its content digest', () => {
+    const pack = buildEvidencePack(claims, references)
+    expect(pack.id).toBe(`evp_${pack.integrity.digest.slice(0, 32)}`)
+  })
+
+  test('different claims produce a different digest and id', () => {
+    const pack = buildEvidencePack(claims, references)
+    const other = buildEvidencePack(
+      { ...claims, claims: [{ id: 'claim-1', text: 'A different claim entirely.' }] },
+      references
+    )
+    expect(other.integrity.digest).not.toBe(pack.integrity.digest)
+    expect(other.id).not.toBe(pack.id)
+  })
+
+  test('rejects a pack whose id does not match its digest', () => {
+    const pack = buildEvidencePack(claims, references)
+    expect(() =>
+      parseEvidencePack({ ...pack, id: 'evp_0000000000000000000000000000ffff' })
+    ).toThrow(/pack id does not match/)
+  })
+
+  // The digest is computed over a canonical serialization, so the key order a
+  // file happens to be written in cannot change it.
+  test('validates a pack whose keys are stored in a different order', () => {
+    const pack = buildEvidencePack(claims, references)
+    const reordered = JSON.parse(
+      JSON.stringify({
+        integrity: pack.integrity,
+        claims: pack.claims,
+        subject: pack.subject,
+        createdAt: pack.createdAt,
+        id: pack.id,
+        version: pack.version,
+      })
+    )
+    expect(parseEvidencePack(reordered).integrity.digest).toBe(pack.integrity.digest)
+  })
+
+  // coverage.gaps could never be non-empty: both writers hard-coded an empty
+  // array and the parser rejected a non-empty one. A field that cannot vary
+  // states nothing, and expiry is reported by `evidence validate` instead.
+  test('does not carry a coverage field', () => {
+    const pack = buildEvidencePack(claims, references)
+    expect(pack).not.toHaveProperty('coverage')
+  })
+
+  test('rejects a pack that still carries the removed coverage field', () => {
+    const pack = buildEvidencePack(claims, references)
+    expect(() =>
+      parseEvidencePack({
+        ...pack,
+        coverage: { completeForDeclaredEvidence: true, gaps: [] },
+      })
+    ).toThrow(EvidencePackValidationError)
+  })
+
+  test('createdAt is metadata and is not covered by the digest', () => {
+    const pack = buildEvidencePack(claims, references)
+    const restamped = parseEvidencePack({ ...pack, createdAt: '2030-01-01T00:00:00.000Z' })
+    expect(restamped.integrity.digest).toBe(pack.integrity.digest)
+  })
+})
+
 describe('evidence packs', () => {
   test('canonicalizes claims and produces a tamper-evident pack', () => {
     const pack = buildEvidencePack(claims, references, {
       now: () => new Date('2026-08-08T12:00:00.000Z'),
-      idFactory: () => 'evp_test-1',
     })
 
-    expect(pack.id).toBe('evp_test-1')
+    expect(pack.id).toBe(`evp_${pack.integrity.digest.slice(0, 32)}`)
     expect(pack.claims[0]?.evidence).toEqual(references)
     expect(parseEvidencePack(JSON.parse(JSON.stringify(pack)))).toEqual(pack)
 
@@ -136,7 +216,7 @@ describe('evidence packs', () => {
   test('writes only inside the workspace and refuses to overwrite a pack', async () => {
     workspace = await mkdtemp(join(tmpdir(), 'dbcli-evidence-pack-'))
     outsideWorkspace = await mkdtemp(join(tmpdir(), 'dbcli-evidence-outside-'))
-    const pack = buildEvidencePack(claims, references, { idFactory: () => 'evp_test-2' })
+    const pack = buildEvidencePack(claims, references)
     const output = await writeEvidencePack(workspace, '.dbcli/evidence/pack.json', pack)
 
     expect(await readEvidencePack(output)).toEqual(pack)
@@ -159,8 +239,7 @@ describe('evidence packs', () => {
         subject: { kind: 'migration', name: '<review>' },
         claims: [{ id: 'claim-1', text: 'See [untrusted](payload) before review.' }],
       },
-      references,
-      { idFactory: () => 'evp_test-3' }
+      references
     )
 
     expect(renderEvidencePackMarkdown(pack)).toContain(


### PR DESCRIPTION
> 這是 ADR-0011 四個 known deviation 的第一個修復。決策反轉記在新的 [ADR-0012](https://github.com/CarlLee1983/dbcli/blob/fix/evidence-pack-schema-honesty/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md)：**已知缺陷一律修，有沒有人用不進入判斷。**

## 決策反轉

ADR-0011 把修復條件綁在「有人在用」。那個條件在 8/16 達成後，問題從假設變成實際，答案是反過來的——而且是永久性的。

ADR-0012 記下為什麼原本的推理錯了：一個被記錄下來、卻沒被修的缺陷不會保持中性，它會變成文件。同一次 dogfood 找到的 `value ==` 比較 bug 就已經被寫進 `assets/reference.md` 當成「Casting note」，教使用者轉型繞過。**那就是已知未修的缺陷放久了會變成的東西——不是待辦事項，是被描述成規格的行為。** 等待的成本不是零，只是被延後並偽裝起來了。

ADR-0011 標為 superseded，但它記錄的 dogfood 發現保留，那部分仍然成立。

## 修了什麼

**digest 不可重現**（EVD-01 準則 3）。digest 蓋住 `evp_<randomUUID>` 和毫秒 `createdAt`，所以同一組 claims 組兩次得到兩個毫不相干的 digest，跨次比對無從談起。

- digest 只涵蓋內容（`version` / `subject` / `claims`），`id` 改由 digest 前 32 碼推導，等價輸入現在產生同一個 pack，連 id 都一樣
- `createdAt` 移出 digest，並在型別註解和 `reference.md` 明說它是唯一能被重新蓋章而不破壞驗證的欄位。不寫這句就是拿「防篡改」騙人
- `canonicalizeWithoutDigest` 原本只是 `JSON.stringify`，所謂 canonical 全靠 build 與 parse 兩條路徑手工維持相同插入順序——任何一邊調整欄位順序都會靜默作廢所有既存 digest。改成遞迴排序鍵的真正正規化
- parse 新增 id 與 digest 的一致性檢查

**`coverage` 是死的 schema surface**（EVD-01 Scope）。兩個 writer 都寫死空陣列、parser 拒絕非空，所以票上承諾的「過期 reference 產生 coverage gap」永遠不可能發生。

**整個欄位移除，不是補上讓它能填值。** pack 是不可變的，reference 在組成之後才過期，本來就寫不回去；而 `evidence validate` 已經在報這件事，那才是讀者能據以行動的地方。一個永遠不會變的欄位什麼都沒說。

## 相容性

pack 格式就地修改，不 bump v2、不做相容層。既存的 pack 會驗證失敗——這是正確的，它們的 digest 是用已經不成立的規則算出來的。沒有使用者要維持相容，而為一個沒人存過的格式扛相容層，正是造成這些缺陷的那種投機建設。

## backlog 標注同步更新

ADR-0011 的 falsified-if 要求「修了 deviation 就要在同一個 change 更新 backlog 標注」，`.claude` 的 boundary hook 在我每次編輯 `src/core/evidence-pack/index.ts` 時都提醒了一次。兩條標注從 `— known deviation:` 改成 `— covered by:` 並指名新測試，`plan:check` 通過。

## Test plan

測試先寫、確認 RED（7 fail）再實作。

- 新增 8 條測試：等價輸入產生相同 digest 與 id、id 由內容推導、不同 claims 產生不同 id、id 與 digest 不符會被拒、鍵序不同的檔案仍然驗證通過、pack 不再帶 coverage、帶著已移除的 coverage 會被拒、createdAt 不被 digest 涵蓋
- `bun test` — 5529 pass / 27 skip / 0 fail（510 檔）
- `typecheck`、`lint`、`prettier`、`skill:check`、`docs:check`、`platform:check`、`plugin:check`、`plan:check` — 全綠

## 還沒修的

另外兩個 deviation 各自獨立 PR：blacklist 對散文的無邊界子字串比對、receipt `observation.fingerprint` 未加鹽。另外 `impact` 的 `coverage.level === 'declared'` 結構不可達也還在。