### PR TITLE
fix: [ evidence-receipt ] 沒加鹽的 fingerprint 藏不住東西，只擋住讀的人

### DIFF
--- a/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
+++ b/docs/adr/0012-known-defects-get-fixed-whether-or-not-anyone-is-using-the-code.md
@@ -56,7 +56,9 @@ they are tracked here.
 - Blacklist substring matching over prose — repaired 2026-08-16; terms match as
   identifiers, the columns map's keys are included, and the refusal names the
   field rather than the term.
-- `observation.fingerprint` unsalted over a low-entropy value — open.
+- `observation.fingerprint` unsalted over a low-entropy value — repaired
+  2026-08-16; the field is replaced by the observation stated plainly, which is
+  less than the digest leaked to anyone who inverted it.
 
 ## Consequences
 

--- a/src/core/evidence-receipt/index.ts
+++ b/src/core/evidence-receipt/index.ts
@@ -30,7 +30,19 @@ export interface EvidenceReceipt {
     verificationArtifactRef: string | null
   }
   replay: { status: 'context-required' }
-  observation: { kind: 'assert-verdict' | 'verify-outcome'; fingerprint: string }
+  /**
+   * What was observed, stated rather than hashed.
+   *
+   * This was an unsalted SHA-256 over the same values: eight possible preimages
+   * for a verify outcome, and 2^(n+1) for an assert with n checks. It hid
+   * nothing a dictionary could not recover, while being deterministic enough to
+   * link two receipts by their result. The counts below reveal how many checks
+   * failed but never which, which is less than the digest leaked to anyone who
+   * bothered to invert it.
+   */
+  observation:
+    | { kind: 'assert-verdict'; checksPassed: number; checksTotal: number }
+    | { kind: 'verify-outcome'; status: VerificationStatus }
 }
 
 interface BuildEvidenceReceiptBase {
@@ -151,7 +163,11 @@ function sha256(value: string): string {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`
 }
 
-function verdictFingerprint(verdict: AssertVerdictBits): string {
+function verdictObservation(verdict: AssertVerdictBits): {
+  kind: 'assert-verdict'
+  checksPassed: number
+  checksTotal: number
+} {
   if (
     !record(verdict) ||
     typeof verdict.pass !== 'boolean' ||
@@ -170,20 +186,24 @@ function verdictFingerprint(verdict: AssertVerdictBits): string {
     }
     return check.pass
   })
-  return sha256(JSON.stringify({ pass: verdict.pass, checks: bits }))
+  return {
+    kind: 'assert-verdict',
+    checksPassed: bits.filter(Boolean).length,
+    checksTotal: bits.length,
+  }
 }
 
-function verificationOutcomeFingerprint(
+function verificationObservation(
   status: VerificationStatus,
   artifactPersisted: boolean
-): string {
+): { kind: 'verify-outcome'; status: VerificationStatus } {
   if (!isVerificationStatus(status)) {
     throw new EvidenceReceiptValidationError('verificationStatus must be a verification status')
   }
   if (typeof artifactPersisted !== 'boolean') {
     throw new EvidenceReceiptValidationError('verificationArtifactPersisted must be a boolean')
   }
-  return sha256(JSON.stringify({ status, artifactPersisted }))
+  return { kind: 'verify-outcome', status }
 }
 
 export function buildEvidenceReceipt(
@@ -193,10 +213,10 @@ export function buildEvidenceReceipt(
   const operation: EvidenceReceipt['operation'] = input.operation === 'verify' ? 'verify' : 'assert'
   const command = canonicalizeEvidenceReceiptCommand(input.command, operation)
   const context = parseContext(input.context)
-  const { observationFingerprint, outcome } =
+  const { observation, outcome } =
     input.operation === 'verify'
       ? {
-          observationFingerprint: verificationOutcomeFingerprint(
+          observation: verificationObservation(
             input.verificationStatus,
             input.verificationArtifactPersisted
           ),
@@ -206,7 +226,7 @@ export function buildEvidenceReceipt(
               : ('failed' as const),
         }
       : {
-          observationFingerprint: verdictFingerprint(input.verdict),
+          observation: verdictObservation(input.verdict),
           outcome: input.verdict.pass ? ('succeeded' as const) : ('failed' as const),
         }
   const receipt: EvidenceReceipt = {
@@ -226,10 +246,7 @@ export function buildEvidenceReceipt(
           : nullableId(input.verificationArtifactRef, 'verificationArtifactRef'),
     },
     replay: { status: 'context-required' },
-    observation: {
-      kind: operation === 'assert' ? 'assert-verdict' : 'verify-outcome',
-      fingerprint: observationFingerprint,
-    },
+    observation,
   }
   return receipt
 }
@@ -299,14 +316,7 @@ export function parseEvidenceReceipt(raw: unknown): EvidenceReceipt {
     Object.keys(raw.replay).length !== 1
   )
     throw new EvidenceReceiptValidationError('replay must be context-required')
-  if (
-    !record(raw.observation) ||
-    raw.observation.kind !== (operation === 'assert' ? 'assert-verdict' : 'verify-outcome') ||
-    Object.keys(raw.observation).length !== 2
-  )
-    throw new EvidenceReceiptValidationError('observation must match receipt operation')
-  const observationKind: EvidenceReceipt['observation']['kind'] =
-    operation === 'assert' ? 'assert-verdict' : 'verify-outcome'
+  const observation = parseObservation(raw.observation, operation)
   return {
     version: EVIDENCE_RECEIPT_VERSION,
     id: safeId(raw.id, 'id'),
@@ -324,10 +334,35 @@ export function parseEvidenceReceipt(raw: unknown): EvidenceReceipt {
       ),
     },
     replay: { status: 'context-required' },
-    observation: {
-      kind: observationKind,
-      fingerprint: fingerprint(raw.observation.fingerprint, 'observation.fingerprint'),
-    },
+    observation,
+  }
+}
+
+function parseObservation(
+  raw: unknown,
+  operation: EvidenceReceipt['operation']
+): EvidenceReceipt['observation'] {
+  if (!record(raw)) throw new EvidenceReceiptValidationError('observation must be an object')
+  if (operation === 'verify') {
+    exact(raw, ['kind', 'status'], 'observation')
+    if (raw.kind !== 'verify-outcome' || !isVerificationStatus(raw.status))
+      throw new EvidenceReceiptValidationError('observation must match receipt operation')
+    return { kind: 'verify-outcome', status: raw.status }
+  }
+  exact(raw, ['kind', 'checksPassed', 'checksTotal'], 'observation')
+  const { kind, checksPassed, checksTotal } = raw
+  if (
+    kind !== 'assert-verdict' ||
+    !Number.isSafeInteger(checksPassed) ||
+    !Number.isSafeInteger(checksTotal) ||
+    (checksPassed as number) < 0 ||
+    (checksTotal as number) < (checksPassed as number)
+  )
+    throw new EvidenceReceiptValidationError('observation must match receipt operation')
+  return {
+    kind: 'assert-verdict',
+    checksPassed: checksPassed as number,
+    checksTotal: checksTotal as number,
   }
 }
 

--- a/tests/unit/commands/verify-receipt.test.ts
+++ b/tests/unit/commands/verify-receipt.test.ts
@@ -75,13 +75,15 @@ describe('verify evidence receipt lifecycle boundary', () => {
         expect(JSON.stringify(receipt)).not.toContain('secret')
         receipts.push({ status, receipt })
       }
-      expect(
-        new Set(
-          receipts.map(
-            ({ receipt }) => (receipt.observation as { fingerprint: string }).fingerprint
-          )
-        ).size
-      ).toBe(4)
+      // Asserted through the typed field rather than a cast: the previous
+      // version reached into `observation` as `{ fingerprint: string }`, so a
+      // change to the shape left it comparing four undefined values.
+      expect(receipts.map(({ receipt }) => receipt.observation)).toEqual([
+        { kind: 'verify-outcome', status: 'verified' },
+        { kind: 'verify-outcome', status: 'not_verified' },
+        { kind: 'verify-outcome', status: 'indeterminate' },
+        { kind: 'verify-outcome', status: 'blocked' },
+      ])
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
+++ b/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
@@ -60,7 +60,12 @@ describe('evidence receipt', () => {
       'failed',
       'failed',
     ])
-    expect(new Set(receipts.map((receipt) => receipt.observation.fingerprint)).size).toBe(4)
+    expect(receipts.map((receipt) => receipt.observation)).toEqual([
+      { kind: 'verify-outcome', status: 'verified' },
+      { kind: 'verify-outcome', status: 'not_verified' },
+      { kind: 'verify-outcome', status: 'indeterminate' },
+      { kind: 'verify-outcome', status: 'blocked' },
+    ])
     for (const receipt of receipts) {
       expect(receipt.operation).toBe('verify')
       expect(receipt.observation.kind).toBe('verify-outcome')
@@ -97,6 +102,74 @@ describe('evidence receipt', () => {
     } finally {
       await rm(workspace, { recursive: true, force: true })
     }
+  })
+
+  // observation.fingerprint was an unsalted SHA-256 over a value with eight
+  // possible preimages for verify, and 2^(n+1) for an assert with n checks. It
+  // hid nothing a dictionary could not recover in milliseconds, while its
+  // determinism let two receipts be linked by their outcome. What it covered is
+  // now stated plainly, which is strictly less than an attacker could already
+  // read out of the hash.
+  test('states the assert verdict as counts rather than a breakable digest', () => {
+    const receipt = buildEvidenceReceipt({
+      command: 'dbcli assert <sql>',
+      context,
+      verdict: { pass: false, checks: [{ pass: true }, { pass: false }, { pass: true }] },
+    })
+    expect(receipt.observation).toEqual({
+      kind: 'assert-verdict',
+      checksPassed: 2,
+      checksTotal: 3,
+    })
+    expect(parseEvidenceReceipt(receipt)).toEqual(receipt)
+  })
+
+  test('does not reveal which check failed', () => {
+    const first = buildEvidenceReceipt({
+      command: 'dbcli assert <sql>',
+      context,
+      verdict: { pass: false, checks: [{ pass: false }, { pass: true }] },
+    })
+    const second = buildEvidenceReceipt({
+      command: 'dbcli assert <sql>',
+      context,
+      verdict: { pass: false, checks: [{ pass: true }, { pass: false }] },
+    })
+    expect(second.observation).toEqual(first.observation)
+  })
+
+  test('carries no fingerprint field at all', () => {
+    const receipt = buildEvidenceReceipt({
+      command: 'dbcli assert <sql>',
+      context,
+      verdict: { pass: true, checks: [{ pass: true }] },
+    })
+    expect(receipt.observation).not.toHaveProperty('fingerprint')
+    expect(JSON.stringify(receipt)).not.toContain('fingerprint')
+  })
+
+  test('rejects a receipt still carrying the removed fingerprint', () => {
+    const receipt = buildEvidenceReceipt({
+      command: 'dbcli assert <sql>',
+      context,
+      verdict: { pass: true, checks: [{ pass: true }] },
+    })
+    expect(() =>
+      parseEvidenceReceipt({
+        ...receipt,
+        observation: { kind: 'assert-verdict', fingerprint: `sha256:${'a'.repeat(64)}` },
+      })
+    ).toThrow(/observation/)
+  })
+
+  test('still rejects a verdict whose checks carry more than a pass bit', () => {
+    expect(() =>
+      buildEvidenceReceipt({
+        command: 'dbcli assert <sql>',
+        context,
+        verdict: { pass: true, checks: [{ pass: true, value: 42 }] },
+      })
+    ).toThrow(/pass bits/)
   })
 
   test('rejects a symlinked output ancestor that resolves outside the workspace', async () => {

--- a/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
+++ b/tests/unit/core/evidence-receipt/evidence-receipt.test.ts
@@ -167,7 +167,10 @@ describe('evidence receipt', () => {
       buildEvidenceReceipt({
         command: 'dbcli assert <sql>',
         context,
-        verdict: { pass: true, checks: [{ pass: true, value: 42 }] },
+        verdict: {
+          pass: true,
+          checks: [{ pass: true, value: 42 } as unknown as { pass: boolean }],
+        },
       })
     ).toThrow(/pass bits/)
   })


### PR DESCRIPTION
> ADR-0011 四個 deviation 的第三個（前兩個是 #116、#117）。

## 問題

`observation.fingerprint` 是對低熵值取的未加鹽 SHA-256：

| 操作 | 原像空間 |
|---|---|
| verify | **8 種**（4 個 `VerificationStatus` × `artifactPersisted` 布林） |
| assert | 2^(n+1)，n = check 數 |

序列化格式固定且公開，攻擊者不必猜格式。verify 這側字典攻擊是毫秒級。

更關鍵的是：**它涵蓋的值本來就以明文出現在 `outcome` 裡**。所以它唯一「多保護」的東西是 per-check 的 pass bit pattern——正好是最容易被窮舉的那部分。它確實擋住了一種人，就是老實讀 JSON 的人。

還有一個順帶的性質：fingerprint 是決定性的，同一組結果在不同 receipt 產生相同雜湊，可以用來跨 receipt 分群。原本的測試斷言「四個不同輸入得到四個相異 fingerprint」——測的正是使字典攻擊成立的那個性質。

## 修法

把觀察結果直接寫出來，不再假裝雜湊藏得住：

- verify → `{ kind: 'verify-outcome', status }`
- assert → `{ kind: 'assert-verdict', checksPassed, checksTotal }`

assert 這側**報數量不報位置**，所以「哪一條 check 失敗」仍然不外洩。這比原本的 digest 洩漏得更少——只要有人去反解，原本連完整 bit pattern 都拿得到。

`parseObservation` 依 operation 分別驗證欄位形狀，並檢查 `checksPassed <= checksTotal`。

## 一個測試的隱患

`tests/unit/commands/verify-receipt.test.ts` 用 `as { fingerprint: string }` 強制轉型讀 `observation`，所以我改型別時 **typecheck 沒有攔到它**——它安靜地變成比較四個 `undefined`，Set 大小 1，只在執行時才炸。改成透過型別欄位斷言，並在註解記下為什麼不用轉型。

## Test plan

測試先寫、確認 RED（5 fail）再實作。

- 新增 5 條：assert 以數量表述、不揭露哪一條 check 失敗（兩個 pass 位置相反的 verdict 產生相同 observation）、完全沒有 fingerprint 欄位、帶著已移除的 fingerprint 會被拒、仍然拒絕 check 夾帶 pass 以外的欄位
- 改寫 2 條原本斷言 fingerprint 相異的測試，改為斷言四個 status 各自可辨
- `bun test` — 5550 pass / 27 skip / 0 fail（511 檔）
- `typecheck`、`lint`、`prettier` — 全綠

`assets/reference.md` 沒有提到 `observation`，無需同步文件。ADR-0012 的 Repair status 更新為三個已修、一個待修。

## 剩下的

`impact` 的 `coverage.level === 'declared'` 結構不可達，下一個 PR。