### PR TITLE
chore: 升級 ForgeFlow 0.3.1，並對帳 completed_stories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
+        with:
+          # `make verify` runs forgeflow:check, which reconciles the handoff's
+          # completed Stories against `Story:` commit trailers. A shallow clone
+          # has no trailers to read.
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ verify:
 	bun run docs:check
 	bun run contract:check
 	bun run plan:check
+	bun run forgeflow:check

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "agent-core:check": "bun run scripts/check-agent-core-purity.ts",
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "plan:check": "bun run scripts/check-plan-acceptance.ts",
+    "forgeflow:check": "bun run scripts/check-forgeflow-handoff.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -1,0 +1,160 @@
+/**
+ * Gate: every Story the handoff calls delivered is backed by the repository.
+ *
+ * `specs/handoff.md` records `completed_stories` as a plain list, and nothing
+ * compared it to anything. DBCLI-001 sat in that list across ten handoff
+ * revisions, was described in four of them as "recorded as delivered by an
+ * earlier handoff; that claim is carried forward and has still not been
+ * re-verified", and no session ever spent the two minutes to settle it. It
+ * turned out to be true. That is the point: an unbacked claim is not
+ * necessarily false, it is unchecked, and an unchecked claim survives by
+ * inertia until someone finally looks.
+ *
+ * Upstream ForgeFlow 0.3.1 added `scripts/story-check` and
+ * `scripts/handoff-check`, and this gate deliberately does not overlap them.
+ * Those are static structure checks over the text a human wrote, and their own
+ * documentation is explicit that they never decide whether a declaration is
+ * truthful. They live in a ForgeFlow checkout, so CI cannot run them anyway.
+ * This gate checks the one thing they exclude: does the repository actually
+ * contain what the handoff says it contains.
+ *
+ * A Story is backed when a commit carries its `Story: <ID>` trailer. Stories
+ * delivered before that convention existed are backed instead by an explicit
+ * DELIVERED_BEFORE_TRAILERS entry naming the commit and the evidence, so the
+ * claim travels with its proof rather than with a promise to check later.
+ *
+ * That map is a ratchet, not an amnesty. It may shrink and never grow: a new
+ * Story must carry a trailer. An entry whose commit stops existing fails, and
+ * so does an entry for a Story that has since acquired a trailer — a stale
+ * exemption is drift of the same kind this gate exists to catch.
+ */
+
+import { $ } from 'bun'
+
+const repoRoot = new URL('../', import.meta.url)
+const handoffPath = new URL('specs/handoff.md', repoRoot)
+const storiesRoot = new URL('specs/stories/', repoRoot)
+
+/**
+ * Stories delivered before commits carried `Story:` trailers.
+ *
+ * Each entry names the commit that delivered it and the evidence that was
+ * re-run to confirm it, so the claim is checkable without reading history.
+ * Only ever remove entries.
+ */
+const DELIVERED_BEFORE_TRAILERS: ReadonlyMap<string, { commit: string; evidence: string }> =
+  new Map([
+    [
+      'DBCLI-001',
+      {
+        commit: '3a310d08eb0460b1d0334453009d734a2d5c5ecb',
+        evidence:
+          "tests/unit/commands/skill-context.test.ts 'preserves semantic context when the optional contracts file is absent without creating an adapter' and tests/unit/core/contracts/contracts.test.ts 'reports invalid drift without disclosing arbitrary input or creating an adapter'",
+      },
+    ],
+  ])
+
+interface Failure {
+  story: string
+  reason: string
+}
+
+/** Reads the lifecycle block's `completed_stories` list. */
+function completedStories(handoff: string): string[] {
+  const lifecycle = handoff.match(/```yaml\n([\s\S]*?)```/)
+  if (!lifecycle) throw new Error('specs/handoff.md has no lifecycle block')
+  const list = lifecycle[1]?.match(/completed_stories:\n((?:\s+-\s+\S+\n)+)/)
+  if (!list) throw new Error('the lifecycle block records no completed_stories')
+  return [...(list[1] ?? '').matchAll(/-\s+(\S+)/g)].map(([, id]) => id as string)
+}
+
+/** Story IDs that have a `Story: <ID>` trailer somewhere in history. */
+async function storiesWithTrailers(): Promise<Set<string>> {
+  const log = await $`git log --all --format=%b`.text()
+  return new Set([...log.matchAll(/^Story:\s*(\S+)\s*$/gm)].map(([, id]) => id as string))
+}
+
+async function commitExists(commit: string): Promise<boolean> {
+  try {
+    await $`git cat-file -e ${`${commit}^{commit}`}`.quiet()
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function storyDirectories(): Promise<Map<string, string>> {
+  const entries = await Array.fromAsync(
+    new Bun.Glob('DBCLI-*/story.md').scan({ cwd: storiesRoot.pathname })
+  )
+  return new Map(
+    entries.map((entry) => {
+      const directory = entry.replace(/\/story\.md$/, '')
+      return [directory.replace(/^(DBCLI-\d+).*$/, '$1'), directory]
+    })
+  )
+}
+
+const handoff = await Bun.file(handoffPath).text()
+const completed = completedStories(handoff)
+const trailers = await storiesWithTrailers()
+const directories = await storyDirectories()
+const failures: Failure[] = []
+
+for (const story of completed) {
+  const directory = directories.get(story)
+  if (!directory) {
+    failures.push({ story, reason: 'is recorded as completed but has no specs/stories directory' })
+    continue
+  }
+
+  const exemption = DELIVERED_BEFORE_TRAILERS.get(story)
+  if (trailers.has(story)) {
+    if (exemption) {
+      failures.push({
+        story,
+        reason:
+          'now carries a Story: trailer, so its DELIVERED_BEFORE_TRAILERS entry is stale — delete the entry',
+      })
+    }
+    continue
+  }
+
+  if (!exemption) {
+    failures.push({
+      story,
+      reason:
+        'is recorded as completed but no commit carries its `Story:` trailer — deliver it, or record the delivering commit and its evidence in DELIVERED_BEFORE_TRAILERS',
+    })
+    continue
+  }
+
+  if (!(await commitExists(exemption.commit))) {
+    failures.push({
+      story,
+      reason: `names delivering commit ${exemption.commit}, which this repository does not contain`,
+    })
+  }
+}
+
+for (const story of DELIVERED_BEFORE_TRAILERS.keys()) {
+  if (!completed.includes(story)) {
+    failures.push({
+      story,
+      reason: 'has a DELIVERED_BEFORE_TRAILERS entry but is not recorded as completed',
+    })
+  }
+}
+
+if (failures.length > 0) {
+  console.error('ForgeFlow handoff reconciliation failed:\n')
+  for (const { story, reason } of failures) console.error(`  ${story} ${reason}`)
+  console.error(`\n${failures.length} unbacked claim(s) in specs/handoff.md.`)
+  process.exit(1)
+}
+
+const exempt = DELIVERED_BEFORE_TRAILERS.size
+console.log(
+  `forgeflow handoff reconciliation passed: ${completed.length} completed Stories ` +
+    `(${completed.length - exempt} by commit trailer, ${exempt} by recorded delivering commit)`
+)

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -27,6 +27,13 @@
  * Story must carry a trailer. An entry whose commit stops existing fails, and
  * so does an entry for a Story that has since acquired a trailer — a stale
  * exemption is drift of the same kind this gate exists to catch.
+ *
+ * A shallow clone is refused rather than tolerated. `actions/checkout` fetches
+ * `--depth=1` by default, and under it `git log` sees one commit, no trailers,
+ * and every Story looks unbacked — twelve confident failures with one real
+ * cause. Skipping instead would be worse: a gate that quietly passes wherever
+ * its evidence is missing is a gate that passes in CI and nowhere else. So it
+ * says which condition it cannot check, and CI hands it full history.
  */
 
 import { $ } from 'bun'
@@ -93,6 +100,17 @@ async function storyDirectories(): Promise<Map<string, string>> {
       return [directory.replace(/^(DBCLI-\d+).*$/, '$1'), directory]
     })
   )
