### PR TITLE
docs: [ specs ] 四份規格的狀態欄落後於程式碼

### DIFF
--- a/docs/specs/2026-08-04-mongodb-field-first-connection.md
+++ b/docs/specs/2026-08-04-mongodb-field-first-connection.md
@@ -1,6 +1,6 @@
 # MongoDB 逐欄連線設定
 
-**狀態**：Ready for implementation
+**狀態**：已於 v1.46.0（2026-08-04）交付；保留為設計記錄
 **決策依據**：`docs/adr/0002-mongodb-connection-field-first-config.md`
 **基準版本**：v1.45.1
 

--- a/docs/specs/2026-08-06-wren-inspired-semantic-roadmap.md
+++ b/docs/specs/2026-08-06-wren-inspired-semantic-roadmap.md
@@ -1,8 +1,11 @@
 # WrenAI 借鑑功能：語意層後續規格
 
 **Date:** 2026-08-06
-**Status:** Slices 1–2 implemented; Slice 3 specification refined, with no
-implementation authorized yet
+**Status:** Slices 1–2 implemented. Slice 3's agent-driven half is delivered —
+SQD-01 through SQD-04, including `dbcli semantic draft validate` — and its
+provider-driven half (SQD-05, SQD-06) is not awaiting engineering: ADR-0005
+defers it as a settled fail-closed policy, reopened only by an approved product
+and security record clearing that ADR's checklist.
 **Depends on:**
 [`2026-08-06-semantic-context-mvp-design.md`](2026-08-06-semantic-context-mvp-design.md)
 and [`docs/adr/0004-database-access-stays-a-cli-surface.md`](../adr/0004-database-access-stays-a-cli-surface.md).

--- a/docs/specs/2026-08-30-cross-engine-blacklist-gaps.md
+++ b/docs/specs/2026-08-30-cross-engine-blacklist-gaps.md
@@ -1,6 +1,13 @@
 # MongoDB 與 SQL 的黑名單缺口，以及 audit 的其餘問題（第九輪）
 
-**狀態**：已確認，未修復。與
+**狀態（2026-09-01）**：全部十二則已處置——MongoDB 1–2 於 ADR-0015，3–6 於
+ADR-0019（第 3 則實測後不成立，見該則的更新），SQL 7–9 於 ADR-0018，audit 10 於
+ADR-0017、11 與 11b 於 ADR-0016、12 補上註解。大小寫折疊的跨引擎不對稱由 ADR-0020
+收尾，驗證過程另外找到的巢狀 glob 缺口記在
+`docs/specs/2026-09-01-nested-glob-rules-on-the-sql-read-path.md`，也已修復。
+以下保留原始記錄。
+
+**狀態（原始）**：已確認，未修復。與
 `docs/specs/2026-08-30-redis-blacklist-gaps.md` 同一輪、同一個理由——那一輪的
 問題是「**一個比對函式，有沒有把它要比的兩樣東西都正規化？**」，而
 `fix/es-shell-permission-enforcement` 只收 Elasticsearch 這條線的修補。

--- a/docs/specs/2026-08-30-elasticsearch-shell-permission-enforcement.md
+++ b/docs/specs/2026-08-30-elasticsearch-shell-permission-enforcement.md
@@ -1,6 +1,6 @@
 # Elasticsearch shell enforces the permission tier
 
-**Status:** ready-for-agent
+**Status:** Delivered in 4.0.0 (2026-08-30); retained as a design record
 **Date:** 2026-08-30
 **Severity:** Critical — permission tier bypass in the current supported major (3.x)
 **Target release:** 4.0.0, with a user advisory


### PR DESCRIPTION
純文件。四份規格的狀態欄讀起來像還有工作待做，實際上沒有——`docs/adr/` 的規則是「undecided 是一個必須可儲存的狀態」，而狀態欄是那個機制唯一的讀取面，落後的狀態欄會讓 backlog 盤點得到錯的答案（我剛才盤點時就被這四份誤導過一次）。

| 檔案 | 原本 | 實情 |
| --- | --- | --- |
| `2026-08-30-cross-engine-blacklist-gaps.md` | 標題行「已確認，未修復」 | 十二則全數處置（ADR-0015／0016／0017／0018／0019），大小寫維度由 ADR-0020 收尾 |
| `2026-08-30-elasticsearch-shell-permission-enforcement.md` | `ready-for-agent` | 4.0.0 的主體 |
| `2026-08-04-mongodb-field-first-connection.md` | `Ready for implementation` | v1.46.0 交付 |
| `2026-08-06-wren-inspired-semantic-roadmap.md` | 「Slice 3 尚未授權實作」 | agent-driven 那半已交付（SQD-01–04）；provider-driven 那半是 ADR-0005 的政策 gate，不是排期 |

最後一則值得特別說：原本的措辭容易讀成「還沒排到」，但 ADR-0005 自己寫著 `This ADR is not an open question awaiting an answer`——要動 SQD-05／06 得先有一份通過該 ADR checklist（provider／model／帳號歸屬、sanitized payload 範圍、資料出境與 retention、key 管理與成本上限、離線與撤銷路徑）的產品與安全核准記錄。同一份檔案的交付順序表本來就寫對了，錯的只有標題那行。

保留原始記錄而不是覆寫，因為那些是當時的量測與判斷。

## 測試

沒有程式碼改動。`bun run format:check` 與 `bun run docs:check` 通過。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B