### PR TITLE
fix: ForgeFlow 收尾——錯誤分類、診斷邊界與 guide 覆蓋檢查

### DIFF
--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1,77 +1,55 @@
 # ForgeFlow Handoff
 
-DBCLI-011 是最後一個 Story，已交付；工作區乾淨。
+十二個 Story 全數交付，已於 PR #144 合併進 `main`（merge commit `04a88a44`）。
+沒有已知的產品缺口，也沒有選定中的下一個 Story。
 
-DBCLI-002 到 DBCLI-010 與 DBCLI-012 先前已在本分支交付
-(`ca123683`、`743688a3`、`49cbb6b8`、`bc8dd329`、`363436ff`、`41983853`、
-`3278b6fd`、`0861bd41`、`e84f889b`、`6af7592f`)，ForgeFlow 0.3.0 遷移為
-`ee3c9907`。DBCLI-001 由更早的交接紀錄記為已交付；該說法沿用至今，仍未重新驗證。
+## 交付紀錄
 
-DBCLI-007 到 DBCLI-011 都以 baseline conformance 執行：先逐條驗證現況，只在
-驗收條件真的不成立的地方改碼。
+DBCLI-001 到 DBCLI-012 都在 `feat/forgeflow-stories-002-006` 上完成，該分支
+已合併並刪除。每個 Story 的理由寫在自己的 commit body 裡，比這份摘要完整——
+要理解某個決定為什麼是那樣，讀 commit，不要從這裡重新推導。
 
-DBCLI-011 有兩個條件不成立，都落在失敗輸出。第一個是 R5：
-`rejectUnknownKeys` 把被拒絕的 JSON property key 內插進診斷路徑，而那個 key
-完全由產物作者控制——實測 `contract validate` 的 stderr 與
-`contract drift --format json` 會原樣印出帶憑證與絕對路徑的 key。現在改為列出
-允許的 property 名稱，不再複述被拒絕的那一個。第二個是 R1：subject 的形式從未
-被檢查，只檢查是否還在 registry 裡，所以 `table:orders` 這種不支援的形式被判為
-`stale`——與「model 被改名」同一個判決。形式檢查移到 parse 階段，形式不合現在是
-`invalid`，`stale` 只留給形式正確但已不存在的 reference。
+DBCLI-007 到 DBCLI-011 是 baseline conformance：先逐條驗證現況，只在驗收條件
+真的不成立的地方改碼。五個 Story 加起來，**每一個不成立的條件都落在失敗輸出，
+沒有一個在 happy path**。這是這批工作最值得記住的一件事：邊界本身大多早就是
+對的，會出問題的是它壞掉時說了什麼。
 
-Code review 又找出三件事。最重要的是形式檢查本身：第一版把 `field:` 的欄位部分
-限制成 `[A-Za-z_][A-Za-z0-9_$]*`，但 `semanticReferenceRegistry` 是直接用可見
-schema 的欄位名組出 `field:<model>.<column>`，帶連字號、點或非 ASCII 的欄位都
-會被它送出來。那會讓一份 subject 確實在 registry 裡的合法產物從 PASS 變成
-fail closed，是 baseline conformance Story 不該引入的回歸。欄位部分現在只排除
-換行，實際的邊界由 registry 成員檢查負責。`isCanonicalSemanticReference` 沒有
-被重用，因為它同樣窄——它守的是 agent 產生的 query draft，不是已審閱的本機產物。
+DBCLI-001 由更早的交接紀錄記為已交付，該說法一路沿用，至今仍未重新驗證。
 
-另外兩件是命令邊界：`fail()` 直接印任何 Error 的 message，而 `configModule.read`
-的錯誤帶絕對路徑（與 DBCLI-010 同一類），現在走 exact-match 的 `safeMessage`；
-`collectContractEvidence` 用 `loadSnippets` 卻只需要 key，等於讀並解析每一份
-saved query 的 SQL body 還把解析警告印到 stderr，違反 loader 自己寫明的邊界，
-改用 `listSnippetKeys`。
+## 合併後的收尾
 
