### PR TITLE
test: 抽出 doc-contract 測試共用的讀檔與去標記

### DIFF
--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -53,10 +53,18 @@ checkout 裡，CI 跑不到，而且文件明說它們不判斷宣告是否屬�
 substring 比對。述詞落地後那個字不再承載任何東西，訊息已改回
 `must use a supported semantic subject form`。
 
-## 仍未處理
+## 結案紀錄
 
-- 四個 doc-contract 測試共用相似的文字正規化卻各自 scope。沿用 DBCLI-009 的
-  決定不合併：合併會改到已交付 Story 的斷言語意。
+沒有未處理項目。以下兩條原本記在這裡待辦，結論留在原地而不是刪掉——刪掉會讓下一
+個人重新踩一次同樣的誤判。
+
+
+（先前這裡記著四個 doc-contract 測試的正規化重複、沿用 DBCLI-009 的決定不合併。
+已處理，但範圍比原本描述的窄：四支裡只有兩支的正規化真的相同，`impact` 不做
+lowercase 也不收合 CJK 換行，`verification-receipt` 多一條標點貼合規則、而且是先
+去標記再定位段落。共用的只有讀檔與去標記，以及那兩支真正相同的部分；各自的 tail
+與 scoping 原封不動，所以沒有任何已交付 Story 的斷言語意被改動——這一點是以四支
+× 四個 surface 的正規化輸出雜湊逐位元組比對證明的，不是靠測試通過推論的。）
 
 （先前這裡記著「`loadSemanticContext` 不拒絕 `version: 2` 的 semantic 產物，
 還沒判斷是不是缺陷」。已查證：不是缺陷。`src/core/semantic/index.ts:486` 明確

