### PR TITLE
fix: [ evidence ] 黑名單比對是無邊界子字串，id 讓「identifier」整包被擋

### DIFF
--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
+++ b/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
@@ -44,6 +44,20 @@ one afternoon. It also invites the reading that correctness is a service level
 offered to users who show up, which is not a position this project wants to
 hold for a tool whose entire promise is that its output can be trusted.
 
+## Repair status
+
+Two of the four are tracked as acceptance criteria in the ticket backlog and
+carry their annotation there. The other two exist only in ADR-0011's list, so
+they are tracked here.
+
+- `coverage.gaps` dead schema surface — repaired 2026-08-16; the field is gone.
+- Pack digest not reproducible — repaired 2026-08-16; the digest covers content
+  and the id derives from it.
+- Blacklist substring matching over prose — repaired 2026-08-16; terms match as
+  identifiers, the columns map's keys are included, and the refusal names the
+  field rather than the term.
+- `observation.fingerprint` unsalted over a low-entropy value — open.
+
 ## Consequences
 
 - Each of the four deviations gets its own change, with the ticket annotation in

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -2721,7 +2721,7 @@ dbcli evidence compose --claims ./claims.json --verification ver_abcd --audit 1a
 
 | Flag | Purpose | Default |
 |---|---|---|
-| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. | — |
+| `--claims <file>` | Required JSON file with exactly `subject` and `claims`; every claim has an `id` and plain-language `text`. SQL-shaped text, credentials, error content, and blacklisted identifiers are rejected. A blacklisted identifier has to appear as an identifier — a term like `id` matches `orders.id` but not the word "identifier" — and the refusal names the field, never the matched term. | — |
 | `--verification <selector...>` | One or more verification artifact ids, unique prefixes, filenames, or in-bounds paths. | none |
 | `--audit <selector...>` | One or more audit ids or unique prefixes (minimum four characters) from the active connection. | none |
 | `--receipt <path...>` | Explicit workspace-relative receipt path(s). Receipts contribute safe provenance only; they are not execution approval. | none |

--- a/src/commands/evidence.ts
+++ b/src/commands/evidence.ts
@@ -54,30 +54,67 @@ async function readClaimsInput(filePath: string): Promise<unknown> {
   }
 }
 