-新 subject 形式訊息刻意含 "reference" 一字，因為 `src/core/context/context-v2.ts`
-用 `message.includes('reference')` 分類錯誤碼；不這樣寫會把已交付的
-`INVALID_RESOURCE_REFERENCE` 悄悄改成 `INVALID_SEMANTIC_CONTEXT`。那個 substring
-判斷本身很脆弱，但收斂它不屬於本 Story。
+`chore/post-forgeflow-cleanup` 處理了 DBCLI-011 的 code review 留下、但不屬於
+該 Story 範圍的三件事：
 
-`validateSubjects` 先查 blacklist 再查形式，所以形式錯誤不會蓋掉「這個 subject
-指向受保護資料」這個對審查者更重要的訊號。
+- `src/core/data-access/index.ts` 的 `rejectUnknownKeys` 仍把被拒絕的 key 內插
+  進診斷路徑，與 DBCLI-011 修掉的是同一類。已改為列出允許的屬性名稱。
+- `context-v2.ts` 用 `message.includes('reference')` 判斷錯誤碼。實際查過之後
+  這個 substring 比對比 review 講的更糟：它把「重複的 reference」與「來源檔
+  路徑不可用」也一併判成 `INVALID_RESOURCE_REFERENCE`。三個模組現在各自匯出
+  一個以具名常數做精確比對的述詞，判斷留在擁有那些訊息的模組裡。
+  `INVALID_RESOURCE_REFERENCE` 先前完全沒有測試覆蓋，這正是過度分類沒被發現
+  的原因；現在六個分類情境都有測試。
+- `verification-evidence` 併入 `guides-pages` 的 `guideSlugs`。同時加上一個
+  讀目錄的檢查：`guideSlugs` 是手維護的清單，曾經有三份 guide 長期落在結構、
+  連結與英文純度檢查之外，靠人維護清單擋不住第四份。
 
-文件方面：英文版 Pages guide 缺了中文版有的 evidence policy 列舉；四個
-`docs/user/{en,zh-TW}/index.{md,html}` 版面本來就對齊，新增的兩條行為由
-`tests/unit/skill-assets/semantic-contract-docs.test.ts` 釘住。
-`semantic-contracts` 已加入 `tests/docs/guides-pages.test.ts` 的 `guideSlugs`，
-現在只剩 `verification-evidence` 不在結構檢查內。
+順帶：DBCLI-011 的 subject 形式訊息當初刻意含 "reference" 一字，只為了遷就那個
+substring 比對。述詞落地後那個字不再承載任何東西，訊息已改回
+`must use a supported semantic subject form`。
 
-新增的每一條斷言都做過 mutation 檢查：把行為改回舊版，對應的測試會紅。
+## 仍未處理
 
-`make verify` 仍因與任何 Story 無關的原因無法 PASS：`bun audit` 回報兩個既有的
-moderate 漏洞（eslint 依賴的 `@humanfs/node`、`mysql2`）。`package.json` 與
-`bun.lock` 未被本次工作動到。其餘 24 個步驟逐項執行全部通過，包含
-`SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test`
-（6357 pass、0 fail）。
-
-分支仍未推送，也沒有 PR。已知的產品缺口沒有剩下的了。
-
-## 未在本 Story 範圍內的待辦
-
-- `src/core/data-access/index.ts:285` 仍用 `` `${path}.${key}` `` 內插被拒絕的
-  key，與本 Story 修掉的是同一類。目前被 `src/commands/impact.ts` 的訊息
-  allowlist 擋住，但三個同級 validator 現在有三種寫法。
-- `context-v2.ts` 以 substring 判斷錯誤分類。
-- 四個 doc-contract 測試共用相似的文字正規化卻各自 scope；沿用 DBCLI-009 的
-  決定不合併，合併會改到已交付 Story 的斷言語意。
+- 四個 doc-contract 測試共用相似的文字正規化卻各自 scope。沿用 DBCLI-009 的
+  決定不合併：合併會改到已交付 Story 的斷言語意。
+- `loadSemanticContext` 不拒絕 `version: 2` 的 semantic 產物——寫收尾測試時
+  發現的，與上述三件事無關，也還沒判斷它是不是缺陷。
 
 ## Lifecycle
 
 ```yaml
 workflow:
   current_story: none
-  next_story: pending
+  next_story: none
   completed_stories:
     - DBCLI-001
     - DBCLI-002
@@ -85,17 +63,17 @@ workflow:
     - DBCLI-010
     - DBCLI-011
     - DBCLI-012
-  status: awaiting_selection
+  status: all_delivered
 
 baseline:
   repository: CarlLee1983/dbcli
-  branch: feat/forgeflow-stories-002-006
-  commit: 9124a4bd876c321aae8c8dc2daa92f89f648e0a7
+  branch: main
+  commit: 04a88a44bdc5025febf77cd5a739d59226df35a7
   dirty_worktree: false
   story_owned_paths: []
   known_unrelated_paths: []
 
 verification:
   last_command: make verify
-  result: blocked_on_preexisting_bun_audit
+  result: pass
 ```

