### PR TITLE
docs: [ skill ] agent 讀到的黑名單語意還停在 4.0.0

### DIFF
--- a/.cursor/rules/dbcli.mdc
+++ b/.cursor/rules/dbcli.mdc
@@ -639,7 +639,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](../skills/dbcli/reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 

--- a/.github/skills/dbcli/SKILL.md
+++ b/.github/skills/dbcli/SKILL.md
@@ -639,7 +639,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -636,7 +636,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](.windsurf/skills/dbcli/reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -639,7 +639,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/assets/SKILL.zh-TW.md
+++ b/assets/SKILL.zh-TW.md
@@ -500,7 +500,7 @@ dbcli export "SELECT * FROM orders" --format html --output orders.html
 ## 備註
 
 - Query-only 模式自動補 `LIMIT 1000`；查 `information_schema` 或會被 `LIMIT` 破壞的語句請加 `--no-limit`。
-- 被 blacklist 的 table / column 會從查詢輸出中遮蔽。
+- 被 blacklist 的 table / column 會從查詢輸出中遮蔽。`blacklist.tables` 與 `blacklist.columns` 的每個條目在所有引擎上都是 glob（`*`、`?`、`[a-z]`），規則與名稱比對時整條點分路徑都不分大小寫——寫成 `password` 的規則同時涵蓋 `Password`，`profile.ssn` 也涵蓋 `profile.SSN`；真的叫 `report*` 的表要寫成 `report\*` 才能回到字面比對。`--fields` 不受影響，維持精確比對。讀不出意思的規則會在設定載入時就被拒絕，而不是靜默地什麼都不保護：以自己的表限定的欄位項（`{"users": ["users.password"]}`）會載入失敗，無法解析的規則則會讓每一個 `dbcli es` 請求失敗，直到改掉為止。
 - `schema` 回報 `estimatedRowCount` 與 `sizeCategory`（small / medium / large / huge）。大 / 巨大表要加 `WHERE` 或 `LIMIT` — 分界值見 [reference.md](reference.md#schema)。
 - 對 `mongodb+srv://` 連線，`doctor` 會回報 SRV 是用原生解析或走 DoH fallback — 在執行環境限制 DNS 時很有用。
 - **全域旗標：** `--version`、`--config <path>`、`--global`、`--use <name>`、`--timeout <ms>`、`--statement-timeout <ms>`、`-v` / `--verbose` / `-vv`、`-q` / `--quiet`、`--no-color`（也尊重 `NO_COLOR`）。除非指令明確宣告 command-level 選項，否則 root-level 旗標必須放在指令之前。

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 

--- a/plugins/dbcli-agent/skills/dbcli/SKILL.md
+++ b/plugins/dbcli-agent/skills/dbcli/SKILL.md
@@ -639,7 +639,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 

--- a/skills/dbcli/SKILL.md
+++ b/skills/dbcli/SKILL.md
@@ -639,7 +639,7 @@ schema. Raw `query` / `export` invocations render a sortable table only.
 ## Notes
 
 - Query-only mode auto-appends `LIMIT 1000`; add `--no-limit` for `information_schema` or statements that break with `LIMIT`.
-- Blacklisted tables and columns are redacted from query output.
+- Blacklisted tables and columns are redacted from query output. Every entry in `blacklist.tables` and `blacklist.columns` is a glob (`*`, `?`, `[a-z]`) on every engine, and a rule is compared against the whole dotted path case-insensitively — a rule spelled `password` also covers `Password`, and `profile.ssn` covers `profile.SSN`; a table literally named `report*` has to be written `report\*` to match literally again. `--fields` is unaffected and still matches exactly. A rule that cannot mean anything is rejected when the config loads rather than silently protecting nothing: a column entry qualified with its own table (`{"users": ["users.password"]}`) fails to load, and an unparsable rule makes every `dbcli es` request fail until it is fixed.
 - `schema` reports `estimatedRowCount` and `sizeCategory` (small / medium / large / huge). For large/huge tables add `WHERE` or `LIMIT` — bands in [reference.md](reference.md#schema).
 - `doctor` on `mongodb+srv://` reports whether SRV resolves natively or through the DoH fallback — useful when the runtime restricts DNS.
 - **Global flags:** `--version`, `--config <path>`, `--global`, `--use <name>`, `--timeout <ms>`, `--statement-timeout <ms>`, `-v` / `--verbose` / `-vv`, `-q` / `--quiet`, `--no-color` (also honours `NO_COLOR`). Root-level flags must precede the command unless the command explicitly declares a command-level option.

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -1102,6 +1102,26 @@ dbcli blacklist column remove users.password
 
 **Subcommands:** `list`, `table add <name>`, `table remove <name>`, `column add <table.column>`, `column remove <table.column>`
 
+**Matching semantics (7.0.0):** every entry in `blacklist.tables` and `blacklist.columns` is a
+glob (`*`, `?`, `[abc]`, `[a-z]`) on **every** engine, not only Redis and Elasticsearch — `tables:
+["secrets*"]` blocks the SQL table `secrets_2026` and the MongoDB collection `secrets_2026` alike.
+A table literally named `report*` has to be written `report\*` to match literally again. Rules and
+returned names are compared over the **whole dotted path, case-insensitively**, so `password` also
+covers `Password` and `profile.ssn` covers `profile.SSN`; folding happens at the comparison and the
+config keeps rules as written. The cost is deliberate over-rejection: where PostgreSQL holds both
+`"Password"` and `"password"`, a rule naming either redacts both. `--fields` is unaffected and still
+matches exactly — it names keys in the document in front of the operator, not a protection rule.
+
+Column-level entries are a **display filter, not an access control**: masking matches returned
+names, so `SELECT password_hash AS x` still returns the value. Table-level entries are the
+enforceable half.
+
+A rule that cannot mean anything fails loudly instead of silently protecting nothing: a column entry
+qualified with its own table (`{"users": ["users.password"]}`) fails to load, and a rule the
+Elasticsearch shell cannot parse (`pass[word`, `a.**`) makes every `dbcli es` request fail until the
+config is fixed. Entries are trimmed and unquoted, and a rule filed under `public.users` applies to
+`SELECT * FROM users` and the reverse.
+
 **`list` options:** `--config <path>`, `--format <text|json>` (default: `text`). JSON writes one
 document to stdout: `{ "tables": string[], "columns": Record<string, string[]>, "warnings":
 [{ "collection", "raw", "reason" }] }`. Invalid MongoDB blacklist patterns appear in `warnings`;
@@ -3546,6 +3566,12 @@ dbcli query "KEYS *"                      # → returns only non-blacklisted key
 ```
 
 Rejections are written to the audit log with `success: false` and `metadata.rejection_reason: 'blacklist'` + `matched_pattern`.
+
+Enforcement covers `q` and `report` as well (7.0.0). Before that, saved queries and the built-in
+`@diag/redis-key-stats` diagnostic ran on an adapter that carried the connection but none of its
+rules, so `dbcli q @<name>` could read a protected key in plaintext and a report could persist
+protected key names. Both now resolve their key targets before execution, apply the connection's
+blacklist and `redis.mask` rules, and drop protected key names from `SCAN` evidence.
 
 ### Value / hash-field masking (v1.22)
 


### PR DESCRIPTION
## 問題

`bun run skill:check` 與 `plugin:check` 只驗結構、清單項與 code token 對齊，不驗內容是否跟得上行為。所以 `assets/SKILL.md`、`assets/SKILL.zh-TW.md`、`assets/reference.md` 在 6.0.0 與 7.0.0 之間一個字都沒動（最後一次實質修改停在 4.0.0 那批），而這兩版改的正是 agent 每次操作第一步要讀的東西——`dbcli blacklist list` 的意思。

三個缺口：

1. `reference.md` 的 `blacklist` 小節只列四個子指令，沒有任何比對語意。agent 照著寫規則會以為條目是字面名稱、大小寫要寫對。
2. `reference.md` 的 Redis「Blacklist enforcement」小節還停在只有 `query` 會被擋的世界，而 7.0.0 的 Security 修的正是 `q @snippet` 與 `report` 先前繞過這層。
3. `SKILL.md` 的 Notes 只有「Blacklisted tables and columns are redacted from query output」一句。

## 改法

`reference.md` 的 `blacklist` 小節補上：每個條目在**所有**引擎都是 glob（`tables: ["secrets*"]` 擋得住 SQL 表與 MongoDB collection，真的叫 `report*` 的表要寫成 `report\*`）、規則與回傳名稱整條點分路徑不分大小寫（含刻意的過度拒絕代價）、`--fields` 不受影響仍是精確比對、欄位層級是顯示過濾而非存取控制、讀不出意思的規則在載入時失敗（以自己的表限定的欄位項、ES shell 無法解析的規則）。

Redis 小節補上 `q` 與 `report` 現在也強制執行、`SCAN` evidence 會移除受保護的 key 名稱，並說明先前的行為，讓讀到舊設定的人知道差別在哪。

`SKILL.md` 與 `SKILL.zh-TW.md` 的 Notes 同步擴寫，兩側 code token 對齊（`skill:check` 從 386 升到 392，兩邊相同）。

## 測試計畫

- `bun run skill:check`：24 sections、392 code tokens，en/zh-TW 對齊
- `bun run plugin:sync` 把十份下游副本（`skills/`、`plugins/dbcli-agent/`、`.cursor/`、`.github/skills/`、`.windsurf/`）帶上，`bun run plugin:check` 全 ok
- `format:check`、`contract:check`、`docs:check` 通過

只動文件，沒有程式碼改動。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B