+}
+
+if ((await $`git rev-parse --is-shallow-repository`.text()).trim() === 'true') {
+  console.error(
+    'ForgeFlow handoff reconciliation cannot run: this is a shallow clone.\n\n' +
+      '  Commit trailers are the evidence this gate reads, and a shallow clone has\n' +
+      '  almost none of them. Fetch full history first:\n\n' +
+      '    git fetch --unshallow          # locally\n' +
+      '    actions/checkout with fetch-depth: 0   # in CI\n'
+  )
+  process.exit(1)
 }
 
 const handoff = await Bun.file(handoffPath).text()

--- a/specs/.forgeflow-adoption
+++ b/specs/.forgeflow-adoption
@@ -1,0 +1,2 @@
+version=0.3.1
+revision=1096ef5125f1e2d7c304f65d5c7405b76aadf335

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1,7 +1,8 @@
 # ForgeFlow Handoff
 
-十二個 Story 全數交付，已於 PR #144 合併進 `main`（merge commit `04a88a44`）。
-沒有已知的產品缺口，也沒有選定中的下一個 Story。
+十二個 Story 全數交付，已於 PR #144 合併進 `main`（merge commit `04a88a44`），
+合併後的收尾為 PR #145（`a2a05cc2`）。沒有已知的產品缺口，也沒有選定中的
+下一個 Story。
 
 ## 交付紀錄
 
