### PR TITLE
docs: 結案 semantic version 2 的觀察——不是缺陷

### DIFF
--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -57,8 +57,13 @@ substring 比對。述詞落地後那個字不再承載任何東西，訊息已�
 
 - 四個 doc-contract 測試共用相似的文字正規化卻各自 scope。沿用 DBCLI-009 的
   決定不合併：合併會改到已交付 Story 的斷言語意。
-- `loadSemanticContext` 不拒絕 `version: 2` 的 semantic 產物——寫收尾測試時
-  發現的，與上述三件事無關，也還沒判斷它是不是缺陷。
+
+（先前這裡記著「`loadSemanticContext` 不拒絕 `version: 2` 的 semantic 產物，
+還沒判斷是不是缺陷」。已查證：不是缺陷。`src/core/semantic/index.ts:486` 明確
+接受 1 與 2，v2 就是加上 `relationships` 的版本，同檔案的 `migrateSemanticContext`
+專門把 v1 升成 v2。誤判來自我當時想找一個形狀錯誤的產物、隨手用了 `version: 2`。
+允許的 key 集合隨版本走，所以 v1 產物帶 `relationships` 會被擋而非靜默忽略；
+`version: 3` 與字串 `"2"` 都會被拒。）
 
 ## Lifecycle
 


### PR DESCRIPTION
## 這個 PR 是什麼

`specs/handoff.md` 記著一條未結案的觀察：「`loadSemanticContext` 不拒絕
`version: 2` 的 semantic 產物，還沒判斷是不是缺陷」。查證完了：**不是缺陷。**

## 查證結果

`src/core/semantic/index.ts:486-487` 明確接受 1 與 2 兩個值——v2 就是加上
`relationships` 的版本，同檔案的 `migrateSemanticContext()` 專門把 v1 產物升成
v2。實測的接受集合：

| 產物 | 結果 |
| --- | --- |
| `version: 1` | 接受 |
| `version: 2` | 接受 |
| `version: 2` 省略 `relationships` | 接受（預設空陣列） |
| `version: 1` 帶 `relationships` | 拒絕 `contains an unknown property` |
| `version: 3` | 拒絕 `must equal 1 or 2` |
| `version: "2"`（字串） | 拒絕 `must equal 1 or 2` |

邊界比原本以為的還嚴：允許的 key 集合隨版本走，所以 v1 產物放 `relationships`
會被擋，不會靜默忽略。

誤判的來源是我自己：寫 context-v2 分類測試時想找一個「形狀錯誤」的 semantic
產物，隨手用了 `version: 2`，結果它根本沒錯。那個測試當時就換成
`models: 'not-an-array'` 並通過，只是觀察被留在交接紀錄裡沒結案。

## 為什麼是改寫而不是刪掉

刪掉會讓下一個人重新踩一次同樣的誤判。結論留在原地，連同誤判的來源一起。

順帶修掉一個渲染問題：新段落緊接在 bullet 後面沒有空行，Markdown 會把它併進上
一個項目——正是 DBCLI-009 修過的那一類。

## 測試計畫

- `make verify` exit 0
- `handoff-check` → `HANDOFF_CONTRACT_OK`
- `forgeflow:check` → 12 completed Stories

https://claude.ai/code/session_0184YnKPFgwjck9aBmDAwFYo