### PR TITLE
chore: [ release ] 7.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 一條規則擋得住寫、擋不住讀，差別只在大小寫
+## [7.0.0] - 2026-09-02 - 一條規則擋得住寫、擋不住讀，差別只在大小寫
 
 ADR-0019 在自己的 Consequences 裡寫下這一則：一份設定的大小寫折疊仍然是三套規則。
 這一版把它收成一套，並在收的過程中發現同一份設定還有一條完全繞過它的路——規則從來

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,13 +13,14 @@ support branch and none is promised: an older major is fixed by upgrading.
 
 | Version | Status |
 | ------- | ------ |
-| **6.x** | :white_check_mark: **Supported** — use the latest 6.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
-| **5.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
-| **4.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
-| **3.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
-| **2.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
-| **1.x** | :x: **Not supported** — superseded by 6.x; upgrade to **6.x**. |
-| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **6.x**. |
+| **7.x** | :white_check_mark: **Supported** — use the latest 7.x patch (see [CHANGELOG.md](CHANGELOG.md)). |
+| **6.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **5.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **4.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **3.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **2.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **1.x** | :x: **Not supported** — superseded by 7.x; upgrade to **7.x**. |
+| **&lt; 1.0** (legacy / pre-release tags) | :x: **Not supported** — upgrade to **7.x**. |
 
 The supported major above is checked against `package.json` by
 `bun run manifest:check`, so this table cannot silently fall behind a release.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",


### PR DESCRIPTION
## 內容

- `package.json` 6.0.0 → 7.0.0
- CHANGELOG 的 `[Unreleased]` 定版為 `## [7.0.0] - 2026-09-02`
- `SECURITY.md` 的 supported 那列換成 7.x，6.x 降為 not supported，其餘各列的升級指向一併改成 7.x（`manifest:check` 會比對這張表與 `package.json`）
- 五份 plugin manifest 由 `manifest:sync` 對齊到 7.0.0

## 為什麼是 major

這一版有四則 BREAKING，每一則都改變既有設定的意思，而不只是修 Bug：

1. 規則與欄位名的比對整條點分路徑都不分大小寫；
2. 折疊涵蓋第一段之後的段落；
3. Elasticsearch shell 遇到讀不懂的欄位規則改為拒絕請求——既有設定會讓每一個 `dbcli es` 失敗，直到規則改掉為止；
4. `AdapterFactory.createAdapter` 改收整份設定，connection-only 的入口改名為 `createAdapterWithoutRules`。

方向以多拒絕為主，但 `İ` 那一則有一格是往少保護的方向（沒有任何保長的折疊能同時映 `İ` 與 `i` + U+0307），對照表留在 CHANGELOG 裡。

這一版另含一則 Security：Redis 的 `dbcli q` 與 `dbcli report` 先前繞過 blacklist（ADR-0021）。

## 測試計畫

`bun run release:check` 九步全過——audit（`No vulnerabilities found`）、prettier、agent-core purity、typecheck（含測試樹）、lint、`bun test`、build、dist smoke、doc & manifest presence（含 `## [7.0.0]` 標題檢查）。

合併後打 `v7.0.0` tag，npm 發佈由 maintainer 手動進行。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B