### PR TITLE
chore: [ release ] 4.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,10 +13,11 @@ support branch and none is promised: an older major is fixed by upgrading.
 
 | Version | Status |
 | ------- | ------ |
-| **3.x** | :white_check_mark: **Supported** — use the latest 3.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
-| **2.x** | :x: **Not supported** — superseded by 3.x; upgrade to **3.x**. |
-| **1.x** | :x: **Not supported** — superseded by 3.x; upgrade to **3.x**. |
-| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **3.x**. |
+| **4.x** | :white_check_mark: **Supported** — use the latest 4.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
+| **3.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
+| **2.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
+| **1.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
+| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **4.x**. |
 
 The supported major above is checked against `package.json` by
 `bun run manifest:check`, so this table cannot silently fall behind a release.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -19,6 +19,9 @@ bun run agent-core:check
 
 step '4/9 typecheck'
 bun run typecheck
+# CI typechecks the test tree as its own step; a release:check that skips it is
+# not the superset of CI it is used as.
+bun run typecheck:tests
 
 step '5/9 lint'
 bun run lint

--- a/tests/unit/scripts/plugin-manifest-contract.test.ts
+++ b/tests/unit/scripts/plugin-manifest-contract.test.ts
@@ -63,6 +63,20 @@ function patchJson(dir: string, path: string, mutate: (value: Record<string, unk
   writeFileSync(join(dir, path), `${JSON.stringify(value, null, 2)}\n`)
 }
 
+/**
+ * A version, and a major, that the repository is guaranteed not to be on.
+ * Writing today's numbers in as the "drifted" value is how these two tests
+ * silently stopped testing anything the moment the package reached them.
+ */
+const PACKAGE_MAJOR = Number(
+  (
+    JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as { version: string }
+  ).version.split('.')[0]
+)
+/** Same major, so SECURITY.md stays valid and only the manifest check can fire. */
+const OTHER_VERSION = `${PACKAGE_MAJOR}.999.0`
+const OTHER_MAJOR = PACKAGE_MAJOR + 1
+
 afterEach(() => {
   for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true })
 })