--- a/src/core/context/context-v2.ts
+++ b/src/core/context/context-v2.ts
@@ -11,12 +11,14 @@ import { configModule } from '@/core/config'
 import { resolveConfigStoragePath } from '@/core/config-binding'
 import {
   filterApprovedSemanticContracts,
+  hasSemanticContractReferenceIssue,
   loadSemanticContracts,
   SemanticContractValidationError,
   type SemanticContract,
 } from '@/core/contracts'
 import {
   defaultDataAccessManifestFile,
+  hasDataAccessReferenceIssue,
   loadDataAccessManifest,
   DataAccessManifestValidationError,
   type DataAccessOperation,
@@ -27,6 +29,7 @@ import { resolveSnippetDirs } from '@/core/saved-queries/snippet-paths'
 import type { ResolvedSnippet } from '@/core/saved-queries/types'
 import {
   containsBlockedSemanticIdentifier,
+  hasSemanticReferenceIssue,
   loadSemanticContext,
   semanticReferenceRegistry,
   SemanticValidationError,
@@ -254,10 +257,7 @@ export async function gatherContextV2(
       missingFile: 'allow',
     })
   } catch (error) {
-    if (
-      error instanceof SemanticValidationError &&
-      error.issues.some(({ message }) => message.includes('reference'))
-    ) {
+    if (error instanceof SemanticValidationError && hasSemanticReferenceIssue(error.issues)) {
       throw new ContextV2Error('INVALID_RESOURCE_REFERENCE')
     }
     throw new ContextV2Error('INVALID_SEMANTIC_CONTEXT')
@@ -284,7 +284,7 @@ export async function gatherContextV2(
   } catch (error) {
     if (
       error instanceof SemanticContractValidationError &&
-      error.issues.some(({ message }) => message.includes('reference'))
+      hasSemanticContractReferenceIssue(error.issues)
     ) {
       throw new ContextV2Error('INVALID_RESOURCE_REFERENCE')
     }
@@ -303,7 +303,7 @@ export async function gatherContextV2(
   } catch (error) {
     if (
       error instanceof DataAccessManifestValidationError &&
-      error.issues.some(({ message }) => message.includes('reference'))
+      hasDataAccessReferenceIssue(error.issues)
     ) {
       throw new ContextV2Error('INVALID_RESOURCE_REFERENCE')
     }

--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -21,6 +21,23 @@ export interface SemanticContractValidationIssue {
   message: string
 }
 
+/**
+ * The issues that mean "the referenced entity is unavailable or protected",
+ * as opposed to "the artifact is malformed". Consumers classify on these
+ * exact literals rather than searching the message for a word: a substring
+ * test silently reclassifies every message that later grows that word.
+ */
+const PROTECTED_SUBJECT = 'must not contain a protected semantic reference'
+const UNAVAILABLE_SUBJECT = 'must reference an available semantic entity'
+const REFERENCE_MESSAGES: ReadonlySet<string> = new Set([PROTECTED_SUBJECT, UNAVAILABLE_SUBJECT])
+
+/** True when a failure is about the referenced entity, not the artifact shape. */
+export function hasSemanticContractReferenceIssue(
+  issues: readonly SemanticContractValidationIssue[]
+): boolean {
+  return issues.some(({ message }) => REFERENCE_MESSAGES.has(message))
+}
+
 export class SemanticContractValidationError extends Error {
   constructor(
     readonly filePath: string,
@@ -272,13 +289,13 @@ function validateSubjects(
       if (containsBlockedIdentifier(subject, blocked)) {
         // Checked before the form guard below: a malformed subject that names
         // blacklisted data is the more important thing to tell a reviewer.
-        issue(issues, path, 'must not contain a protected semantic reference')
+        issue(issues, path, PROTECTED_SUBJECT)
       } else if (!SUBJECT_FORM.test(subject)) {
         // A malformed subject already carries its own parse issue; asking the
         // registry about it would report the same subject twice.
         continue
       } else if (!registry.has(subject)) {
-        issue(issues, path, 'must reference an available semantic entity')
+        issue(issues, path, UNAVAILABLE_SUBJECT)
       }
     }
   }
@@ -297,7 +314,7 @@ function parseSubjects(
   return values.map((value, index) => {
     const subject = text(value, `${path}[${index}]`, MAX_NAME_LENGTH, issues)
     if (subject.length > 0 && !SUBJECT_FORM.test(subject)) {
-      issue(issues, `${path}[${index}]`, 'must use a supported semantic subject reference form')
+      issue(issues, `${path}[${index}]`, 'must use a supported semantic subject form')
     } else if (seen.has(subject)) {
       issue(issues, `${path}[${index}]`, 'duplicate subject')
     }

--- a/src/core/data-access/index.ts
+++ b/src/core/data-access/index.ts
@@ -27,6 +27,24 @@ export interface DataAccessManifestIssue {
   message: string
 }
 
+/**
+ * The issues that mean "the referenced entity is unavailable or protected".
+ * A duplicate reference, an unbounded reference list, and an unusable source
+ * path are malformed-manifest problems, so they are deliberately absent: the
+ * substring test this replaced classified all three as reference failures.
+ */
+const PROTECTED_REFERENCE = 'must not contain a protected semantic reference'
+const UNAVAILABLE_REFERENCE = 'must reference an available semantic entity'
+const REFERENCE_MESSAGES: ReadonlySet<string> = new Set([
+  PROTECTED_REFERENCE,
+  UNAVAILABLE_REFERENCE,
+])
+
+/** True when a failure is about the referenced entity, not the manifest shape. */
+export function hasDataAccessReferenceIssue(issues: readonly DataAccessManifestIssue[]): boolean {
+  return issues.some(({ message }) => REFERENCE_MESSAGES.has(message))
+}
+
 export class DataAccessManifestValidationError extends Error {
   readonly issues: readonly DataAccessManifestIssue[]
 
@@ -173,9 +191,9 @@ function parseReferences(
     if (!isCanonicalSemanticReference(reference)) {
       issue(issues, `${path}[${index}]`, 'must be a canonical semantic reference')
     } else if (containsBlockedSemanticIdentifier(reference, blocked)) {
-      issue(issues, `${path}[${index}]`, 'must not contain a protected semantic reference')
+      issue(issues, `${path}[${index}]`, PROTECTED_REFERENCE)
     } else if (!registry.has(reference)) {
-      issue(issues, `${path}[${index}]`, 'must reference an available semantic entity')
+      issue(issues, `${path}[${index}]`, UNAVAILABLE_REFERENCE)
     }
     return reference
   })
@@ -275,14 +293,19 @@ function text(value: unknown, path: string, issues: DataAccessManifestIssue[]): 
   return ''
 }
 
+/**
+ * Names the allowed properties rather than the rejected one: a rejected key is
+ * manifest input, and these diagnostics reach `impact assess` output.
+ */
 function rejectUnknownKeys(
   value: Record<string, unknown>,
   allowed: readonly string[],
   path: string,
   issues: DataAccessManifestIssue[]
 ): void {
-  for (const key of Object.keys(value))
-    if (!allowed.includes(key)) issue(issues, `${path}.${key}`, 'is not allowed')
+  if (Object.keys(value).some((key) => !allowed.includes(key))) {
+    issue(issues, path, `must contain only these properties: ${allowed.join(', ')}`)
+  }
 }
 
 function issue(issues: DataAccessManifestIssue[], path: string, message: string): void {

--- a/src/core/semantic/index.ts
+++ b/src/core/semantic/index.ts
@@ -139,6 +139,27 @@ const MAX_TEXT_LENGTH = 1_000
 const DEFAULT_SEARCH_LIMIT = 20
 const MAX_SEARCH_LIMIT = 100
 const IDENTIFIER = /^[a-z][a-z0-9-]*$/
+
+/**
+ * The issues that mean "the referenced entity is unavailable", as opposed to
+ * "the artifact is malformed". Consumers classify on these exact literals
+ * rather than searching the message for a word.
+ */
+const UNAVAILABLE_TABLE = 'must reference a visible cached table'
+const UNAVAILABLE_SAVED_QUERY = 'must reference an available saved query'
+const UNDECLARED_MODEL = 'must reference a declared model'
+const UNDECLARED_FIELD = 'must reference a declared field on the model'
+const REFERENCE_MESSAGES: ReadonlySet<string> = new Set([
+  UNAVAILABLE_TABLE,
+  UNAVAILABLE_SAVED_QUERY,
+  UNDECLARED_MODEL,
+  UNDECLARED_FIELD,
+])
+
+/** True when a failure is about the referenced entity, not the artifact shape. */
+export function hasSemanticReferenceIssue(issues: readonly SemanticValidationIssue[]): boolean {
+  return issues.some(({ message }) => REFERENCE_MESSAGES.has(message))
+}
 const CARDINALITIES = new Set<SemanticRelationshipCardinality>([
   'one-to-one',
   'one-to-many',
@@ -519,7 +540,7 @@ function validateReferences(
   for (const [modelIndex, model] of context.models.entries()) {
     const path = `$.models[${modelIndex}]`
     const table = schema[model.table]
-    if (!table) issue(issues, `${path}.table`, 'must reference a visible cached table')
+    if (!table) issue(issues, `${path}.table`, UNAVAILABLE_TABLE)
     for (const [fieldIndex, field] of model.fields.entries()) {
       if (table && !table.columns.some((candidate) => candidate.name === field.column)) {
         issue(
@@ -532,7 +553,7 @@ function validateReferences(
   }
   for (const [metricIndex, metric] of context.metrics.entries()) {
     if (!snippetKeys.has(metric.query)) {
-      issue(issues, `$.metrics[${metricIndex}].query`, 'must reference an available saved query')
+      issue(issues, `$.metrics[${metricIndex}].query`, UNAVAILABLE_SAVED_QUERY)
     }
   }
 }
@@ -613,9 +634,9 @@ function parseEndpoint(
   const model = namedString(value.model, `${path}.model`, issues)
   const field = requiredText(value.field, `${path}.field`, issues)
   const target = models.find((candidate) => candidate.name === model)
-  if (!target) issue(issues, `${path}.model`, 'must reference a declared model')
+  if (!target) issue(issues, `${path}.model`, UNDECLARED_MODEL)
   else if (!target.fields.some((candidate) => candidate.column === field)) {
-    issue(issues, `${path}.field`, 'must reference a declared field on the model')
+    issue(issues, `${path}.field`, UNDECLARED_FIELD)
   }
   return { model, field }
 }

--- a/tests/docs/guides-pages.test.ts
+++ b/tests/docs/guides-pages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { Window } from 'happy-dom'
+import { readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -10,6 +11,7 @@ const guideSlugs = [
   'offline-impact-assessment',
   'evidence-packs',
   'semantic-contracts',
+  'verification-evidence',
   'slow-endpoint',
   'why-dbcli',
   // Not `as const`, for the same reason as `locales` below.
@@ -40,6 +42,25 @@ async function loadPage(path: string) {
   window.document.write(html)
   return { html, document: window.document }
 }
+
+/**
+ * `guideSlugs` is a hand-kept list, and three guides once sat outside it for
+ * several releases with no hub, structure, link or English-purity checking.
+ * Reading the directory is what stops a fourth from doing the same.
+ */
+describe('guide coverage', () => {
+  test.each(locales.map(({ locale, directory }) => [locale, directory]))(
+    '%s: every published guide is listed in guideSlugs',
+    async (_locale, directory) => {
+      const published = (await readdir(directory))
+        .filter((entry) => entry.endsWith('.html') && entry !== 'index.html')
+        .map((entry) => entry.replace(/\.html$/, ''))
+        .sort()
+
+      expect(published).toEqual([...guideSlugs].sort())
+    }
+  )
+})
 
 describe.each(locales)(
   '$locale guide collection',

--- a/tests/unit/commands/contracts.test.ts
+++ b/tests/unit/commands/contracts.test.ts
@@ -282,7 +282,7 @@ describe('contract commands', () => {
       issues: [
         {
           path: '$.contracts[0].subjects[0]',
-          message: 'must use a supported semantic subject reference form',
+          message: 'must use a supported semantic subject form',
         },
       ],
     })

--- a/tests/unit/core/context/context-v2.test.ts
+++ b/tests/unit/core/context/context-v2.test.ts
@@ -429,6 +429,129 @@ SELECT 'CANARY_QUERY_BODY' FROM users WHERE id >= :min_id`)
     await expect(gatherContextV2(workspace, configPath)).rejects.toBeInstanceOf(ContextV2Error)
   })
 
+  /**
+   * `INVALID_RESOURCE_REFERENCE` had no coverage at all, which is how a
+   * substring test on the issue message ("reference") kept classifying a
+   * duplicate reference and an unusable source path as reference failures.
+   */
+  describe('invalid-evidence classification', () => {
+    const SCHEMA = {
+      orders: {
+        name: 'orders',
+        columns: [{ name: 'customer_id', type: 'int', nullable: false }],
+      },
+    }
+
+    async function writeSemantic(): Promise<void> {
+      await Bun.file(join(workspace, 'dbcli.semantic.json')).write(
+        JSON.stringify({
+          version: 1,
+          models: [{ name: 'orders', table: 'orders', fields: [{ column: 'customer_id' }] }],
+          metrics: [],
+        })
+      )
+    }
+
+    async function writeDataAccess(operation: Record<string, unknown>): Promise<void> {
+      await Bun.file(join(workspace, 'dbcli.data-access.json')).write(
+        JSON.stringify({ version: 1, operations: [operation] })
+      )
+    }
+
+    const VALID_OPERATION = {
+      name: 'orders.list',
+      source: 'src/orders.ts',
+      kind: 'read',
+      references: ['model:orders'],
+      coverage: 'declared',
+    }
+
+    beforeEach(async () => {
+      mkdirSync(join(workspace, 'src'), { recursive: true })
+      await Bun.file(join(workspace, 'src', 'orders.ts')).write('export {}\n')
+    })
+
+    test('an unknown semantic reference in the manifest is a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await writeSemantic()
+      await writeDataAccess({ ...VALID_OPERATION, references: ['model:not-declared'] })
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_RESOURCE_REFERENCE',
+      })
+    })
+
+    test('a duplicate reference is a malformed manifest, not a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await writeSemantic()
+      await writeDataAccess({ ...VALID_OPERATION, references: ['model:orders', 'model:orders'] })
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_DATA_ACCESS_MANIFEST',
+      })
+    })
+
+    test('an unusable source path is a malformed manifest, not a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await writeSemantic()
+      await writeDataAccess({ ...VALID_OPERATION, source: 'src/does-not-exist.ts' })
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_DATA_ACCESS_MANIFEST',
+      })
+    })
+
+    test('an unknown semantic model reference is a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await Bun.file(join(workspace, 'dbcli.semantic.json')).write(
+        JSON.stringify({
+          version: 1,
+          models: [{ name: 'orders', table: 'not-a-visible-table', fields: [] }],
+          metrics: [],
+        })
+      )
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_RESOURCE_REFERENCE',
+      })
+    })
+
+    test('a malformed semantic artifact is an invalid context, not a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await Bun.file(join(workspace, 'dbcli.semantic.json')).write(
+        JSON.stringify({ version: 1, models: 'not-an-array', metrics: [] })
+      )
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_SEMANTIC_CONTEXT',
+      })
+    })
+
+    test('an unknown contract subject is a reference failure', async () => {
+      await writeConfig('postgresql', SCHEMA)
+      await writeSemantic()
+      await Bun.file(join(workspace, 'dbcli.contracts.json')).write(
+        JSON.stringify({
+          version: 1,
+          contracts: [
+            {
+              name: 'active-customer',
+              status: 'approved',
+              description: 'A customer definition.',
+              subjects: ['model:not-declared'],
+              owner: 'growth',
+              evidencePolicy: 'none',
+            },
+          ],
+        })
+      )
+
+      await expect(gatherContextV2(workspace, configPath)).rejects.toMatchObject({
+        code: 'INVALID_RESOURCE_REFERENCE',
+      })
+    })
+  })
+
   test('emits stable missing-evidence gaps instead of ambiguous empty resources', async () => {
     await writeConfig('mysql')
 

--- a/tests/unit/core/contracts/contracts.test.ts
+++ b/tests/unit/core/contracts/contracts.test.ts
@@ -251,7 +251,7 @@ A customer with a paid order in the trailing 30 days.
     await expect(
       loadSemanticContracts({ workspaceRoot: workspace!, filePath, references })
     ).rejects.toThrow(
-      /bounded plain text.*supported semantic subject reference form.*available semantic entity/
+      /bounded plain text.*supported semantic subject form.*available semantic entity/
     )
   })
 
@@ -320,7 +320,7 @@ A customer with a paid order in the trailing 30 days.
     expect(report.issues).toEqual([
       {
         path: '$.contracts[0].subjects[0]',
-        message: 'must use a supported semantic subject reference form',
+        message: 'must use a supported semantic subject form',
       },
     ])
   })
@@ -382,7 +382,7 @@ A customer with a paid order in the trailing 30 days.
       expect((error as SemanticContractValidationError).issues).toEqual([
         {
           path: '$.contracts[0].subjects[0]',
-          message: 'must use a supported semantic subject reference form',
+          message: 'must use a supported semantic subject form',
         },
       ])
     }
@@ -406,7 +406,7 @@ A customer with a paid order in the trailing 30 days.
       issues: [
         {
           path: '$.contracts[0].subjects[0]',
-          message: 'must use a supported semantic subject reference form',
+          message: 'must use a supported semantic subject form',
         },
       ],
     })

--- a/tests/unit/core/data-access/data-access.test.ts
+++ b/tests/unit/core/data-access/data-access.test.ts
@@ -51,6 +51,38 @@ describe('data-access manifest', () => {
     ])
   })
 
+  test('reports an unsupported property without reproducing the rejected key', async () => {
+    const seededKey = 'SECRET-8d02-/Users/example/private/leak.txt'
+
+    try {
+      await normalizeDataAccessManifest(
+        {
+          version: 1,
+          [seededKey]: 'x',
+          operations: [
+            {
+              name: 'orders.list',
+              source: 'src/orders.ts',
+              kind: 'read',
+              references: ['model:orders'],
+              coverage: 'declared',
+              [seededKey]: 'x',
+            },
+          ],
+        },
+        { workspaceRoot: workspace, references }
+      )
+      throw new Error('expected validation failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(DataAccessManifestValidationError)
+      const issues = (error as DataAccessManifestValidationError).issues
+      expect(JSON.stringify(issues)).not.toContain(seededKey)
+      expect(JSON.stringify(issues)).not.toContain('SECRET')
+      expect(issues.map(({ path }) => path)).toEqual(['$', '$.operations[0]'])
+      expect(issues[0]?.message).toContain('version, operations')
+    }
+  })
+
   test('rejects duplicate names, unknown references, and missing declared coverage without exposing protected text', async () => {
     await expect(
       normalizeDataAccessManifest(


### PR DESCRIPTION
## 這個 PR 是什麼

PR #144 合併後的收尾。三件事來自 DBCLI-011 的 code review，當時判定不屬於該
Story 範圍而記在交接紀錄裡；加上把交接紀錄本身收尾到合併後的狀態。

## 1. 錯誤分類改用精確述詞（`05a09d3c`）

`context-v2.ts` 有三處用 `message.includes('reference')` 決定回哪個錯誤碼。
實際查過之後，這個 substring 比對比 review 講的更糟——data-access 那邊有七個
訊息含 "reference"：

| 訊息 | 現況分類 | 應該是 |
| --- | --- | --- |
| `must reference an available semantic entity` | reference | reference ✓ |
| `must not contain a protected semantic reference` | reference | reference ✓ |
| `must be a canonical semantic reference` | reference | 產物形狀錯 |
| `duplicate reference` | reference | 產物形狀錯 |
| `must contain bounded references` | reference | 產物形狀錯 |
| `must reference a regular source file` | reference | 產物形狀錯 |
| `must reference an existing source file` | reference | 產物形狀錯 |

也就是說，一個重複的 reference 或一個路徑打錯的來源檔，會告訴 agent
「你引用的資源無效」，而不是「你的檔案壞了」。

`contracts`、`data-access`、`semantic` 三個模組現在各自匯出一個述詞，以具名
常數做精確比對。判斷留在擁有那些訊息的模組裡，而不是在消費端猜字——一個字串
日後改寫時，要改的地方和訊息在同一個檔案。

**判別刻意不放進 issue 物件**：`contract drift --format json` 會把 `issues`
直接序列化給使用者，加欄位等於改已交付的輸出契約。

`INVALID_RESOURCE_REFERENCE` 先前**完全沒有測試覆蓋**，這正是過度分類一直沒被
發現的原因。補上六個分類情境（reference 失敗、重複 reference、來源檔路徑、
semantic model reference、產物形狀、contract subject）。

順帶：DBCLI-011 的 subject 形式訊息當初刻意含 "reference" 一字，只為了遷就那個
substring 比對，commit body 也寫明了那個字是承載語意的。述詞落地後它不再承載
任何東西，訊息改回 `must use a supported semantic subject form`。

## 2. data-access 診斷不再複述被拒的 key（同一個 commit）

`src/core/data-access/index.ts` 的 `rejectUnknownKeys` 仍把被拒絕的 JSON key
內插進診斷路徑，與 DBCLI-011 修掉的是同一類。那些診斷會出現在
`impact assess` 的輸出裡。改為列出允許的屬性名稱。

## 3. guideSlugs 改由目錄檢查（`eb6b39e4`）

`guideSlugs` 是手維護的清單，曾經有三份 guide 長期落在 hub、結構、連結與英文
純度檢查之外，各自等到自己的 Story 才被補進去。`verification-evidence` 是最後
一份，現在補齊。

補齊清單只解決今天，所以另加一個讀目錄的檢查：published 的 guide 必須與
`guideSlugs` 完全一致。第四份漏掉的 guide 會讓測試紅，而不是安靜地少一層檢查。

## 4. 交接紀錄收尾（`4b6c409a`）

先前的版本停在「分支仍未推送，也沒有 PR」，baseline 指著一個已刪除的分支。

## 測試計畫

```bash
make verify   # exit 0
```

- 全套測試 **6368 pass / 0 fail**（551 檔案，需要 docker 測試服務）
- `bun audit` 無漏洞
- 每一項修改都做過 mutation 檢查：把行為改回舊版，對應測試會紅
  - substring 分類復原 → 2 個分類測試紅
  - data-access key 內插復原 → 洩漏測試紅
  - 從 guideSlugs 拿掉一個 slug → 兩個語系的覆蓋檢查都紅

## 未處理

- 四個 doc-contract 測試共用相似的文字正規化卻各自 scope。沿用 DBCLI-009 的
  決定不合併：合併會改到已交付 Story 的斷言語意。
- `loadSemanticContext` 不拒絕 `version: 2` 的 semantic 產物——寫收尾測試時
  順手發現的，與這批收尾無關，也還沒判斷它是不是缺陷。已記在交接紀錄。

https://claude.ai/code/session_0184YnKPFgwjck9aBmDAwFYo