-function blockedTerms(config: EvidenceConfig): string[] {
+/**
+ * Every protected identifier, including the table names that appear only as
+ * keys of the columns map. Omitting those keys meant a table protected through
+ * a column entry was never blocked in prose.
+ */
+export function blockedTerms(config: EvidenceConfig): string[] {
   return [
     ...(config.blacklist?.tables ?? []),
+    ...Object.keys(config.blacklist?.columns ?? {}),
     ...Object.values(config.blacklist?.columns ?? {}).flat(),
   ]
     .map((value) => value.trim().toLowerCase())
     .filter((value) => value.length > 0)
 }
 
-function assertNoBlockedText(value: string | undefined, terms: readonly string[]): void {
-  if (!value) return
+/**
+ * Whether a protected identifier appears in this text as an identifier.
+ *
+ * Matching used to be an unbounded substring test, so a blacklisted column
+ * named `id` blocked any claim containing "identifier" or "considered", and the
+ * error named no term — leaving the author with a refusal and no way to find
+ * the cause. A term now has to stand alone: `_`, letters, and digits on either
+ * side are part of a longer identifier and are not a match, while a dot, quote,
+ * space, or punctuation is a boundary.
+ *
+ * This catches an identifier written as an identifier. It does not catch one
+ * spelled around — `secret_customer` written as "secret customer" still passes,
+ * and no matcher over free prose can honestly promise otherwise.
+ */
+export function containsBlockedTerm(value: string, terms: readonly string[]): boolean {
   const normalized = value.toLowerCase()
-  if (terms.some((term) => normalized.includes(term))) {
-    throw new EvidencePackValidationError('evidence content contains a blocked identifier')
+  return terms.some((term) => {
+    const trimmed = term.trim().toLowerCase()
+    if (trimmed.length === 0) return false
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`).test(normalized)
+  })
+}
+
+function assertNoBlockedText(
+  value: string | undefined,
+  terms: readonly string[],
+  field: string
+): void {
+  if (!value) return
+  if (containsBlockedTerm(value, terms)) {
+    // The field is named and the term is not: saying which identifier matched
+    // would print the protected name into an error the author may paste on.
+    throw new EvidencePackValidationError(`${field} contains a blocked identifier`)
   }
 }
 
 function assertClaimsSafe(raw: unknown, terms: readonly string[]): void {
   const input = parseEvidenceClaimsInput(raw)
-  assertNoBlockedText(input.subject.kind, terms)
-  assertNoBlockedText(input.subject.name, terms)
-  for (const claim of input.claims) {
-    assertNoBlockedText(claim.id, terms)
-    assertNoBlockedText(claim.text, terms)
+  assertNoBlockedText(input.subject.kind, terms, 'subject.kind')
+  assertNoBlockedText(input.subject.name, terms, 'subject.name')
+  // Located by position, not by id: a claim id that is itself blocked would put
+  // the protected identifier straight into the error message.
+  for (const [index, claim] of input.claims.entries()) {
+    assertNoBlockedText(claim.id, terms, `claim ${index + 1} id`)
+    assertNoBlockedText(claim.text, terms, `claim ${index + 1} text`)
   }
 }
 

--- a/tests/unit/commands/evidence-blacklist.test.ts
+++ b/tests/unit/commands/evidence-blacklist.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { blockedTerms, containsBlockedTerm } from '@/commands/evidence'
+
+describe('evidence blacklist matching', () => {
+  // Terms were matched as unbounded substrings, so a blacklisted column named
+  // `id` blocked any claim containing "identifier", "considered", or "valid" —
+  // and the error named no term, so the author could not tell why.
+  test.each([
+    ['identifier', 'id'],
+    ['considered', 'id'],
+    ['pending', 'end'],
+    ['keyword', 'key'],
+    ['nonuser', 'user'],
+    ['username', 'user'],
+  ])('does not block the prose word %s for the term %s', (prose, term) => {
+    expect(containsBlockedTerm(`The ${prose} was reviewed.`, [term])).toBe(false)
+  })
+
+  test.each([
+    ['The id was reviewed.', 'id'],
+    ['Rows in orders.id were counted.', 'id'],
+    ['The secret_customer table was excluded.', 'secret_customer'],
+    ['Checked ID casing.', 'id'],
+    ['Values in "user" were masked.', 'user'],
+  ])('blocks %s for the term %s', (prose, term) => {
+    expect(containsBlockedTerm(prose, [term])).toBe(true)
+  })
+
+  test('treats a term with regex metacharacters literally', () => {
+    expect(containsBlockedTerm('The a.c column was read.', ['a.c'])).toBe(true)
+    expect(containsBlockedTerm('The abc column was read.', ['a.c'])).toBe(false)
+  })
+
+  test('ignores an empty or whitespace-only term', () => {
+    expect(containsBlockedTerm('Anything at all.', ['', '   '])).toBe(false)
+  })
+
+  // The keys of blacklist.columns are table names. They were never added to the
+  // term list, so a table protected only through a column entry was not blocked
+  // when it appeared in prose.
+  test('collects table names from both the tables list and the columns map keys', () => {
+    const terms = blockedTerms({
+      blacklist: { tables: ['audit_log'], columns: { secret_customers: ['ssn'] } },
+    })
+    expect(terms).toContain('audit_log')
+    expect(terms).toContain('secret_customers')
+    expect(terms).toContain('ssn')
+  })
+
+  test('lowercases and trims collected terms', () => {
+    expect(blockedTerms({ blacklist: { tables: ['  Audit_Log  '], columns: {} } })).toEqual([
+      'audit_log',
+    ])
+  })
+
+  test('collects nothing when no blacklist is configured', () => {
+    expect(blockedTerms({})).toEqual([])
+  })
+})


### PR DESCRIPTION
> ADR-0011 四個 deviation 的第二個（第一個是 #116）。

## 問題

`blockedTerms` 收集到的詞彙用 `includes()` 比對，沒有邊界也沒有長度下限。黑名單裡有一個叫 `id` 的欄位，任何含 "identifier"、"considered"、"valid" 的 claim 都會被拒絕。錯誤訊息是一句 `evidence content contains a blocked identifier`——不說哪個欄位，更不說撞到什麼，作者拿到一個拒絕和零線索。

還有一個沉默的反向漏洞：`blacklist.columns` 的 key 是資料表名，從來沒被收進詞彙表。只透過 column 條目保護的資料表，在散文裡完全不會被擋。

## 修法

**比對改成識別字邊界**。前後若是字母、數字或底線，代表它屬於一個更長的識別字，不算命中；點號、引號、空白、標點則是邊界。所以 `id` 會命中 `orders.id` 和單獨的 `id`，不會命中 `identifier`。詞彙中的正則 metacharacter 逐字轉義，`a.c` 不再匹配 `abc`。

**補上 columns map 的 key**。

**錯誤訊息指出欄位**（`subject.kind`、`claim 2 text`），依然不說撞到哪個詞——把受保護的識別字印進使用者可能貼給別人的錯誤訊息，正是黑名單要防的事。claim 用序號而非 id 定位，因為 id 本身就可能是被擋的那個字串。

## 沒有修的，照實說

`secret_customer` 寫成 "secret customer" 仍然逃得掉。對自由散文做識別字比對沒辦法誠實承諾攔得住這個，註解裡寫明了，沒有假裝。

references 欄位（audit 的 `command`、receipt 的 `path`）目前不經黑名單檢查，而 receipt path 可以帶到資料表名。這是同一份稽核記下的另一個洞，範圍不同，**沒有在這個 PR 修**，在此揭露而不是默默略過。

`validate` 與 `render` 以當下的黑名單重新檢查、使既存 pack 可能事後變成不可 render——這個行為是刻意的，有測試明確覆蓋：黑名單新增之後就不該再渲染一份會揭露該識別字的 pack。真正的問題是誤判讓它動輒觸發，那才是這次修的。

## Test plan

測試先寫、確認 RED 再實作。

- 新增 16 條測試：六組散文詞不再被誤擋（identifier/considered/pending/keyword/nonuser/username）、五組真正的識別字仍然被擋（含 `orders.id`、大小寫、引號包住的 `"user"`）、metacharacter 逐字處理、空詞彙忽略、columns map 的 key 與 value 都收進詞彙表、trim 與小寫、無黑名單時為空
- `bun test` — 5545 pass / 27 skip / 0 fail（511 檔）
- `typecheck`、`lint`、`prettier`、`skill:check`、`docs:check`、`platform:check`、`plugin:check`、`plan:check` — 全綠

`reference.md` 補上這條規則的說明並同步六份 plugin/skill 複本。ADR-0012 新增 Repair status 一節追蹤四個 deviation，因為其中兩個不對應任何驗收條件，backlog 裡沒有它們的位置。