### PR TITLE
fix: [ blacklist ] 一套折疊規則沒有走到巢狀下潛與規則挑選

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -61,14 +61,16 @@ async function checkAction(
     const checker = new HealthChecker(adapter)
     const blacklistManager = new BlacklistManager(config)
     const blacklistedColumns = getBlacklistedColumnSet(blacklistManager)
-    const blacklistedTables = getBlacklistedTableSet(blacklistManager)
 
     const checkTypes = options.checks ? (options.checks.split(',') as CheckType[]) : undefined
 
     const sampleSize = parseInt(options.sample, 10) || 10_000
 
     if (table) {
-      if (blacklistedTables.has(table.toLowerCase())) {
+      // 問 manager，不要自己查它的私有 state：那份 Set 只有字面條目、而且是用
+      // `foldFieldPath` 折的，這裡卻用裸的 `toLowerCase` 查。萬用字元規則因此
+      // 對這條路徑完全不存在（ADR-0019 Decision 4），折疊也對不上（ADR-0020）。
+      if (blacklistManager.isTableBlacklisted(table)) {
         throw new Error(`Table "${table}" is blacklisted`)
       }
 
@@ -86,7 +88,7 @@ async function checkAction(
       const skipped: string[] = []
 
       for (const t of tables) {
-        if (blacklistedTables.has(t.name.toLowerCase())) {
+        if (blacklistManager.isTableBlacklisted(t.name)) {
           skipped.push(`${t.name} (blacklisted)`)
           continue
         }
@@ -169,11 +171,4 @@ function getBlacklistedColumnSet(manager: BlacklistManager): Set<string> {
     }
   }
   return result
-}
-
-function getBlacklistedTableSet(manager: BlacklistManager): Set<string> {
-  const state = (
-    manager as unknown as { state: { columns: Map<string, Set<string>>; tables: Set<string> } }
-  ).state
-  return state?.tables || new Set<string>()
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { foldFieldPath } from '@/core/blacklist-fold'
 import { colors } from '@/utils/colors'
 import { configModule } from '@/core/config'
 import { AdapterFactory, type ConnectionOptions, type SqlConnectionOptions } from '@/adapters'
@@ -341,9 +342,14 @@ export const runDoctorChecks = {
     for (const [table, columns] of tableColumns) {
       const blacklisted = blacklistedColumns.get(table) ?? new Set()
       for (const col of columns) {
+        // 兩個不同的問題，兩種折疊，刻意如此。`SENSITIVE_PATTERNS` 是 ASCII 的
+        // 啟發式子字串，`toLowerCase` 就夠；`blacklisted` 這一半是拿名稱去比對
+        // 規則，走的必須是同一個折疊函式——先前完全不折，於是規則換個大小寫寫，
+        // 這份報告就說那個欄位沒有受保護。
         const colLower = col.toLowerCase()
         const isSensitive = SENSITIVE_PATTERNS.some((p) => colLower.includes(p))
-        if (isSensitive && !blacklisted.has(col)) {
+        const foldedRules = new Set([...blacklisted].map(foldFieldPath))
+        if (isSensitive && !foldedRules.has(foldFieldPath(col))) {
           unprotected.push(`${table}.${col}`)
         }
       }

--- a/src/core/blacklist-validator.ts
+++ b/src/core/blacklist-validator.ts
@@ -59,7 +59,9 @@ function dedupe(values: string[]): string[] {
   const seen = new Set<string>()
   const result: string[] = []
   for (const value of values) {
-    const key = value.toLowerCase()
+    // 同一個折疊函式。這裡不折反而會多留條目（往檢查更多的方向），所以不是
+    // fail-open，但一套折疊規則就是一套。
+    const key = foldFieldPath(value)
     if (value.length === 0 || seen.has(key)) continue
     seen.add(key)
     result.push(value)

--- a/src/core/elasticsearch/dml-plan.ts
+++ b/src/core/elasticsearch/dml-plan.ts
@@ -1,4 +1,5 @@
 import { parseWhereClause } from '@/utils/where-parser'
+import { foldFieldPath } from '@/core/blacklist-fold'
 import type { DmlPlanIntent } from '@/core/dml-plan'
 
 export type ElasticsearchBuildInput =
@@ -125,8 +126,10 @@ function applyTableBlacklist(
   context: NonSqlAnalyzerContext,
   factors: QueryRiskFactor[]
 ): void {
-  const blacklisted = (context.blacklist.tables ?? []).map((t) => t.toLowerCase())
-  if (blacklisted.includes(target.toLowerCase())) {
+  // 同一個折疊函式。這條路徑是風險規劃的顧問輸出，`BlacklistManager` 仍會另外
+  // 強制執行，所以折錯只是少報一項風險因子而不是放行——但一套折疊規則就是一套。
+  const blacklisted = (context.blacklist.tables ?? []).map(foldFieldPath)
+  if (blacklisted.includes(foldFieldPath(target))) {
     pushFactor(
       factors,
       'table_blacklisted',
@@ -143,10 +146,10 @@ function applyColumnBlacklist(
   factors: QueryRiskFactor[]
 ): void {
   const columns = context.blacklist.columns ?? {}
-  const lower = target.toLowerCase()
+  const lower = foldFieldPath(target)
   let blacklistedFields: string[] = []
   for (const [t, cols] of Object.entries(columns)) {
-    if (t.toLowerCase() === lower) {
+    if (foldFieldPath(t) === lower) {
       blacklistedFields = cols
       break
     }

--- a/src/core/field-projection.ts
+++ b/src/core/field-projection.ts
@@ -1,4 +1,5 @@
 import { matchSegment, type MongoPathPattern } from './mongo/path-matcher'
+import { foldCase } from '@/utils/case-fold'
 
 export type FieldSelection =
   | { mode: 'include'; paths: readonly string[] }
@@ -70,11 +71,14 @@ export function hasFieldPath(
   const caseInsensitive = options?.caseInsensitive === true
   // Folded once here rather than at every level of every row: the masker asks
   // this question once per dotted rule per row, so folding inside `readPath`
-  // repeated the same `toLowerCase` tens of thousands of times.
+  // repeated the same fold tens of thousands of times.
+  //
+  // `foldCase`, not a bare `toLowerCase`: the rule's segments arrive folded by
+  // `foldFieldPath`, and the two agreed only while `foldFieldPath` *was*
+  // `toLowerCase`. Once it stopped being that, a rule `profile.ΑΣ` returned the
+  // key it names and masked the one it does not. ADR-0020, first clause.
   const folded =
-    caseInsensitive && options?.alreadyFolded !== true
-      ? segments.map((segment) => segment.toLowerCase())
-      : segments
+    caseInsensitive && options?.alreadyFolded !== true ? segments.map(foldCase) : segments
   return readPath(row, folded, caseInsensitive).found
 }
 
@@ -349,7 +353,7 @@ export function omitFieldPaths(
   // a thousand, over the benchmark's budget, for traversal 999 rows cannot use.
   //
   // Ceiling: a genuinely nested row still costs one rebuild per path that reaches it.
-  const fold = (value: string): string => (caseInsensitive ? value.toLowerCase() : value)
+  const fold = (value: string): string => (caseInsensitive ? foldCase(value) : value)
   const topLevel = new Set<string>(paths.map(fold))
   const dotted = paths
     .filter((path) => path.includes('.'))
@@ -451,7 +455,7 @@ function foldedKeys(value: Record<string, unknown>): Map<string, string> {
   if (memo !== undefined) return memo
   const index = new Map<string, string>()
   for (const key of Object.getOwnPropertyNames(value)) {
-    const folded = key.toLowerCase()
+    const folded = foldCase(key)
     if (!index.has(folded)) index.set(folded, key)
   }
   foldedKeyIndex.set(value, index)
@@ -531,7 +535,7 @@ function omitPath(value: unknown, segments: readonly string[], caseInsensitive: 
   if (Array.isArray(value)) return value.map((item) => omitPath(item, segments, caseInsensitive))
   if (!isPlainRecord(value)) return value
 
-  const fold = (name: string): string => (caseInsensitive ? name.toLowerCase() : name)
+  const fold = (name: string): string => (caseInsensitive ? foldCase(name) : name)
   const exactPath = fold(segments.join('.'))
   const head = fold(segments[0]!)
   const tail = segments.slice(1)
@@ -557,7 +561,7 @@ function cloneRecord(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [key, child] of Object.entries(value)) {
-    if (!omittedKeys.has(caseInsensitive ? key.toLowerCase() : key)) defineData(out, key, child)
+    if (!omittedKeys.has(caseInsensitive ? foldCase(key) : key)) defineData(out, key, child)
   }
   return out
 }

--- a/src/core/mongo/dml-plan.ts
+++ b/src/core/mongo/dml-plan.ts
@@ -1,4 +1,5 @@
 import { parseWhereClause } from '@/utils/where-parser'
+import { foldFieldPath } from '@/core/blacklist-fold'
 import type { DmlPlanIntent } from '@/core/dml-plan'
 import { compilePatterns, matchAny } from '@/core/mongo/path-matcher'
 
@@ -266,8 +267,10 @@ function applyTableBlacklist(
   context: NonSqlAnalyzerContext,
   factors: QueryRiskFactor[]
 ): void {
-  const blacklisted = (context.blacklist.tables ?? []).map((t) => t.toLowerCase())
-  if (blacklisted.includes(target.toLowerCase())) {
+  // 同一個折疊函式。這條路徑是風險規劃的顧問輸出，`BlacklistManager` 仍會另外
+  // 強制執行，所以折錯只是少報一項風險因子而不是放行——但一套折疊規則就是一套。
+  const blacklisted = (context.blacklist.tables ?? []).map(foldFieldPath)
+  if (blacklisted.includes(foldFieldPath(target))) {
     pushFactor(factors, 'table_blacklisted', 'block', `Target collection ${target} is blacklisted.`)
   }
 }
@@ -279,10 +282,10 @@ function applyColumnBlacklist(
   factors: QueryRiskFactor[]
 ): void {
   const columns = context.blacklist.columns ?? {}
-  const lower = target.toLowerCase()
+  const lower = foldFieldPath(target)
   let raw: string[] = []
   for (const [t, cols] of Object.entries(columns)) {
-    if (t.toLowerCase() === lower) {
+    if (foldFieldPath(t) === lower) {
       raw = cols
       break
     }

--- a/src/core/mongo/field-masker.ts
+++ b/src/core/mongo/field-masker.ts
@@ -1,5 +1,6 @@
 import { BlacklistError, type BlacklistConfig } from '@/types/blacklist'
 import { compilePatterns, matchAny, type MongoPathPattern } from './path-matcher'
+import { foldFieldPath } from '@/core/blacklist-fold'
 import { escapeGlob } from '@/utils/glob'
 import { globMatches } from '@/utils/glob'
 import type { MongoCollectionScope } from './collection-references'
@@ -125,13 +126,20 @@ function maskValue(
   return value
 }
 
+/**
+ * 挑選規則也是一次名稱比對，所以走同一個折疊函式。
+ *
+ * 裸的 `toLowerCase` 曾與 `foldFieldPath` 一致——因為那時 `foldFieldPath` 就是
+ * `toLowerCase`。ADR-0020 Decision 4 讓它不再是，於是設定在 `ασ` 底下的規則
+ * 對 collection `ΑΣ` 查不到，而查不到的意思是「沒有規則」：明文原樣回傳。
+ */
 function findCaseInsensitive(
   columns: Record<string, string[]>,
   name: string
 ): string[] | undefined {
-  const target = name.toLowerCase()
+  const target = foldFieldPath(name)
   for (const [k, v] of Object.entries(columns)) {
-    if (k.toLowerCase() === target) return v
+    if (foldFieldPath(k) === target) return v
   }
   return undefined
 }

--- a/src/core/mongo/request-fields.ts
+++ b/src/core/mongo/request-fields.ts
@@ -167,14 +167,16 @@ export function protectedFieldsForRequest(
   }
   collectStrings(request)
 
-  // Lower-cased on both sides. `findCaseInsensitive` in `field-masker.ts` looks
-  // rules up that way, so an exact-match test here would have made the same
-  // configuration protect the response and not the request.
-  const namedLower = new Set([...named].map((value) => value.toLowerCase()))
+  // 折疊過的兩側，用的是每個比對器都呼叫的那個函式。`findCaseInsensitive` 在
+  // `field-masker.ts` 以同一種方式查規則，所以這裡若用精確比對，同一份設定會
+  // 保護回應而不保護請求。裸的 `toLowerCase` 是同樣的問題換一個字母——
+  // `foldFieldPath` 不再是 `toLowerCase` 之後，`ασ` 底下的規則對 `ΑΣ` 查不到。
+  const namedFolded = new Set([...named].map(foldFieldPath))
+  const collectionFolded = foldFieldPath(collection)
   const fields = new Set<string>()
   for (const [name, rules] of Object.entries(columns)) {
-    const applies =
-      name.toLowerCase() === collection.toLowerCase() || namedLower.has(name.toLowerCase())
+    const folded = foldFieldPath(name)
+    const applies = folded === collectionFolded || namedFolded.has(folded)
     if (!applies) continue
     for (const rule of rules) {
       const trimmed = rule.trim()

--- a/src/core/query-risk-analyzer.ts
+++ b/src/core/query-risk-analyzer.ts
@@ -1,4 +1,5 @@
 import type { TableSchema } from '@/adapters/types'
+import { foldFieldPath } from '@/core/blacklist-fold'
 import { checkPermission, classifyStatement } from '@/core/permission-guard'
 import { getSizeCategory } from '@/core/size-category'
 import type { BlacklistConfig } from '@/types/blacklist'
@@ -316,10 +317,11 @@ function applyBlacklistRules(
   blacklist: BlacklistConfig,
   factors: QueryRiskFactor[]
 ): void {
-  const blacklistedTables = new Set((blacklist.tables ?? []).map((table) => table.toLowerCase()))
+  // 同一個折疊函式——顧問輸出，但一套折疊規則就是一套。
+  const blacklistedTables = new Set((blacklist.tables ?? []).map(foldFieldPath))
 
   for (const table of facts.targetTables) {
-    if (blacklistedTables.has(table.toLowerCase())) {
+    if (blacklistedTables.has(foldFieldPath(table))) {
       pushFactor(factors, 'table_blacklisted', 'block', `Target table ${table} is blacklisted.`)
     }
   }
@@ -342,7 +344,7 @@ function applyBlacklistRules(
 function findBlacklistedColumnsForTable(blacklist: BlacklistConfig, table: string): Set<string> {
   const columns = blacklist.columns ?? {}
   for (const [tableName, columnNames] of Object.entries(columns)) {
-    if (tableName.toLowerCase() === table.toLowerCase()) {
+    if (foldFieldPath(tableName) === foldFieldPath(table)) {
       return new Set(columnNames)
     }
   }

--- a/src/core/redis/dml-plan.ts
+++ b/src/core/redis/dml-plan.ts
@@ -1,4 +1,5 @@
 import type { DmlPlanIntent } from '@/core/dml-plan'
+import { foldFieldPath } from '@/core/blacklist-fold'
 
 export type RedisBuildInput =
   | { operation: 'insert'; target: string; data: Record<string, unknown> }
@@ -93,8 +94,10 @@ function applyTableBlacklist(
   context: NonSqlAnalyzerContext,
   factors: QueryRiskFactor[]
 ): void {
-  const blacklisted = (context.blacklist.tables ?? []).map((t) => t.toLowerCase())
-  if (blacklisted.includes(target.toLowerCase())) {
+  // 同一個折疊函式。這條路徑是風險規劃的顧問輸出，`BlacklistManager` 仍會另外
+  // 強制執行，所以折錯只是少報一項風險因子而不是放行——但一套折疊規則就是一套。
+  const blacklisted = (context.blacklist.tables ?? []).map(foldFieldPath)
+  if (blacklisted.includes(foldFieldPath(target))) {
     pushFactor(factors, 'table_blacklisted', 'block', `Redis key ${target} is blacklisted.`)
   }
 }
@@ -106,10 +109,10 @@ function applyColumnBlacklist(
   factors: QueryRiskFactor[]
 ): void {
   const columns = context.blacklist.columns ?? {}
-  const lower = target.toLowerCase()
+  const lower = foldFieldPath(target)
   let blacklistedFields: string[] = []
   for (const [t, cols] of Object.entries(columns)) {
-    if (t.toLowerCase() === lower) {
+    if (foldFieldPath(t) === lower) {
       blacklistedFields = cols
       break
     }

--- a/src/utils/es-index-target.ts
+++ b/src/utils/es-index-target.ts
@@ -134,8 +134,11 @@ export function matchesIndexGlob(pattern: string, name: string): boolean {
  * documented ceiling.
  */
 function reachesByConvention(name: string, entry: string): boolean {
-  const lower = name.toLowerCase()
-  const target = entry.toLowerCase()
+  // 與 `indexExpressionReaches` 的精確比對那一半折得一樣。裸的 `toLowerCase` 曾是
+  // 同一個函式裡的第二套折疊，於是條目 `ΑΣ` 構得到 index `ασ`、構不到它的 backing
+  // index `.ds-ασ-2026`——擋不住 backing index 就是擋不住讀取。ADR-0020。
+  const lower = foldFieldPath(name)
+  const target = foldFieldPath(entry)
   return (
     new RegExp(`^\\.ds-${escapeRegExp(target)}-`).test(lower) ||
     new RegExp(`^${escapeRegExp(target)}-\\d+$`).test(lower)

--- a/tests/unit/core/collection-and-table-fold-parity.test.ts
+++ b/tests/unit/core/collection-and-table-fold-parity.test.ts
@@ -1,0 +1,67 @@
+/**
+ * 「哪些規則適用於這張表／這個 collection」也是一次名稱比對，也要走同一個折疊。
+ *
+ * ADR-0020 的 falsification 第一條管的是**所有**黑名單比對，不只欄位名。
+ * `e92a6e55` 把 `foldFieldPath` 從 `path.toLowerCase()` 換成 `foldCase` 之後，
+ * 這幾處挑選規則的比對仍是裸的 `toLowerCase`：`BlacklistManager` 用新的折疊建
+ * 索引，呼叫端用舊的折疊去查，查不到，而查不到的結果是「沒有規則」。
+ *
+ * 兩處都是 enforcing。`dbcli check` 會去抽樣一張它自己認為被擋下的表；MongoDB
+ * 的讀取遮罩與請求檢查會對一個 `isColumnBlacklisted` 說受保護的 collection
+ * 回傳明文，並放行 `$project` 把它搬出來。
+ */
+import { describe, test, expect } from 'bun:test'
+import { BlacklistManager } from '@/core/blacklist-manager'
+import { maskMongoRows } from '@/core/mongo/field-masker'
+import { findProtectedFieldReference, protectedFieldsForRequest } from '@/core/mongo/request-fields'
+
+// 折疊分歧的碼點只有三個：U+0130、U+03A3、U+03C2。`ΑΣ` 與 `ασ` 是可觸及的最短形狀
+// ——`toLowerCase('ΑΣ')` 是 `ας`（尾字 sigma），`foldCase('ΑΣ')` 是 `ασ`。
+const AS_RULE = 'ΑΣ'
+const AS_NAME = 'ασ'
+
+describe('a command consults the table set the way the manager built it', () => {
+  const manager = new BlacklistManager({
+    blacklist: { enabled: true, tables: [AS_RULE, 'secrets*'], columns: {} },
+  } as never)
+
+  test('a blacklisted table is refused under either spelling', () => {
+    expect(manager.isTableBlacklisted(AS_NAME)).toBe(true)
+    expect(manager.isTableBlacklisted(AS_RULE)).toBe(true)
+  })
+
+  // 一併蓋住的既有缺口：`dbcli check` 讀的是 `state.tables`，那裡只有字面條目，
+  // 所以萬用字元規則對它完全不存在。ADR-0019 Decision 4 讓 `tables` 對所有引擎
+  // 都是 glob，這條路徑沒跟上。
+  test('a wildcard table rule is refused too', () => {
+    expect(manager.isTableBlacklisted('secrets_2026')).toBe(true)
+    expect(manager.isTableBlacklisted('SECRETS_2026')).toBe(true)
+  })
+
+  test('an unrelated table is still allowed', () => {
+    expect(manager.isTableBlacklisted('orders')).toBe(false)
+  })
+})
+
+describe('the rules that apply to a collection are selected by the one fold rule', () => {
+  const columns: Record<string, string[]> = { [AS_NAME]: ['password'] }
+
+  test('the read mask finds the rules filed under another spelling', () => {
+    const masked = maskMongoRows([{ _id: 1, password: 'p1' }], AS_RULE, {
+      enabled: true,
+      tables: [],
+      columns,
+    } as never)
+    expect(JSON.stringify(masked)).not.toContain('p1')
+  })
+
+  test('the request check finds them too', () => {
+    const fields = protectedFieldsForRequest({}, AS_RULE, columns)
+    expect(fields.has('password')).toBe(true)
+    expect(findProtectedFieldReference({ $project: { leak: '$password' } }, fields)).toBeDefined()
+  })
+
+  test('an unrelated collection still gets no rules', () => {
+    expect(protectedFieldsForRequest({}, 'orders', columns).size).toBe(0)
+  })
+})

--- a/tests/unit/core/nested-descent-fold-parity.test.ts
+++ b/tests/unit/core/nested-descent-fold-parity.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 一套折疊規則要走到巢狀下潛與 index 慣例名，而不是停在最外層。
+ *
+ * ADR-0020 的 falsification 條件第一條說：黑名單的比對不得用 `foldFieldPath`
+ * 或 `globMatches` 的 `caseInsensitive` 以外的方式折疊名稱。`e92a6e55`（PR #136）
+ * 把 `foldFieldPath` 從 `path.toLowerCase()` 換成 `foldCase`（`ς`→`σ`、`İ`→`i`），
+ * 而 `field-projection.ts` 的五處與 `es-index-target.ts` 的 `reachesByConvention`
+ * 仍是裸的 `toLowerCase`。在那之前兩邊天生一致，換掉之後就是兩套折疊——正是
+ * ADR-0018 記下、ADR-0020 要移除的那個失敗形狀，而且解在 fail-open 的方向。
+ *
+ * 最尖銳的一列是規則 `profile.ΑΣ`：它**回傳自己指名的那個鍵**，卻遮掉它沒有指名
+ * 的 `ασ`。操作者確認規則有效的方式通常是看某個東西被遮下來，而被遮的是錯的那個。
+ */
+import { describe, test, expect } from 'bun:test'
+import { BlacklistManager } from '@/core/blacklist-manager'
+import { BlacklistValidator } from '@/core/blacklist-validator'
+import { indexExpressionReaches } from '@/utils/es-index-target'
+
+/** SQL／ES 讀取路徑對一個 jsonb 形狀的欄位下潛的結果。 */
+function nestedRead(rule: string, nestedKey: string): { leaked: boolean; omitted: string[] } {
+  const blacklist = { enabled: true, tables: [], columns: { probe: [rule] } }
+  const validator = new BlacklistValidator(new BlacklistManager({ blacklist } as never))
+  const result = validator.filterColumnsForTables(
+    ['probe'],
+    [{ id: 1, profile: { [nestedKey]: 'PLAIN' } }],
+    ['id', 'profile']
+  )
+  return {
+    leaked: JSON.stringify(result.filteredRows).includes('PLAIN'),
+    omitted: result.omittedColumns,
+  }
+}
+
+describe('the nested descent folds by the one fold rule', () => {
+  // 分歧的碼點正好是 `foldCase` 與 `toLowerCase` 不同的那三個：U+0130、U+03A3、
+  // U+03C2。掃過 BMP 沒有第四個，所以這三列就是可觸及的全部形狀。
+  const cases: Array<[string, string]> = [
+    ['profile.ΑΣ', 'ΑΣ'],
+    ['profile.ΑΣ', 'ασ'],
+    ['profile.İd', 'İd'],
+    ['profile.id', 'İd'],
+    ['profile.ssn', 'SSN'],
+  ]
+
+  test.each(cases)('rule %p masks the nested key %p', (rule, key) => {
+    expect(nestedRead(rule, key).leaked).toBe(false)
+  })
+
+  test('a rule that masks reports itself in omittedColumns', () => {
+    expect(nestedRead('profile.ΑΣ', 'ΑΣ').omitted).toEqual(['profile.ΑΣ'])
+  })
+})
+
+describe('an index reached by naming convention folds the same way', () => {
+  // `.ds-<name>-<generation>` 是 data stream 的 backing index：黑名單條目指名資料流
+  // 時，擋不住它的 backing index 就是擋不住讀取。同一個函式的精確比對那一半已經
+  // 用 `foldFieldPath`，慣例那一半是裸的 `toLowerCase`——一個函式兩套折疊。
+  const rules = ['ΑΣ']
+
+  test('the exact name and its backing index answer the same', () => {
+    expect(indexExpressionReaches('ασ', rules)).toBe(true)
+    expect(indexExpressionReaches('.ds-ασ-2026', rules)).toBe(true)
+  })
+
+  test('an unrelated index is still not reached', () => {
+    expect(indexExpressionReaches('orders', rules)).toBe(false)
+    expect(indexExpressionReaches('.ds-orders-2026', rules)).toBe(false)
+  })
+})


### PR DESCRIPTION
## 問題

ADR-0020 把 `foldFieldPath` 從 `toLowerCase` 換成 `foldCase`（`ς`→`σ`、`İ`→`i`）之後，散落各處的裸 `toLowerCase` 就不再是同一套折疊。這些地方比對的都是名稱，折不一致的意思是「查不到規則」，而查不到就是明文回傳：

- `field-projection` 的巢狀下潛與 `omitFieldPaths`：規則段落已由 `foldFieldPath` 折過，比對這一側還是 `toLowerCase`，於是規則 `profile.ΑΣ` 回傳它指名的 key、遮掉它沒指名的。
- `field-masker` / `request-fields`：挑選規則也是一次名稱比對，設定在 `ασ` 底下的規則對 collection `ΑΣ` 查不到。
- `es-index-target` 的慣例名：條目 `ΑΣ` 構得到 index `ασ`，構不到它的 backing index `.ds-ασ-2026`——擋不住 backing index 就是擋不住讀取。
- `check`：先前從 `BlacklistManager` 的私有 state 撈 Set 自己比對，那份 Set 只有字面條目，萬用字元規則對這條路徑等於不存在（ADR-0019 Decision 4），折疊也對不上。改問 `isTableBlacklisted`。
- `doctor` 的未保護欄位報告先前完全不折，規則換個大小寫寫就漏報。
- `blacklist-validator` 的 dedupe、三個 `dml-plan` 與 `query-risk-analyzer` 的顧問輸出不會放行（`BlacklistManager` 仍會另外強制執行），但一套折疊規則就是一套。

## 測試計畫

- `bunx tsc --noEmit` 乾淨
- `bun test`：6150 pass / 27 skip / 0 fail（536 檔）
- 新增 `tests/unit/core/nested-descent-fold-parity.test.ts` 與 `tests/unit/core/collection-and-table-fold-parity.test.ts`，直接對 ADR-0020 falsification 第一條：黑名單的比對不得用 `foldFieldPath` 或 `globMatches` 的 `caseInsensitive` 以外的方式折疊名稱

本分支與 `fix/connection-only-adapters-say-without-rules`（#137）無共同檔案，兩者可獨立合併。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B