@@ -89,9 +103,12 @@ describe('plugin manifest drift guard', () => {
   test('fails when package.json moves and the manifests do not', () => {
     const dir = scratchRepo()
     patchJson(dir, 'package.json', (value) => {
-      value.version = '4.0.0'
+      value.version = OTHER_VERSION
     })
-    expect(runCheck(dir).code).toBe(1)
+    const { code, output } = runCheck(dir)
+    expect(code).toBe(1)
+    expect(output).toContain(OTHER_VERSION)
+    expect(output).toContain(MANIFESTS[0])
   })
 
   test('--write realigns the versions and the check then passes', () => {
@@ -142,10 +159,10 @@ describe('plugin manifest drift guard', () => {
 
   test('fails when SECURITY.md supports a major the package has left behind', () => {
     const dir = scratchRepo()
-    const security = readFileSync(join(dir, 'SECURITY.md'), 'utf8').replace(
-      '| **3.x** | :white_check_mark:',
-      '| **1.x** | :white_check_mark:'
-    )
+    const current = readFileSync(join(dir, 'SECURITY.md'), 'utf8')
+    const supported = new RegExp(`\\| \\*\\*${PACKAGE_MAJOR}\\.x\\*\\* \\| :white_check_mark:`)
+    expect(current).toMatch(supported)
+    const security = current.replace(supported, `| **${OTHER_MAJOR}.x** | :white_check_mark:`)
     writeFileSync(join(dir, 'SECURITY.md'), security)
     const { code, output } = runCheck(dir)
     expect(code).toBe(1)

--- a/tests/unit/scripts/plugin-manifest-contract.test.ts
+++ b/tests/unit/scripts/plugin-manifest-contract.test.ts
@@ -76,6 +76,7 @@ const PACKAGE_MAJOR = Number(
 /** Same major, so SECURITY.md stays valid and only the manifest check can fire. */
 const OTHER_VERSION = `${PACKAGE_MAJOR}.999.0`
 const OTHER_MAJOR = PACKAGE_MAJOR + 1
+const FIRST_MANIFEST = MANIFESTS[0]!
 
 afterEach(() => {
   for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true })
@@ -108,7 +109,7 @@ describe('plugin manifest drift guard', () => {
     const { code, output } = runCheck(dir)
     expect(code).toBe(1)
     expect(output).toContain(OTHER_VERSION)
-    expect(output).toContain(MANIFESTS[0])
+    expect(output).toContain(FIRST_MANIFEST)
   })
 
   test('--write realigns the versions and the check then passes', () => {


### PR DESCRIPTION
`main` 上已經有 #120、#121、#122 的內容與折好的 `## [4.0.0]` changelog 段落，缺的是版本號本身。

## bump 的三件事必須同一個 commit

`package.json` 3.0.0 → 4.0.0、六份 manifest 由 `manifest:sync` 對齊、`SECURITY.md` 的 supported major 改為 `4.x`。#120 新增的 `manifest:check` 以 `package.json` 為唯一來源，同時比對 manifest 版本與 `SECURITY.md` 的 major——任一邊單獨動都會讓 CI 紅。`3.x` 一併降為不支援，不發明不存在的 backport 承諾。

## 為什麼是 major

三條分支各自帶著 BREAKING：

- **#120** evidence pack 與 receipt 的格式升到 `version: 2`（2.x 與 3.0.0 寫出的 artifact 都不再是 current-valid）
- **#121** `@carllee1983/dbcli/core` 不再匯出 `AdapterFactory`（public API 移除）；ES shell 開始套用連線的 permission 等級；shell 的退出碼改為非零（依賴它一律成功的 CI 步驟會開始紅）
- **#122** Redis 的 `insert`／`update`／`delete` 開始套 glob 黑名單（先前能刪改這些 key 的腳本會被擋）

原本 #121 寫的是 `[3.0.1]`，那個號碼在三則 BREAKING 之下站不住。

## 一併修掉的測試缺陷

`tests/unit/scripts/plugin-manifest-contract.test.ts` 有兩則契約測試在這次 bump 底下**轉綠**——不是守衛壞了，是它們要製造的「漂移」已經成為現況：一則把 `package.json` 改寫成 `4.0.0`（現在正是 4.0.0），另一則把 `SECURITY.md` 的 `3.x` 換成 `1.x`（supported 那列現在是 `4.x`，字串對不上，`replace` 沒有作用）。兩處改為從 `package.json` 推導。

漂移版本刻意用**同一個 major** 的 `N.999.0`：先前試寫成 `N+1.0.0` 時，package.json 那則會連帶觸發 SECURITY.md 的檢查，於是把版本比對整個拔掉它照樣綠——測到的是別道關卡。順帶把只斷言退出碼的那則補上輸出斷言。

## release:check 少一格

第一次推上去 CI 十二格全紅，是 `MANIFESTS[0]` 在 `noUncheckedIndexedAccess` 下為 `string | undefined`、`toContain` 不收——一個本機應該擋下來的型別錯誤。它沒被擋下來，是因為 `release-check.sh` 只跑 `typecheck`，**不跑 `typecheck:tests`**，而 CI 把測試樹當成獨立一步。一個被當成 CI 超集使用、實際上少一格的腳本，比沒有腳本更容易讓人放行。`typecheck:tests` 已補進 `release-check.sh` 的第 4 步。

## 測試計畫

- `bun run release:check` 本機通過（含 `bun test` 6026 tests / 0 fail、`manifest:check`、`build:determinism`、`bun audit`、`✓ CHANGELOG.md has ## [4.0.0] heading`）
- 兩則契約測試都**驗過會轉紅**：分別停用 `check-plugin-manifests.ts` 的版本比對與 SECURITY.md 比對，確認對應測試轉紅後還原
- **未執行**：`test:docker`——本機沒有 Docker，那 27 個 skip 裡的資料庫 integration 測試是跳過的，會在 CI 的 `integration` job 以 `REQUIRE_INTEGRATION_SERVICES=true` 真正執行

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B
