### PR TITLE
chore: [ release ] 7.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "author": {
     "name": "Carl Lee",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbcli-agent",
   "displayName": "dbcli Agent",
   "description": "Database CLI skill and command reference for AI agents.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "Carl Lee",
     "url": "https://github.com/CarlLee1983"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.1] - 2026-09-02 - agent 讀到的黑名單語意還停在 4.0.0
+
+### Documentation
+
+- **skill 的黑名單語意跟上 6.0.0 與 7.0.0。** `skill:check` 與 `plugin:check` 只驗結構、
+  清單項與 code token 對齊，不驗內容是否跟得上行為，於是 `assets/SKILL.md`、
+  `assets/SKILL.zh-TW.md` 與 `assets/reference.md` 在這兩版之間一個字都沒動——而這兩版改的
+  正是 agent 每次操作第一步要讀的東西。`reference.md` 的 `blacklist` 小節先前只列四個子指令，
+  現在寫明每個條目在所有引擎都是 glob（真的叫 `report*` 的表要寫成 `report\*`）、規則與回傳
+  名稱整條點分路徑不分大小寫、`--fields` 不受影響仍是精確比對、欄位層級是顯示過濾而非存取
+  控制，以及讀不出意思的規則會在載入時失敗而不是靜默不保護。Redis 的 Blacklist enforcement
+  小節補上 `q` 與 `report` 現在也強制執行、`SCAN` evidence 會移除受保護的 key 名稱。
+  `SKILL.md` 的 Notes 兩個語系同步擴寫。十份下游副本由 `plugin:sync` 帶上。
+
 ## [7.0.0] - 2026-09-02 - 一條規則擋得住寫、擋不住讀，差別只在大小寫
 
 ADR-0019 在自己的 Consequences 裡寫下這一則：一份設定的大小寫折疊仍然是三套規則。

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Database CLI skill and command reference for AI agents.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carllee1983/dbcli",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Database CLI for AI agents",
   "type": "module",
   "publishConfig": {

--- a/plugins/dbcli-agent/.codex-plugin/plugin.json
+++ b/plugins/dbcli-agent/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dbcli-agent",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Database CLI skill and command reference for AI agents",
   "author": {
     "name": "Carl Lee",


### PR DESCRIPTION
## 內容

- `package.json` 7.0.0 → 7.0.1
- CHANGELOG 新增 `## [7.0.1] - 2026-09-02`，記 #142 那則 skill 文件更新
- 五份 plugin manifest 由 `manifest:sync` 對齊到 7.0.1
- `SECURITY.md` 不動——major 線仍是 7.x，`manifest:check` 比對的是 major

## 為什麼是 patch

`v7.0.0..main` 只有 #142 一個 commit，13 個檔案全是 skill 文件（`assets/SKILL.md`、`assets/SKILL.zh-TW.md`、`assets/reference.md` 加十份由 `plugin:sync` 帶上的下游副本）。沒有程式碼、CLI 介面或設定語意的變動。

發這一版的理由是 `assets/` 隨套件打包：7.0.0 發出去的 skill 內容還停在 4.0.0 的黑名單語意，安裝它的 agent 會以為條目是字面名稱、大小寫要寫對。

## 測試計畫

`bun run release:check` 九步全過，含 `## [7.0.1]` 標題檢查與 `ok 5 plugin manifests match package.json 7.0.1`。

合併後打 `v7.0.1` tag，npm 發佈由 maintainer 手動進行。

https://claude.ai/code/session_01NK8Xha9waEmYbBeHJGxD4B