--- a/tests/unit/skill-assets/doc-section.ts
+++ b/tests/unit/skill-assets/doc-section.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared reading and normalization for the documentation-contract tests.
+ *
+ * Four tests assert that a published claim appears on all four
+ * `docs/user/{en,zh-TW}/index.{md,html}` surfaces. They all read the file the
+ * same way and all strip markup and decode entities before matching, so those
+ * steps live here.
+ *
+ * What is deliberately NOT shared is the rest of each pipeline. The four
+ * normalizations are not the same: `impact` never lowercases and does not
+ * collapse CJK line wraps, and `verification-receipt` closes the space around
+ * bracket and CJK punctuation and strips markup before locating its section
+ * rather than after. Folding them into one function would silently widen or
+ * narrow what each delivered Story's claims match, which is why this
+ * unification was refused twice before. Each caller keeps its own tail and its
+ * own section scoping; only the byte-identical parts moved here.
+ */
+
+/** Raw file text with only line endings normalized. */
+export async function readDocSource(path: string): Promise<string> {
+  // Windows checks out CRLF, so line endings are not part of any claim.
+  return (await Bun.file(path).text()).replace(/\r\n/g, '\n')
+}
+
+/** Removes tags and decodes the entities the published surfaces use. */
+export function stripMarkup(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+/**
+ * Collapses the Markdown hard wraps that would otherwise split a CJK claim.
+ *
+ * A newline between two CJK characters is that wrap and nothing else, so it
+ * disappears; every other newline is left for the caller to collapse to a
+ * space, which is what a wrap between CJK and a Latin word stood for. Only a
+ * newline counts: matching any whitespace would also join two sentences across
+ * a full stop, letting a claim span text the document never wrote as one
+ * statement.
+ */
+export function collapseCjkWraps(text: string): string {
+  return text
+    .replace(
+      /([\u3000-\u303f\u3400-\u9fff\uff00-\uffef])\n\s*(?=[\u3000-\u303f\u3400-\u9fff\uff00-\uffef])/g,
+      '$1'
+    )
+    .replace(/([、。，；：！？])\n[ \t]*/g, '$1')
+}
+
+/**
+ * The source text between one `<!-- doc-key: ... -->` marker and the next.
+ *
+ * The markers are the most robust section boundary available: both the
+ * Markdown and the HTML carry them, so an unrelated section cannot satisfy a
+ * claim. Slicing happens before `stripMarkup`, which would otherwise delete
+ * the markers along with every other tag. Returns null when the section is
+ * absent or unterminated, so a silently empty section cannot pass.
+ */
+export function docKeySection(source: string, key: string): string | null {
+  const marker = `<!-- doc-key: ${key} -->`
+  const start = source.indexOf(marker)
+  if (start < 0) return null
+  const end = source.indexOf('<!-- doc-key:', start + marker.length)
+  if (end <= start) return null
+  return source.slice(start, end)
+}

--- a/tests/unit/skill-assets/evidence-pack-docs.test.ts
+++ b/tests/unit/skill-assets/evidence-pack-docs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { collapseCjkWraps, docKeySection, readDocSource, stripMarkup } from './doc-section'
 
 /**
  * A pack is an index of references and externally supplied claims. It is not a
@@ -9,40 +10,17 @@ import { describe, expect, test } from 'bun:test'
  * Markdown and the HTML carry, so an unrelated section cannot satisfy a claim.
  */
 async function evidencePackSection(path: string): Promise<string> {
-  // Windows checks out CRLF, so line endings are not part of what these
-  // claims assert. Normalize before any `\n`-shaped matching below.
-  const raw = (await Bun.file(path).text()).replace(/\r\n/g, '\n')
-  const marker = '<!-- doc-key: evidence-packs -->'
-  const start = raw.indexOf(marker)
-  expect(start).toBeGreaterThanOrEqual(0)
-  const end = raw.indexOf('<!-- doc-key:', start + marker.length)
-  expect(end).toBeGreaterThan(start)
+  const section = docKeySection(await readDocSource(path), 'evidence-packs')
+  expect(section).not.toBeNull()
 
-  return (
-    raw
-      .slice(start, end)
-      .replace(/<[^>]+>/g, '')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&')
+  return collapseCjkWraps(
+    stripMarkup(section ?? '')
       // Emphasis and code markers vanish without leaving a space behind, so
       // `**not**` between CJK characters does not split the sentence.
       .replace(/[`*]/g, '')
-      // Markdown hard-wraps mid-sentence. A newline between two CJK characters
-      // is that wrap and nothing else, so it disappears; every other newline
-      // collapses to a space below, which is what a wrap between CJK and a
-      // Latin word stood for.
-      .replace(
-        /([\u3000-\u303f\u3400-\u9fff\uff00-\uffef])\n\s*(?=[\u3000-\u303f\u3400-\u9fff\uff00-\uffef])/g,
-        '$1'
-      )
-      // Only a newline is a wrap. Matching any whitespace after the collapse
-      // above would also join two sentences across a full stop, letting a claim
-      // span text the document never wrote as one statement.
-      .replace(/([、。，；：！？])\n[ \t]*/g, '$1')
-      .replace(/\s+/g, ' ')
-      .toLowerCase()
   )
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
 }
 
 const en = [

--- a/tests/unit/skill-assets/impact-docs.test.ts
+++ b/tests/unit/skill-assets/impact-docs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { readDocSource, stripMarkup } from './doc-section'
 
 /**
  * The impact assessment is incomplete by design, and that is the claim a
@@ -10,9 +11,7 @@ import { describe, expect, test } from 'bun:test'
  * covers a language's Markdown and HTML without encoding either's line breaks.
  */
 async function impactSection(path: string): Promise<string> {
-  // Windows checks out CRLF, so line endings are not part of what these
-  // claims assert. Normalize before any `\n`-shaped matching below.
-  const raw = (await Bun.file(path).text()).replace(/\r\n/g, '\n')
+  const raw = await readDocSource(path)
   // Scope to the impact topic: some claims recur elsewhere in these documents,
   // and a whole-file match would let an unrelated section satisfy them.
   const start = raw.indexOf('dbcli impact assess')
@@ -20,13 +19,11 @@ async function impactSection(path: string): Promise<string> {
   const end = raw.indexOf('safe-backfill-verify', start)
   expect(end).toBeGreaterThan(start)
 
-  return raw
-    .slice(start, end)
-    .replace(/<[^>]+>/g, '')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/[`\s]+/g, ' ')
+  // No lowercasing and no CJK wrap collapse: this Story's claims were written
+  // against the surfaces as they are, and adding either would widen what they
+  // match. Backticks collapse together with whitespace here, unlike the other
+  // three tests, for the same reason.
+  return stripMarkup(raw.slice(start, end)).replace(/[`\s]+/g, ' ')
 }
 
 const claims = {

--- a/tests/unit/skill-assets/semantic-contract-docs.test.ts
+++ b/tests/unit/skill-assets/semantic-contract-docs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { collapseCjkWraps, docKeySection, readDocSource, stripMarkup } from './doc-section'
 
 /**
  * A contract is a reviewed local definition, not an executable rule and not a
@@ -10,40 +11,17 @@ import { describe, expect, test } from 'bun:test'
  * Markdown and the HTML carry, so an unrelated section cannot satisfy a claim.
  */
 async function advancedToolsSection(path: string): Promise<string> {
-  // Windows checks out CRLF, so line endings are not part of what these
-  // claims assert. Normalize before any `\n`-shaped matching below.
-  const raw = (await Bun.file(path).text()).replace(/\r\n/g, '\n')
-  const marker = '<!-- doc-key: advanced-tools -->'
-  const start = raw.indexOf(marker)
-  expect(start).toBeGreaterThanOrEqual(0)
-  const end = raw.indexOf('<!-- doc-key:', start + marker.length)
-  expect(end).toBeGreaterThan(start)
+  const section = docKeySection(await readDocSource(path), 'advanced-tools')
+  expect(section).not.toBeNull()
 
-  return (
-    raw
-      .slice(start, end)
-      .replace(/<[^>]+>/g, '')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&')
+  return collapseCjkWraps(
+    stripMarkup(section ?? '')
       // Emphasis and code markers vanish without leaving a space behind, so
       // `**not**` between CJK characters does not split the sentence.
       .replace(/[`*]/g, '')
-      // Markdown hard-wraps mid-sentence. A newline between two CJK characters
-      // is that wrap and nothing else, so it disappears; every other newline
-      // collapses to a space below, which is what a wrap between CJK and a
-      // Latin word stood for.
-      .replace(
-        /([\u3000-\u303f\u3400-\u9fff\uff00-\uffef])\n\s*(?=[\u3000-\u303f\u3400-\u9fff\uff00-\uffef])/g,
-        '$1'
-      )
-      // Only a newline is a wrap. Matching any whitespace after the collapse
-      // above would also join two sentences across a full stop, letting a claim
-      // span text the document never wrote as one statement.
-      .replace(/([、。，；：！？])\n[ \t]*/g, '$1')
-      .replace(/\s+/g, ' ')
-      .toLowerCase()
   )
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
 }
 
 const en = [

--- a/tests/unit/skill-assets/verification-receipt-docs.test.ts
+++ b/tests/unit/skill-assets/verification-receipt-docs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { readDocSource, stripMarkup } from './doc-section'
 
 /**
  * A receipt is provenance, never approval, and it cannot exist before the
@@ -11,17 +12,12 @@ import { describe, expect, test } from 'bun:test'
  * Markdown and HTML word the same claim differently, hence one list per surface.
  */
 async function receiptSection(path: string): Promise<string> {
-  // Windows checks out CRLF, so line endings are not part of what these
-  // claims assert. Normalize before any `\n`-shaped matching below.
-  const raw = (await Bun.file(path).text()).replace(/\r\n/g, '\n')
-  const text = raw
-    // Tags go before entities, so `&lt;path&gt;` cannot decode into something
-    // the tag pass then deletes. A claim must therefore not contain a
-    // `<placeholder>`: Markdown writes those literally and this pass eats them.
-    .replace(/<[^>]+>/g, '')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
+  // `stripMarkup` takes tags before entities, so `&lt;path&gt;` cannot decode
+  // into something the tag pass then deletes. A claim must therefore not
+  // contain a `<placeholder>`: Markdown writes those literally and it eats
+  // them. Unlike the other three tests, the section is located after markup is
+  // stripped, not before.
+  const text = stripMarkup(await readDocSource(path))
     // Strip emphasis and code markers without inserting a space: `**not**`
     // between CJK characters would otherwise leave one behind.
     .replace(/[`*]/g, '')


### PR DESCRIPTION
## 這個 PR 是什麼

交接紀錄兩度記著「四個 doc-contract 測試共用相似的正規化」並沿用 DBCLI-009 的
決定不合併。這次實際查證後動手了——但**範圍比原本那句描述的窄**。

## 重複的範圍其實只有一半

四支的正規化不是同一套：

| 測試 | lowercase | CJK 換行收合 | 其他 | 段落定位 |
| --- | --- | --- | --- | --- |
| `evidence-pack` | ✓ | ✓ | 去 `` ` `` `*` | doc-key marker |
| `semantic-contract` | ✓ | ✓ | 去 `` ` `` `*` | doc-key marker |
| `impact` | **✗** | **✗** | `` ` `` 與空白一起收 | 字面文字 |
| `verification-receipt` | ✓ | ✗ | **多一條標點貼合規則** | **先去標記再定位**（順序相反） |

所以只抽真正逐字相同的部分到 `tests/unit/skill-assets/doc-section.ts`：

- `readDocSource` — 讀檔與 CRLF 正規化（四支共用）
- `stripMarkup` — 去標記與 entity 解碼（四支共用）
- `docKeySection` — `<!-- doc-key: … -->` 段落切分（兩支共用）
- `collapseCjkWraps` — CJK 硬換行收合（兩支共用）

**各自的 tail 與 scoping 原封不動。** 當初拒絕合併的理由是對的，只是它涵蓋的是
scoping 與 tail，不是整條管線。這個差異在共用檔的註解裡寫明了，免得下一個人以為
可以再往前合。

## 等價性是證明的，不是推論的

「測試還是綠的」不足以證明正規化沒變——測試可能只是剛好還通過。所以重構前後各取
**四支 × 四個 surface** 的正規化輸出算 sha256：

```
16 個雜湊全部相同（含長度）
```

escape 形式後來從字面 CJK 改成 `\u` escape（`no-irregular-whitespace`，U+3000 是
全形空格），改完**重新證明過一次**，不是沿用先前的結果。

## Mutation 檢查

四支各改一條文件宣稱，確認對應測試會紅：

- `impact` → 1 紅
- `verification-receipt` → 1 紅
- `semantic-contract` → 1 紅
- `evidence-pack` → 1 紅（這條宣稱本身跨硬換行，順帶驗證共用的
  `collapseCjkWraps` 仍在做事）

## 交接紀錄

「仍未處理」兩條都結案了，改名為結案紀錄。結論留在原地而不是刪掉——刪掉會讓下一
個人重新踩一次同樣的誤判。

## 測試計畫

`make verify` exit 0、6368 pass / 0 fail、`bun audit` 無漏洞、
`handoff-check` → `HANDOFF_CONTRACT_OK`。

https://claude.ai/code/session_0184YnKPFgwjck9aBmDAwFYo