### PR TITLE
chore: [ release ] 5.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 一次被黑名單擋下的查詢，紀錄裡指向的是沒被擋的那張表
+## [5.1.0] - 2026-08-31 - 一次被黑名單擋下的查詢，紀錄裡指向的是沒被擋的那張表
 
 `docs/specs/2026-08-30-cross-engine-blacklist-gaps.md` 的 audit 第 10 則。設計決策記在 `docs/adr/0017-the-audit-target-stays-wrong-and-the-record-stops-depending-on-it.md`。
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",


### PR DESCRIPTION
`main` 上已有 #127 的內容與 `[Unreleased]` 段落，這條把版本號補上。

## 為什麼是 minor

#127 只新增 `metadata.blacklist_checked`，`target` 一個字沒改，沒有既有欄位的語意或值被動到。任何解析稽核紀錄的下游都不受影響。

## bump 的內容

`package.json` 5.0.0 → 5.1.0、六份 manifest 由 `manifest:sync` 對齊、CHANGELOG 的 `[Unreleased]` 定版為 `[5.1.0]`。`SECURITY.md` 這次不動——major 仍是 5，supported 那列已經是 `5.x`，`manifest:check` 因此自然通過。

## 測試計畫

- `bun run release:check` 通過（含 `bun test` 6039 tests / 0 fail、`typecheck:tests`、`manifest:check`、`build:determinism`、`bun audit`、`✓ CHANGELOG.md has ## [5.1.0] heading`）
- **未執行**：`test:docker`——本機沒有 Docker，那些資料庫 integration 測試會在 CI 的 `integration` job 真正執行

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B