### PR TITLE
chore: [ release ] 6.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 一份黑名單設定，四個互不相同的比對器
+## [6.0.0] - 2026-09-01 - 一份黑名單設定，四個互不相同的比對器
 
 規格 SQL 第 7、8、9 則與 MongoDB 第 3–6 則。設計決策記在
 `docs/adr/0018-a-blacklist-rule-that-does-not-match-fails-loudly.md` 與

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,12 +13,13 @@ support branch and none is promised: an older major is fixed by upgrading.
 
 | Version | Status |
 | ------- | ------ |
-| **5.x** | :white_check_mark: **Supported** — use the latest 5.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
-| **4.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
-| **3.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
-| **2.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
-| **1.x** | :x: **Not supported** — superseded by 5.x; upgrade to **5.x**. |
-| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **5.x**. |
+| **6.x** | :white_check_mark: **Supported** — use the latest 6.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
+| **5.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
+| **4.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
+| **3.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
+| **2.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
+| **1.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
+| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **6.x**. |
 
 The supported major above is checked against `package.json` by
 `bun run manifest:check`, so this table cannot silently fall behind a release.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",


### PR DESCRIPTION
`[Unreleased]` 定版為 6.0.0（2026-09-01），內容是已合併的 #131：一份黑名單設定，四個互不相同的比對器。

## 這一版動了什麼

- `package.json` 5.1.0 → 6.0.0，五份 plugin manifest 由 `manifest:sync` 對齊
- `CHANGELOG.md` 的 `[Unreleased]` 標題定版
- `SECURITY.md` 的 supported 表：6.x 為 supported，5.x 降為 not supported，其餘各列的升級指向改成 6.x

## 為什麼是 major

#131 有六則 BREAKING，其中三則會讓既有設定停止載入或改變既有規則的意思：

1. 欄位規則與回傳欄位名比對時，第一段折成小寫
2. 以自己的表限定的欄位項（`{"users": ["users.password"]}`）改為載入失敗
3. `blacklist.tables` 與 `blacklist.columns` 的每個條目都成為 glob——含 `*` 的既有設定在 SQL 與 MongoDB 連線上開始擋東西

方向都是只多拒絕不少拒絕，但那仍是既有設定的行為改變。

## 測試

`bun run release:check` 九步全過：audit、prettier、agent-core purity、typecheck（含 test tree）、lint、`bun test`（6074 pass / 0 fail）、build、dist smoke、doc & manifest presence。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B