### PR TITLE
fix: [ redis ] glob 的萬用字元吃不下換行，Redis 吃得下

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **glob 的萬用字元涵蓋換行，與 Redis 一致。** `globToRegex` 把 `*` 譯成 `.*`，而 JavaScript 的 `.` 在沒有 dotAll 時不匹配 `\n`；Redis 的 `stringmatchlen` 逐位元組比對，`*` 吃任何位元組。於是 `secrets:*` 保護不到 `secrets:\nx`，而 `parseRedisCommand` 在引號內保留換行，這條路是可達的；同一組 regex 也驅動 `sampleKeyNames`，所以 `dbcli list` 也照樣顯示那個 key。`$` 不需要配套改動：JavaScript 把它錨在輸入結尾（不像 Perl 允許結尾換行），所以字面 pattern 仍然不匹配尾端多一個換行的 key——那也正是 Redis 的答案。同一個函式也用於 Elasticsearch 的 index 運算式，那裡 index 名不含換行，因此不受影響。
+
 - **設定裡的前後空白與外層引號會被去掉。** `[" password "]`、`["\"password\""]`、``["`password`"]``、鍵 `" users "` 全部靜默無效。ES 那側的 `es-index-target.ts` 早就 trim 兼解引號，SQL 側沒有。
 
 - **表規則同時以完整名稱與最後一段查找。** `{"public.users": …}` 對 `SELECT * FROM users` 不生效，反向也一樣——`extractTableReferences` 會保留限定名稱的完整字串，所以每個鍵只對它被寫成的那一種拼法生效。這是查找的改動而非解析時的猜測：沒有任何地方決定操作者指的是哪一種拼法，同一張表的兩種拼法解析到同一份規則。

--- a/docs/specs/2026-08-30-redis-blacklist-gaps.md
+++ b/docs/specs/2026-08-30-redis-blacklist-gaps.md
@@ -1,7 +1,7 @@
 # Redis 的黑名單與遮罩缺口（第九輪對抗式複查）
 
 **狀態**：第 1-4 則已於 `fix/cross-engine-blacklist-gaps` 修復（ADR-0015），
-第 5 則（glob 對含換行的 key）未修，仍是 MEDIUM。原始狀態如下。
+第 5 則已修（見該節）。原始狀態如下。
 
 **狀態（原始）**：已確認，未修復。刻意不在
 `fix/es-shell-permission-enforcement` 上修——那條分支已跑九輪且只談
@@ -91,7 +91,7 @@ Redis 幾乎沒有人這樣設。
 不要讓每個 call site 各自記得傳。這是 ES 分支第五輪那個教訓的翻版——控制掛在
 呼叫端，等於下一個呼叫端不會有。
 
-## 5. glob 對含換行的 key 與 Redis 不一致（MEDIUM）
+## 5. [已修] glob 對含換行的 key 與 Redis 不一致（MEDIUM）
 
 `globToRegex`（`src/utils/glob.ts:18-19`）把 `*` 譯成 `.*`，而 JS 的 `.` 不
 匹配 `\n`；Redis 的 `stringmatchlen` 逐位元組比對，`*` 吃任何位元組。所以
@@ -100,7 +100,12 @@ Redis 幾乎沒有人這樣設。
 換行，所以這條路可達。同一組 regex 也用在 `sampleKeyNames`，因此 `dbcli list`
 也會顯示這種 key。
 
-**修法方向**：`new RegExp(out, 's')`，並確認 `$` 不會在尾端 `\n` 前提早收尾。
+**已修**（`new RegExp(out, 's')`）。`$` 那半經查證不成立：JavaScript 把 `$`
+錨在輸入結尾，不像 Perl 允許尾端換行，所以 `globToRegex('secrets:x')` 對
+`'secrets:x\n'` 本來就回 false——而那也是 Redis 的答案。
+
+端到端在本機 Redis 複驗：`GET` 一般 key 與含換行的 key 都被擋，`dbcli list`
+只列出不受保護的那個 key（總數仍誠實回報）。
 
 ---
 

--- a/src/utils/glob.ts
+++ b/src/utils/glob.ts
@@ -37,7 +37,14 @@ export function globToRegex(glob: string): RegExp {
     }
   }
   out += '$'
-  return new RegExp(out)
+  // `s` (dotAll): Redis's `stringmatchlen` compares byte by byte, so its `*`
+  // and `?` eat a newline like any other byte. Without the flag JavaScript's
+  // `.` stops at `\n`, and `secrets:*` left `secrets:\nx` unprotected while
+  // `parseRedisCommand` happily carried that key through a quoted argument.
+  // `$` needs no companion change: JavaScript anchors it at end of input,
+  // unlike Perl, so a literal pattern still refuses a key with a trailing
+  // newline — which is also what Redis answers.
+  return new RegExp(out, 's')
 }
 
 /** Index of the `]` closing the class opened at `open`, honouring backslash escapes. */

