### PR TITLE
chore: [ release ] 5.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,11 +13,12 @@ support branch and none is promised: an older major is fixed by upgrading.
 
 | Version | Status |
 | ------- | ------ |
-| **4.x** | :white_check_mark: **Supported** — use the latest 4.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
-| **3.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
-| **2.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
-| **1.x** | :x: **Not supported** — superseded by 4.x; upgrade to **4.x**. |
-| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **4.x**. |
+| **5.x** | :white_check_mark: **Supported** — use the latest 5.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
+| **4.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
+| **3.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
+| **2.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
+| **1.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
+| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **5.x**. |
 
 The supported major above is checked against `package.json` by
 `bun run manifest:check`, so this table cannot silently fall behind a release.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",


### PR DESCRIPTION
`main` 上已經有 #124、#125 的內容與 `## [5.0.0]` changelog 段落，缺的是版本號本身。

## bump 的三件事必須同一個 commit

`package.json` 4.0.0 → 5.0.0、六份 manifest 由 `manifest:sync` 對齊、`SECURITY.md` 的 supported major 改為 `5.x`。`manifest:check` 以 `package.json` 為唯一來源，同時比對 manifest 版本與 `SECURITY.md` 的 major——任一邊單獨動都會讓 CI 紅。`4.x` 一併降為不支援，不發明不存在的 backport 承諾。

## 為什麼是 major

`metadata.es_shell_phase` 改名為 `metadata.shell_phase`（#125）。那是 4.0.0 已發布的 audit 欄位，任何在解析它的下游都會斷。改名是 ADR-0016 Decision 2 的直接後果：兩個鍵名正好是「讀 audit 的人要先知道一列是哪個引擎產生的」那件事。

同一版還有兩個行為改變，都不是破壞性的，但值得在升級前知道：SQL shell 現在為每一句語句寫稽核列（含讀取，每句兩列），而 `audit.strict: true` 因此也涵蓋讀取——送出前那一列寫不出去就拒絕執行。`strict` 預設是關的。

## 測試計畫

- `bun run release:check` 通過（含 `bun test` 6036 tests / 0 fail、`typecheck:tests`、`manifest:check`、`build:determinism`、`bun audit`、`✓ CHANGELOG.md has ## [5.0.0] heading`）
- **未執行**：`test:docker`——本機沒有 Docker，那 27 個 skip 裡的資料庫 integration 測試會在 CI 的 `integration` job 真正執行

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B