@@ -14,7 +15,22 @@ DBCLI-007 到 DBCLI-011 是 baseline conformance：先逐條驗證現況，只�
 沒有一個在 happy path**。這是這批工作最值得記住的一件事：邊界本身大多早就是
 對的，會出問題的是它壞掉時說了什麼。
 
-DBCLI-001 由更早的交接紀錄記為已交付，該說法一路沿用，至今仍未重新驗證。
+DBCLI-001 的交付狀態已驗證並結案。它跨十份交接紀錄被記為已交付卻從未查證，
+其中四份還逐字寫著「該說法沿用至今，仍未重新驗證」。查證只花了兩分鐘：它是一個
+只加測試的 Story，兩項產出都在 `3a310d08` 裡——早於 `Story:` trailer 慣例，所以
+沒有 commit 認領它。兩支測試已重跑通過。結論是那個宣稱一直是真的；問題不在它是
+假的，而在沒有人檢查，而沒被檢查的宣稱會靠慣性一直活下去。
+
+## 流程版本
+
+採用 ForgeFlow 0.3.1（`specs/.forgeflow-adoption`）。0.3.1 新增上游的
+`story-check` 與 `handoff-check` 兩支靜態結構檢查——它們住在 ForgeFlow 的
+checkout 裡，CI 跑不到，而且文件明說它們不判斷宣告是否屬實。
+
+`make verify` 因此多了一步 `bun run forgeflow:check`，補的是上游明說不做的那一
+層：把 `completed_stories` 與 repository 實況對帳。升級到 0.3.1 時，上游的
+`handoff-check` 立刻抓出這份紀錄用了協議裡不存在的 `next_story: none` 與
+`status: all_delivered`，兩個值都是前一個 session 憑語意自己造的。
 
 ## 合併後的收尾
 