--- a/tests/unit/utils/glob.test.ts
+++ b/tests/unit/utils/glob.test.ts
@@ -1,0 +1,37 @@
+/**
+ * `globToRegex` answers a security question: does this key match a blacklist
+ * rule? Redis's own `stringmatchlen` compares byte by byte, so `*` there eats
+ * any byte including a newline.
+ */
+import { describe, expect, test } from 'bun:test'
+import { globToRegex } from '@/utils/glob'
+
+describe('globToRegex against Redis semantics', () => {
+  test('a wildcard covers a newline, as Redis does', () => {
+    // Measured 2026-08-31: `.` in JavaScript does not match `\n` without the
+    // dotAll flag, so `secrets:*` left `secrets:\nx` unprotected — and
+    // `parseRedisCommand` keeps a newline inside quotes, so the key is
+    // reachable. The same regex drives `sampleKeyNames`, so `dbcli list`
+    // showed it too.
+    expect(globToRegex('secrets:*').test('secrets:\nx')).toBe(true)
+    expect(globToRegex('secrets:*').test('secrets:x\ny')).toBe(true)
+    expect(globToRegex('*').test('a\nb')).toBe(true)
+  })
+
+  test('a single-character wildcard covers a newline', () => {
+    expect(globToRegex('secrets:?').test('secrets:\n')).toBe(true)
+  })
+
+  test('a literal pattern still does not match a longer key', () => {
+    // JavaScript's `$` matches only at the end of input — unlike Perl's, it
+    // does not permit a trailing newline — so this is already right and the
+    // dotAll flag must not change it. Redis agrees: the pattern is shorter
+    // than the key.
+    expect(globToRegex('secrets:x').test('secrets:x\n')).toBe(false)
+  })
+
+  test('unchanged: a wildcard does not cross what it never crossed', () => {
+    expect(globToRegex('secrets:*').test('other:x')).toBe(false)
+    expect(globToRegex('secrets:?').test('secrets:ab')).toBe(false)
+  })
+})


### PR DESCRIPTION
規格 `docs/specs/2026-08-30-redis-blacklist-gaps.md` 第 5 則，最後一則未修的 Redis 項目。

## 先量再修

`globToRegex` 把 `*` 譯成 `.*`，而 JavaScript 的 `.` 在沒有 dotAll 時不匹配 `\n`；Redis 的 `stringmatchlen` 逐位元組比對，`*` 吃任何位元組。

| glob | key | 修復前 | 修復後 |
| --- | --- | --- | --- |
| `secrets:*` | `secrets:x` | 擋住 | 擋住 |
| `secrets:*` | `secrets:\nx` | **不匹配** | 擋住 |
| `secrets:*` | `secrets:x\ny` | **不匹配** | 擋住 |
| `secrets:?` | `secrets:\n` | **不匹配** | 擋住 |
| `*` | `a\nb` | **不匹配** | 擋住 |
| `secrets:x` | `secrets:x\n` | 不匹配 | 不匹配（正確） |

`parseRedisCommand` 在引號內保留換行，所以這條路可達；同一組 regex 也驅動 `sampleKeyNames`，所以 `dbcli list` 也照樣把那種 key 顯示出來。

## 規格的另一半不成立

規格要求「確認 `$` 不會在尾端 `\n` 前提早收尾」。查證後不成立：JavaScript 把 `$` 錨在輸入結尾，不像 Perl 允許尾端換行，所以 `globToRegex('secrets:x')` 對 `'secrets:x\n'` 本來就回 `false`——而那也正是 Redis 的答案（pattern 比 key 短）。表格最後一行就是這一格，測試把它釘住，免得日後有人為了「保險」改成 `m` 旗標或補 `\n?` 而把它弄壞。這一點已寫回規格。

## 端到端

本機 Redis（db0 原本是空的，種子資料測完已刪）：

```
GET dbcli_probe:plain      → matched blacklist pattern: dbcli_probe:*
GET "dbcli_probe:\nnl"     → matched blacklist pattern: dbcli_probe:*
dbcli list                 → 只列出 dbcli_other（Total in DB 仍誠實回報 3）
```

## 影響範圍

同一個函式也用於 Elasticsearch 的 index 運算式。ES 的 index 名不含換行，所以那側不受影響；真要有，方向也是多擋而不是少擋。

## 測試計畫

- 新增 `tests/unit/utils/glob.test.ts`，四則，兩則先驗過紅，另兩則是回歸護欄（字面 pattern 不匹配較長的 key；萬用字元沒有跨過它本來就不跨的東西）
- `bun test` 6049 tests / 27 skip / 0 fail
- `typecheck`、`typecheck:tests`、`lint`、`format:check`、`docs:check` 皆過
- **未執行**：`test:docker`

## 版本號

併進現有的 `[Unreleased]` 段落。那個段落已含破壞性變更，這一則是純修復，不改變它的版本層級。

**base 指向 #129 的分支**，不是 `main`——兩者都動到 `CHANGELOG.md` 的同一段，從 `main` 開會在合併時衝突。#129 合併後，把這條的 base 改成 `main`。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B
