### PR TITLE
fix: [ shell ] 拒絕訊息說要求的等級是使用者已經持有的那個

### DIFF
--- a/docs/specs/2026-08-30-cross-engine-blacklist-gaps.md
+++ b/docs/specs/2026-08-30-cross-engine-blacklist-gaps.md
@@ -126,9 +126,42 @@ blacklist 走 tokenizer（`query-executor.ts:133`），audit 走單一名稱推�
 return true`。也就是在 shell 打的 SELECT 與 tier-one 的 UPDATE／DELETE／INSERT
 完全沒有稽核列。
 
-**注意**：這是純讀碼結論，未端到端跑過互動 shell。ES shell 這側已經每個請求
-兩列（attempt / outcome），SQL shell 這側是這個狀態——落差很大，值得先端到端
-確認再動手。
+**已端到端驗證（2026-08-31，本機 MariaDB 10.11，`read-write` 連線，每次先清空
+audit）。結論成立，而且比讀碼看到的更嚴重。**
+
+| 路徑 | 執行結果 | 稽核列 |
+| --- | --- | --- |
+| `dbcli query "SELECT …"` | 回 2 列 | 1 |
+| shell `SELECT …` | 回 2 列 | **0** |
+| shell `UPDATE … WHERE id=2` | **實際改動了資料** | **0** |
+| shell `DELETE FROM …`（無 WHERE） | 被權限擋下 | **0** |
+| shell `UPDATE …`（無 WHERE） | 被寫入閘門拒絕 | 1 |
+
+一次真正生效的資料修改走完全程、改掉了資料，稽核裡沒有任何一列。
+
+**讀碼沒看出來的兩件事：**
+
+1. **tier-two 的覆蓋本身有缺口。** 無 WHERE 的 `DELETE` 在 `read-write` 下由
+   `repl-engine.ts` 的權限檢查擋下，發生在 `createShellWriteGate` 之前，所以
+   連唯一會寫的那種決策列也沒有。tier-two「有覆蓋」只在「權限放行、閘門拒絕」
+   這一種組合下成立。
+
+2. **拒絕訊息說要求已被滿足。**（已修，見下）
+
+### 11b. [已修] shell 的權限拒絕訊息寫死了 `required`
+
+`repl-engine.ts` 的 SQL 分支把 `required` 算成
+`classification.type === 'UNKNOWN' ? 'admin' : 'read-write'`——一個猜測，不是
+`checkPermission` 實際判定的等級。於是 `read-write` 使用者刪整張表會讀到
+`Permission denied. Required: read-write (current: read-write)`：一則宣稱自己
+的要求已被滿足的拒絕。實際需要的是 `data-admin`（`TIER_GRANTS`）。
+
+`permission-guard.ts` 的 `minimumPermissionFor` 註解記載這一類錯誤已在其他
+呼叫端修過（「Refusals used to name whichever tier sat one step above the one
+refusing」），shell 的 SQL 這處是漏掉的一站。同檔案的 Redis 分支
+（`checkRedisPermission`）本來就是對的，用 `cls.requiredPermission`。
+
+改為 `permResult.requiredPermission ?? 'admin'`。
 
 ### 12. `redactSql` 的界線沒寫下來（非缺陷）
 

--- a/src/core/repl/repl-engine.ts
+++ b/src/core/repl/repl-engine.ts
@@ -284,7 +284,11 @@ export class ReplEngine {
           action: 'continue',
           output: pc.red(
             t_vars('shell.error_permission', {
-              required: permResult.classification.type === 'UNKNOWN' ? 'admin' : 'read-write',
+              // checkPermission already derives the lowest level that grants
+              // this statement, from the same table the decision uses. Guessing
+              // here instead told a read-write user that DELETE "Required:
+              // read-write" — a refusal whose stated requirement was already met.
+              required: permResult.requiredPermission ?? 'admin',
               current: this.context.permission,
             })
           ),

--- a/tests/core/repl/repl-engine.test.ts
+++ b/tests/core/repl/repl-engine.test.ts
@@ -299,6 +299,19 @@ describe('ReplEngine', () => {
     expect(result.output).toBeDefined()
   })
 
+  test('a refusal names the level that would have worked, not the one already held', async () => {
+    // `required` was a hardcoded guess — 'admin' for UNKNOWN, 'read-write' for
+    // everything else — so a read-write user deleting a table read
+    // "Required: read-write (current: read-write)": a refusal stating its own
+    // requirement was already met. DELETE is granted by data-admin
+    // (permission-guard TIER_GRANTS), and that is what the line has to say.
+    const ctx: ReplContext = { ...mockContext, permission: 'read-write' }
+    const engine = new ReplEngine(createMockAdapter(), ctx, historyPath)
+    const result = await engine.processInput('DELETE FROM users;')
+    expect(result.output ?? '').toContain('data-admin')
+    expect(result.output ?? '').not.toMatch(/Required: read-write/)
+  })
+
   test('state updates from meta commands persist', async () => {
     const adapter = createMockAdapter()
     const engine = new ReplEngine(adapter, mockContext, historyPath)


### PR DESCRIPTION
起因是去端到端驗證 `docs/specs/2026-08-30-cross-engine-blacklist-gaps.md` 的 audit 第 11 則——規格自己註明那是純讀碼結論、「值得先端到端確認再動手」。驗證過程撞見一個獨立的缺陷，這條 PR 修它，並把驗證結果寫回規格。

## 修的是什麼

`src/core/repl/repl-engine.ts` 的 SQL 分支把拒絕訊息的 `required` 算成 `classification.type === 'UNKNOWN' ? 'admin' : 'read-write'`——一個猜測，不是 `checkPermission` 實際判定的等級。於是 `read-write` 使用者刪整張表會讀到：

```
Permission denied. Required: read-write (current: read-write)
```

一則宣稱自己的要求已被滿足的拒絕。實際需要的是 `data-admin`（`permission-guard.ts` 的 `TIER_GRANTS`）。照著這行字去查的操作者查不出所以然。

改為 `permResult.requiredPermission ?? 'admin'`，輸出變成 `Required: data-admin (current: read-write)`。

值得記的是這不是新缺陷：`minimumPermissionFor` 的註解明寫這一類錯誤已在其他呼叫端修過（「Refusals used to name whichever tier sat one step above the one refusing」），shell 的 SQL 這處是漏掉的一站。同檔案的 Redis 分支（`checkRedisPermission`）本來就用 `cls.requiredPermission`，不受影響。

## 一併寫回規格的驗證結果

第 11 則成立，而且比讀碼看到的更嚴重。本機 MariaDB 10.11、`read-write` 連線、每次先清空 audit：

| 路徑 | 執行結果 | 稽核列 |
| --- | --- | --- |
| `dbcli query "SELECT …"` | 回 2 列 | 1 |
| shell `SELECT …` | 回 2 列 | **0** |
| shell `UPDATE … WHERE id=2` | **實際改動了資料** | **0** |
| shell `DELETE FROM …`（無 WHERE） | 被權限擋下 | **0** |
| shell `UPDATE …`（無 WHERE） | 被寫入閘門拒絕 | 1 |

一次真正生效的資料修改走完全程、改掉了資料，稽核裡沒有任何一列。

讀碼沒看出來的是：無 WHERE 的 `DELETE` 在 `read-write` 下由權限檢查擋下，發生在 `createShellWriteGate` 之前，所以連唯一會寫的那種決策列也沒有。tier-two「有覆蓋」只在「權限放行、閘門拒絕」這一種組合下成立。

## 第 11 則的本體不在這條 PR 裡

讓 shell 為每一句語句寫稽核列是行為與輸出格式的改變（ES shell 那側是 attempt / outcome 兩列），該先有 ADR 再動手，不該夾在一個訊息修補裡默默補上。規格的狀態欄已標明哪些修了、哪些沒有。

## 測試計畫

- 新測試先驗過紅：斷言收到 `Required: read-write (current: read-write)` 之後才動實作
- 修完在本機 MariaDB 的真實 shell 複驗，輸出 `Required: data-admin (current: read-write)`
- `bun test` 6000 pass / 27 skip / 0 fail；`typecheck`、`typecheck:tests`、`lint`、`format:check`、`docs:check` 皆過
- **未執行**：`test:docker`——本機沒有 Docker，那 27 個 skip 裡的資料庫 integration 測試會在 CI 的 `integration` job 真正執行

驗證用的沙盒只在本機 MariaDB 的 `test` schema 建過一張探測表，已 DROP。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B