### PR TITLE
chore: 採用版本推進到 ForgeFlow 0.3.2

### DIFF
--- a/specs/.forgeflow-adoption
+++ b/specs/.forgeflow-adoption
@@ -1,2 +1,2 @@
-version=0.3.1
-revision=1096ef5125f1e2d7c304f65d5c7405b76aadf335
+version=0.3.2
+revision=7bbdf443ead484780e23df9abf055095d4c629e2

--- a/specs/stories/README.md
+++ b/specs/stories/README.md
@@ -1,7 +1,7 @@
 # ForgeFlow Stories
 
-This repository adopted ForgeFlow 0.3.1 from revision
-`1096ef5125f1e2d7c304f65d5c7405b76aadf335`; `specs/.forgeflow-adoption` is the
+This repository adopted ForgeFlow 0.3.2 from revision
+`7bbdf443ead484780e23df9abf055095d4c629e2`; `specs/.forgeflow-adoption` is the
 machine-readable record of that. It was first adopted at 0.3.0
 (`afca7600db01279ddfe74ac030bd226444cc8b11`).
 


### PR DESCRIPTION
## 這個 PR 是什麼

把採用版本從 0.3.1 推進到 0.3.2。**接在 #146 之後**（base 是
`chore/forgeflow-0.3.1`），#146 合併後 GitHub 會自動改指 `main`。

## 0.3.2 對採用者沒有實質變更

這不是我的判斷，是上游自己的分類。`protocol/versioning.md` 把 FF-213 標為
**Corrective** 並明寫「These changes align the documentation with existing
behavior and require no adopter changes」。

查證相符：

| 面向 | 0.3.1 → 0.3.2 |
| --- | --- |
| 三個 Story 範本 | 逐位元組相同 |
| `story-check` / `handoff-check` | 未變更 |
| `protocol/repository-contract.md` | 只補一句敘述：bootstrap 也會裝 `specs/.forgeflow-adoption` |
| `protocol/versioning.md` | 只新增 0.3.2 的分類說明 |

所以採用面的變更就是 marker 與 `specs/stories/README.md` 的版本與 revision。

## 查掉的兩件事

**`bootstrap --upgrade` 的 AGENTS.md 警告。** 它會說 `AGENTS.md` 可能早於任一
版本。上游 `templates/AGENTS.md` 自 0.3.0 起**沒有任何 commit**，所以那是通用
警告，沒有東西需要帶過來。這個 repo 的 `AGENTS.md` 由自己擁有，`--upgrade`
不碰它。

**README 的 revision SHA。** 第一次是用猜的（`7bbdf447…`），與 `bootstrap`
實際寫入 marker 的值（`7bbdf443ead4…`）不同。已改以 marker 為準，並確認該
commit 在上游 checkout 中存在。

## 測試計畫

0.3.2 的三支工具跑過本 repo：

```
story-check    → STORY_CONTRACT_OK，Stories checked: 12
handoff-check  → HANDOFF_CONTRACT_OK
doctor         → Result: STRUCTURE_OK / Adopted version: 0.3.2
```

`make verify` exit 0，6368 pass / 0 fail，`bun audit` 無漏洞。

https://claude.ai/code/session_0184YnKPFgwjck9aBmDAwFYo