@@ -49,7 +65,7 @@ substring 比對。述詞落地後那個字不再承載任何東西，訊息已�
 ```yaml
 workflow:
   current_story: none
-  next_story: none
+  next_story: pending
   completed_stories:
     - DBCLI-001
     - DBCLI-002
@@ -63,12 +79,12 @@ workflow:
     - DBCLI-010
     - DBCLI-011
     - DBCLI-012
-  status: all_delivered
+  status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 04a88a44bdc5025febf77cd5a739d59226df35a7
+  commit: a2a05cc2e11e0754339e734d1db5319ec6744693
   dirty_worktree: false
   story_owned_paths: []
   known_unrelated_paths: []

--- a/specs/stories/README.md
+++ b/specs/stories/README.md
@@ -1,7 +1,15 @@
 # ForgeFlow Stories
 
-This repository adopted ForgeFlow 0.3.0 from revision
-`afca7600db01279ddfe74ac030bd226444cc8b11`.
+This repository adopted ForgeFlow 0.3.1 from revision
+`1096ef5125f1e2d7c304f65d5c7405b76aadf335`; `specs/.forgeflow-adoption` is the
+machine-readable record of that. It was first adopted at 0.3.0
+(`afca7600db01279ddfe74ac030bd226444cc8b11`).
+
+`make verify` runs `bun run forgeflow:check`, which reconciles the handoff's
+`completed_stories` against the repository. Upstream's `story-check` and
+`handoff-check` are static structure checks that live in a ForgeFlow checkout
+and are documented as never deciding whether a declaration is truthful; this
+repository's check covers that separate layer and duplicates neither.
 
 Create a Story by copying the template:
 


### PR DESCRIPTION
## 這個 PR 是什麼

把這個 repo 從 ForgeFlow 0.3.0 升到 0.3.1，並補上一層上游明說不做的檢查。

0.3.2 的採用另開 PR，接在這支之後。

## 上游 0.3.1 帶來什麼

修正版，v0.3.0 之後只有兩個 Story、669 行變更：新增 `scripts/story-check` 與
`scripts/handoff-check` 兩支靜態結構檢查，並讓它們只用 shell builtin——原本呼叫
`grep`/`sort`/`uniq`，空 `PATH` 下會讓一個合規的 repo 被 Doctor 報成
`CONTRACT_DRIFT`。

Story 範本與 0.3.0 **逐位元組相同**，所以升級實際上只是安裝
`specs/.forgeflow-adoption` 版本標記。用的是 `bootstrap --upgrade`，它不動
`AGENTS.md`（fresh bootstrap 會覆蓋，那對這個 repo 是破壞性的）。

## 升級當下抓到的東西

拿上游的 `handoff-check` 一跑 `specs/handoff.md`：

```
FAIL  workflow.next_story must be one Story ID or pending
FAIL  workflow.status is not a lifecycle state: all_delivered
```

`next_story: none` 與 `status: all_delivered` 這兩個值協議裡都不存在，是上一個
session 憑語意自己造的。已改為 `pending` / `done`，現在 `HANDOFF_CONTRACT_OK`。
`story-check` 12 個 Story 全 PASS。

## 為什麼還要自己寫一支（`scripts/check-forgeflow-handoff.ts`）

上游那兩支是**靜態結構檢查**，而且：

- 住在 ForgeFlow 的 checkout 裡，CI 跑不到；
- 文件明說它們永遠不判斷宣告是否屬實——
  「The check never decides whether a declared classification is truthful」、
  「a stale `pass` is a human-review concern, not a check failure」。

也就是 `completed_stories` 寫什麼就是什麼，沒有人跟 repo 對帳。新增的這支只補這
一層：一個被宣稱已交付的 Story，必須有 commit 帶著它的 `Story: <ID>` trailer。
兩者不重疊。

## 順帶結案 DBCLI-001

它跨**十份**交接紀錄被記為已交付卻從未查證，其中四份還逐字寫著「該說法沿用至今，
仍未重新驗證」。

查證花了兩分鐘：DBCLI-001 是一個只加測試的 Story，兩項產出都在 `3a310d08`
（分支基準點）裡，早於 `Story:` trailer 慣例所以沒有 commit 認領它。兩支測試已
重跑通過：

- `skill-context.test.ts` — 缺少 contracts 檔時保留 semantic context、不加
  `contracts` 欄位、不建立 adapter
- `contracts.test.ts` — invalid drift 有界、不洩漏 seeded 輸入、不建立 adapter

**那個宣稱一直是真的。** 重點不在它是假的，而在沒有人檢查——而沒被檢查的宣稱會
靠慣性一直活下去，直到有人終於去看。

`DELIVERED_BEFORE_TRAILERS` 記下交付 commit 與證據，讓宣稱帶著證明走。它是只能
縮小的 ratchet：新 Story 必須有 trailer；項目陳舊（該 Story 後來有了 trailer）
或指向不存在的 commit，都會讓檢查失敗。

## 測試計畫

```bash
make verify   # exit 0，新增第 26 步 forgeflow:check
```

- 全套測試 **6368 pass / 0 fail**、`bun audit` 無漏洞
- `forgeflow:check` → `12 completed Stories (11 by commit trailer, 1 by recorded delivering commit)`
- 四個失敗分支都做過 mutation 檢查，確認各自會以 exit 1 失敗：
  - 宣稱一個沒有目錄的 Story
  - 宣稱一個沒有 trailer 也沒有 exemption 的 Story
  - exemption 指向不存在的 commit
  - 陳舊的 exemption（該 Story 已有 trailer）
- 上游 `handoff-check` / `story-check` 手動跑過，皆 OK

https://claude.ai/code/session_0184YnKPFgwjck9aBmDAwFYo
