### PR TITLE
chore: [ forgeflow ] 採用版本可對帳化與 DBCLI-013 交接

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,143 @@ All notable changes to dbcli are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 建議版本 8.0.0
+
+ForgeFlow Story DBCLI-001 到 DBCLI-012 全數交付但尚未發布：`v7.0.1`（`224ee59d`）
+早於 Story 的合併點 `04a88a44`，因此以下每一條都在 `7.0.1` 之外。DBCLI-013 補上
+採用漂移的檢查與這份紀錄本身。
+
+版本建議 **8.0.0**。理由不是變更量，而是三處會拒絕先前被接受的輸入、以及一處會
+改變 JSON 判決值——SemVer 對這四項的答案都是 MAJOR，詳見下方 Breaking。
+
+### Breaking
+
+- **query-only 的最後一道界線改由資料庫提供。** PostgreSQL / MySQL / MariaDB 上
+  每一句 caller-controlled SQL 都在該實體連線上開一個原生唯讀交易後才送出，涵蓋
+  `query`、`export`、saved query 及其 verification、`report` 診斷、SQL shell、
+  analyzed explain，以及會把較高權限收斂成 query-only 的多連線 fan-out。語句分類
+  只看得到語句形狀，看不到 `SELECT mutate_accounts()` 背後的函式會不會寫資料——
+  這類先前成功的呼叫現在會被資料庫本身擋下。邊界建立不起來就在送出目標語句前失敗；
+  目標語句跑完但交易收尾失敗時回報結果不確定並丟棄該連線。（DBCLI-002）
+
+- **slow-endpoint-investigation task pack 新增必填的 `table` 參數。** 計畫順序變成
+  blacklist → proxy analyze → schema `<table>` → explain → guide
+  missing-index-for。先前不帶 table 的呼叫現在會在產出任何計畫之前失敗。在沒確認
+  資料表形狀的情況下讀執行計畫或索引候選，那是猜測，不是佐證。（DBCLI-012）
+
+- **儀表板內嵌 payload 改為 allowlist。** `SavedQueryMeta` 先前是整包序列化進獨立
+  HTML 的，把參數預設值與列舉、目標 index / collection、verification 的 query 與
+  expects 一起帶進一個從未渲染它們的檔案。現在只有已顯示的資料列、applied-limit
+  與安全通知、provenance，以及顯示用的 name / description 與引用已顯示欄位的圖表
+  ／KPI 定義會被序列化。讀取那些欄位的下游消費者會發現它們不再存在。（DBCLI-006）
+
+- **語意契約中形式錯誤的 subject 判為 `invalid` 而非 `stale`。** `table:orders`
+  這類形式本身就不合法的 subject 先前與「model 被改名」得到同一個判決，
+  `contract drift --format json` 的消費者因此無法區分兩者。形式檢查移到 parse
+  階段。（DBCLI-011）
+
+- **`init --no-interactive` 從無效變成有效。** 它先前讀的是
+  `options.noInteractive`，而 Commander 存的是 `interactive`，所以那個旗標從來沒
+  擋掉任何提問。依賴舊行為（帶著 `--no-interactive` 卻仍期待被提問）的腳本會改變
+  行為。（DBCLI-004）
+
+- **互動式 `init` 的遮蔽輸入沒有純文字退路。** 沒有 TTY 或載入不到遮蔽實作時，
+  直接在寫出任何設定之前失敗，並指出當下模式支援的替代輸入（`--password`、
+  `.env` / 環境變數、`--use-env-refs`，MongoDB 則是 `--uri`）。先前這些情境會以
+  可見提示收下密碼。（DBCLI-004）
+
+- **`assert` 在 receipt 寫入失敗時的 stdout 形狀改變。** 先前是一行 stderr 且沒有
+  envelope，現在 `--format json` 的呼叫端拿得到完整 envelope，exit code 仍為 1。
+  解析舊有失敗輸出的呼叫端需要跟著改。（DBCLI-009）
+
+### Added
+
+- **`skill context --context-version 2`：給外部 agent 的穩定契約。** 離線、不開
+  連線、不掃 Redis key、不讀文件、不讀專案原始碼。輸出引擎、設定權限、能力、可見
+  資源、snippet metadata、semantic 與 contracts、truncation 與 gaps；不輸出憑證、
+  實際值、預設值與計數、原始 ES mapping、Redis key/value 或專案路徑。Elasticsearch
+  只以快取的扁平欄位呈現，Redis 只接受 repository 自己宣告的
+  `dbcli.redis-context.json`。缺證據時明確回報 gap，不推測名稱與語意。不帶旗標時
+  維持 byte-compatible 的 version 1 輸出。（DBCLI-003）
+
+- **saved-query 儀表板帶上可攜、封閉的執行溯源。** version 1 的 provenance 物件與
+  對應的 Execution Traceability 區塊：邏輯連線名稱與引擎、snippet key 與來源分類、
+  實際生效的權限，以及實際生效的筆數上限——沒有套上限時明講 `not-applied`，而不是
+  留白讓人分不出完整結果與被截斷的結果。applied-limit 與畫面上的截斷警示不一致就
+  在寫檔前拒絕。直接查詢的儀表板行為不變，也不帶溯源區塊。（DBCLI-006）
+
+- **`impact assess` 的不完整性契約寫進兩份 `index.html`。** coverage 永遠是
+  `declared` 或 `partial`、v1 不宣稱 `complete`、`--fail-on` 只在報告寫出後改變
+  exit code。（DBCLI-008）
+
+### Security
+
+- **互動式 `init` 的憑證改走遮蔽輸入。** PostgreSQL / MySQL / MariaDB / Redis /
+  Elasticsearch 的密碼、MongoDB 逐欄模式的密碼，以及貼上的 MongoDB 連線字串（它
+  本身就帶著帳密），先前都停在終端機捲動紀錄、session 錄影與螢幕分享畫面裡。連線
+  測試失敗時 driver 常把密碼或整條 URI 原樣寫回錯誤訊息，現在先經過共用的
+  `redactSecretsForDisplay` 遮蔽並截斷再輸出。（DBCLI-004）
+
+- **safe-backfill 的佐證文物不再外洩敏感字串。** 寫進佐證文物的失敗原因改用固定的
+  安全字串而非 driver 的錯誤訊息；使用者自訂的 subject / summary 與 SQL 佐證會先把
+  憑證、檔案系統路徑與 SQL 註解遮掉再落檔。（DBCLI-005）
+
+- **evidence pack 的失敗輸出不再帶出絕對路徑與原始錯誤。**
+  `evidence compose --receipt <不存在>` 先前會原樣印出
+  `ENOENT: ... lstat '/private/var/.../x.json'`。receipt 的 realpath 失敗改拋有界
+  訊息；`safeMessage` 只放行兩個 validation error 類別；`validateFormat` 換成自己的
+  有界檢查——它先前會把被拒的值原樣引用，而那個位置可以是路徑。（DBCLI-010）
+
+- **語意契約的診斷不再複述產物輸入。** `rejectUnknownKeys` 先前把被拒絕的 JSON
+  property key 內插進診斷路徑，而那個 key 由產物作者控制：`contract validate` 的
+  stderr 與 `contract drift --format json` 會原樣印出帶憑證與絕對路徑的 key。改為
+  列出允許的 property 名稱。`fail()` 與 `collectContractEvidence` 的邊界一併收
+  緊。（DBCLI-011）
+
+### Fixed
+
+- **safe-backfill 的四項防護全數執行。** 先前一失敗就中斷，操作者只看得到第一個
+  擋下來的原因。blacklist、schema、plan、verify-query-readonly 現在都會執行並各自
+  回報結果；after-write 仍只在四項全過時才跑回讀斷言。（DBCLI-005）
+
+- **`assert` 的 receipt 寫入失敗不再吞掉斷言判決。** 先前直接 `process.exit(1)`，
+  `--format json` 的呼叫端拿到的不是 envelope 而是一行 stderr，`--no-fail` 的語意
+  也被推翻。改成錯誤記在結果旁邊、判決照常輸出、exit code 仍為 1——與同一個檔案裡
+  相鄰的 artifact 寫入分支一致。（DBCLI-009）
+
+- **JSON 形態的 ORM 產物改為指名檔案的 fail closed。** Drizzle snapshot 與
+  normalized JSON 先前會把 `JSON.parse` 與 Zod 的原始錯誤直接丟出去，都沒有指出是
+  哪一個檔案壞掉；agent 一次審多份產物時無從得知該修哪一個。（DBCLI-007）
+
+- **`impact assess` 的輸出目標衝突看得出原因。** `impact output already exists`
+  不在 `safeMessage` 的清單裡而被壓成泛用句子，審查者無從得知是報告檔已存在。
+  同時把 prefix 比對改成完全比對——這是雙向的：`design dialect` 這類帶插值後綴的
+  訊息反而不再放行、收斂成泛用句。prefix 的寫法在某個字串日後長出插值後綴時會默默
+  漏資訊，而那正是這個函式存在的理由。（DBCLI-008）
+
+### Documentation
+
+- **`--context-version 2`、儀表板溯源、遮蔽輸入、safe-backfill、slow-endpoint pack
+  的說明同步到四份使用者文件與相關 Pages guide**，中英雙語、Markdown 與 HTML 兩種
+  格式皆同步。（DBCLI-002 到 DBCLI-012）
+
+- **三份長期落在檢查外的 guide 納入涵蓋範圍。** `evidence-packs`、
+  `offline-impact-assessment`、`semantic-contracts` 與 `verification-evidence`
+  併入 `guideSlugs`；該清單本身改由讀目錄的檢查守住，因為手維護的清單擋不住第四
+  份。（DBCLI-008、DBCLI-010、DBCLI-011）
+
+- **receipt 旗標表格不再被一句話切成兩張**，「Flag trio」／「旗標三件組」列了四個
+  旗標，四份文件一併改為「Flags」／「旗標」。（DBCLI-009）
+
+### Process
+
+- **ForgeFlow 採用版本現在只有一個可檢查的答案。** `specs/.forgeflow-adoption` 是
+  唯一權威，`bun run forgeflow:check` 新增的
+  `scripts/check-forgeflow-adoption.ts` 把 `specs/stories/README.md`、
+  `specs/handoff.md`、Story template 與本地 `story-development` Skill 全部對回它。
+  這條 gate 的起因是它已經失效過一次：marker 與 README 推進到 0.3.2 之後，handoff
+  跨兩個已合併的 PR 仍寫著 0.3.1，沒有任何東西比對過。（DBCLI-013）
+
 ## [7.0.1] - 2026-09-02 - agent 讀到的黑名單語意還停在 4.0.0
 
 ### Documentation

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "agent-core:check": "bun run scripts/check-agent-core-purity.ts",
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "plan:check": "bun run scripts/check-plan-acceptance.ts",
-    "forgeflow:check": "bun run scripts/check-forgeflow-handoff.ts",
+    "forgeflow:check": "bun run scripts/check-forgeflow-adoption.ts && bun run scripts/check-forgeflow-handoff.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",

--- a/scripts/check-forgeflow-adoption.ts
+++ b/scripts/check-forgeflow-adoption.ts
@@ -1,0 +1,55 @@
+/**
+ * Gate: this repository gives one answer about which ForgeFlow it adopted.
+ *
+ * The companion gate `check-forgeflow-handoff.ts` reconciles delivery claims —
+ * whether a Story the handoff calls done is backed by the repository. This one
+ * reconciles the process version those Stories were written against, which had
+ * the same failure in a different place: `specs/.forgeflow-adoption` and
+ * `specs/stories/README.md` said 0.3.2 while `specs/handoff.md` still said
+ * 0.3.1, across two merged pull requests, and nothing looked.
+ *
+ * The rules live in `lib/forgeflow-adoption.ts` next to the reasoning for why
+ * each is drawn where it is. Everything here is offline by construction: the
+ * marker records an upstream revision but nothing fetches it, because a gate
+ * that needs the network is a gate that fails for reasons unrelated to the
+ * repository it is checking.
+ */
+
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  collectAdoptionDrift,
+  formatAdoptionDrift,
+  MARKER_PATH,
+  README_PATH,
+  RESTATEMENT_SURFACES,
+} from './lib/forgeflow-adoption'
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url))
+
+/** Reads a repository file, reporting absence rather than throwing. */
+export const readFromRoot =
+  (root: string) =>
+  async (path: string): Promise<string | undefined> => {
+    const file = Bun.file(join(root, path))
+    return (await file.exists()) ? await file.text() : undefined
+  }
+
+if (import.meta.main) {
+  const drift = await collectAdoptionDrift(readFromRoot(repoRoot))
+
+  if (drift.length > 0) {
+    console.error('ForgeFlow adoption reconciliation failed:\n')
+    for (const item of drift) console.error(`  ${formatAdoptionDrift(item)}`)
+    console.error(
+      `\n${drift.length} disagreement(s) about the adopted ForgeFlow release.\n` +
+        `${MARKER_PATH} is the source of truth; change it first, then bring every surface to match.`
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `forgeflow adoption reconciliation passed: ${MARKER_PATH} agrees with ` +
+      `${README_PATH} and ${RESTATEMENT_SURFACES.length} other surface(s)`
+  )
+}

--- a/scripts/lib/forgeflow-adoption.ts
+++ b/scripts/lib/forgeflow-adoption.ts
@@ -1,0 +1,352 @@
+// Drift signals for this repository's recorded ForgeFlow adoption.
+//
+// `specs/.forgeflow-adoption` is the machine-readable record of which upstream
+// ForgeFlow revision this repository's Story contract came from. Every other
+// mention of that version lives in prose, and prose drifts silently: the
+// handoff spent two merged pull requests claiming 0.3.1 while the marker and
+// `specs/stories/README.md` both said 0.3.2. Nothing was wrong with the code —
+// the adoption simply had three answers, and the only one a reader is likely to
+// hit first was the stale one.
+//
+// So the marker is the single source of truth and everything else is measured
+// against it, on two rules that are deliberately narrow enough not to misread
+// history:
+//
+//   1. `specs/stories/README.md` carries the canonical declaration, in a fixed
+//      form naming both the version and the revision. It is the one file that
+//      restates the marker, and both values must match it exactly.
+//   2. Every other adoption surface — the handoff, the Story template, the
+//      local `story-development` Skill — may mention a ForgeFlow version, but
+//      not a version DIFFERENT from the marker.
+//
+// Rule 2 matches only a version written immediately after the word ForgeFlow
+// (`ForgeFlow 0.3.1`), never a bare version elsewhere in the sentence. That
+// narrowness is the point. These documents legitimately discuss earlier
+// releases — "0.3.1 新增上游的 story-check", "It was first adopted at 0.3.0" —
+// and a looser pattern would report each of those as drift, which is how a gate
+// gets switched off in a week. What it does catch is the failure that actually
+// happened: a sentence asserting which ForgeFlow this repository is on.
+//
+// Nothing here reaches the network. Whether the recorded revision exists
+// upstream is not checkable offline and is not claimed; what is checkable is
+// that this repository gives one consistent answer about it.
+
+/** The parsed contents of `specs/.forgeflow-adoption`. */
+export interface AdoptionMarker {
+  version: string
+  revision: string
+}
+
+/**
+ * One disagreement about the adopted ForgeFlow release.
+ *
+ * `expected` and `actual` are carried separately from the prose so a failure
+ * report can always name the value it wanted and the value it found, rather
+ * than leaving the reader to diff two sentences by eye.
+ */
+export interface AdoptionDrift {
+  file: string
+  field: string
+  expected: string
+  actual: string
+  detail: string
+}
+
+/** Keys the marker may declare. An unknown key is drift, not a comment. */
+const MARKER_KEYS = ['version', 'revision'] as const
+
+const SEMVER = /^\d+\.\d+\.\d+$/
+const REVISION = /^[0-9a-f]{40}$/
+
+/**
+ * The canonical declaration in `specs/stories/README.md`.
+ *
+ * `\s+` spans the line break, because the sentence wraps in the file and a
+ * line-oriented pattern would report the wrapped form as missing.
+ */
+const README_DECLARATION = /adopted ForgeFlow (\d+\.\d+\.\d+) from revision\s+`([0-9a-f]{40})`/
+
+/** A version asserted as the ForgeFlow release in use. See the header note. */
+const RESTATED_VERSION = /ForgeFlow\s+v?(\d+\.\d+\.\d+)/g
+
+/** Files that may mention a ForgeFlow version but must not contradict the marker. */
+export const RESTATEMENT_SURFACES: readonly string[] = [
+  'specs/handoff.md',
+  'specs/stories/_template/story.md',
+  'specs/stories/_template/acceptance.md',
+  'specs/stories/_template/task.md',
+  '.agents/skills/story-development/SKILL.md',
+]
+
+export const MARKER_PATH = 'specs/.forgeflow-adoption'
+export const README_PATH = 'specs/stories/README.md'
+
+const drift = (
+  file: string,
+  field: string,
+  expected: string,
+  actual: string,
+  detail: string
+): AdoptionDrift => ({ file, field, expected, actual, detail })
+
+/**
+ * Read the adoption marker.
+ *
+ * Returns the marker only when every field is present and well formed; a
+ * partially parsed marker is not returned, because comparing other files
+ * against half an answer produces failures that point at the wrong file.
+ */
+export function parseAdoptionMarker(
+  source: string,
+  file: string = MARKER_PATH
+): { marker?: AdoptionMarker; drift: AdoptionDrift[] } {
+  const found = new Map<string, string>()
+  const problems: AdoptionDrift[] = []
+
+  for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+
+    const separator = line.indexOf('=')
+    if (separator === -1) {
+      problems.push(
+        drift(
+          file,
+          `line ${index + 1}`,
+          'a `key=value` line',
+          line,
+          'the marker is a key=value record; a line without `=` declares nothing'
+        )
+      )
+      continue
+    }
+
+    const key = line.slice(0, separator).trim()
+    const value = line.slice(separator + 1).trim()
+
+    if (!(MARKER_KEYS as readonly string[]).includes(key)) {
+      problems.push(
+        drift(
+          file,
+          `line ${index + 1}`,
+          `one of ${MARKER_KEYS.join(', ')}`,
+          key,
+          'an unrecognised key is not read by anything, so it records nothing'
+        )
+      )
+      continue
+    }
+
+    if (found.has(key)) {
+      problems.push(
+        drift(
+          file,
+          key,
+          'exactly one declaration',
+          `declared again on line ${index + 1} as "${value}"`,
+          'a repeated key leaves which value is authoritative undefined'
+        )
+      )
+      continue
+    }
+
+    found.set(key, value)
+  }
+
+  const version = found.get('version')
+  const revision = found.get('revision')
+
+  if (version === undefined) {
+    problems.push(
+      drift(file, 'version', 'a semantic version such as 0.3.2', 'absent', 'the field is missing')
+    )
+  } else if (!SEMVER.test(version)) {
+    problems.push(
+      drift(
+        file,
+        'version',
+        'a semantic version such as 0.3.2',
+        version,
+        'the value does not parse as MAJOR.MINOR.PATCH'
+      )
+    )
+  }
+
+  if (revision === undefined) {
+    problems.push(
+      drift(
+        file,
+        'revision',
+        'a 40-character upstream commit SHA',
+        'absent',
+        'the field is missing'
+      )
+    )
+  } else if (!REVISION.test(revision)) {
+    problems.push(
+      drift(
+        file,
+        'revision',
+        'a 40-character upstream commit SHA',
+        revision,
+        'the value is not a full lowercase hexadecimal SHA, so it does not identify a revision'
+      )
+    )
+  }
+
+  if (problems.length > 0) return { drift: problems }
+  return { marker: { version: version as string, revision: revision as string }, drift: [] }
+}
+
+/**
+ * Check the canonical declaration in `specs/stories/README.md`.
+ *
+ * A missing declaration fails rather than passing quietly: the README is the
+ * file a human reads to learn the adopted version, and one that has stopped
+ * declaring it has stopped being checkable.
+ */
+export function findReadmeDeclarationDrift(
+  source: string,
+  marker: AdoptionMarker,
+  file: string = README_PATH
+): AdoptionDrift[] {
+  const declaration = source.match(README_DECLARATION)
+  if (!declaration) {
+    return [
+      drift(
+        file,
+        'adoption declaration',
+        `a sentence reading: adopted ForgeFlow ${marker.version} from revision \`${marker.revision}\``,
+        'no such sentence',
+        'the README is the canonical restatement of the marker and must declare both values'
+      ),
+    ]
+  }
+
+  const [, version, revision] = declaration
+  const problems: AdoptionDrift[] = []
+
+  if (version !== marker.version) {
+    problems.push(
+      drift(
+        file,
+        'declared version',
+        marker.version,
+        version as string,
+        `disagrees with ${MARKER_PATH}`
+      )
+    )
+  }
+
+  if (revision !== marker.revision) {
+    problems.push(
+      drift(
+        file,
+        'declared revision',
+        marker.revision,
+        revision as string,
+        `disagrees with ${MARKER_PATH}`
+      )
+    )
+  }
+
+  return problems
+}
+
+/**
+ * Check that a document does not assert a ForgeFlow version other than the
+ * marker's.
+ */
+export function findRestatedVersionDrift(
+  source: string,
+  marker: AdoptionMarker,
+  file: string
+): AdoptionDrift[] {
+  const lines = source.split(/\r?\n/)
+  const problems: AdoptionDrift[] = []
+
+  for (const [index, line] of lines.entries()) {
+    for (const [, version] of line.matchAll(RESTATED_VERSION)) {
+      if (version === marker.version) continue
+      problems.push(
+        drift(
+          file,
+          `line ${index + 1}`,
+          `ForgeFlow ${marker.version}`,
+          `ForgeFlow ${version as string}`,
+          `${MARKER_PATH} records ${marker.version}; a sentence naming a different release as the adopted one is the drift this gate exists to catch`
+        )
+      )
+    }
+  }
+
+  return problems
+}
+
+/** Render one disagreement as a line a reader can act on without opening a diff. */
+export function formatAdoptionDrift(item: AdoptionDrift): string {
+  return `${item.file} — ${item.field}: expected ${item.expected}, found ${item.actual} (${item.detail})`
+}
+
+/** Reads a file from `root`, or `undefined` when it does not exist. */
+type ReadFile = (path: string) => Promise<string | undefined>
+
+/**
+ * Reconcile every adoption surface against the marker.
+ *
+ * `read` is injected so this runs against a fixture tree in tests without
+ * touching the working copy the gate is protecting.
+ */
+export async function collectAdoptionDrift(read: ReadFile): Promise<AdoptionDrift[]> {
+  const markerSource = await read(MARKER_PATH)
+  if (markerSource === undefined) {
+    return [
+      drift(
+        MARKER_PATH,
+        'file',
+        'a key=value record of the adopted ForgeFlow release',
+        'absent',
+        'nothing records which upstream revision the Story contract came from'
+      ),
+    ]
+  }
+
+  const { marker, drift: markerDrift } = parseAdoptionMarker(markerSource)
+  if (!marker) return markerDrift
+
+  const problems: AdoptionDrift[] = []
+
+  const readme = await read(README_PATH)
+  if (readme === undefined) {
+    problems.push(
+      drift(
+        README_PATH,
+        'file',
+        'the canonical adoption declaration',
+        'absent',
+        'the Story README is where the adopted version is declared to humans'
+      )
+    )
+  } else {
+    problems.push(...findReadmeDeclarationDrift(readme, marker))
+  }
+
+  for (const path of RESTATEMENT_SURFACES) {
+    const source = await read(path)
+    if (source === undefined) {
+      problems.push(
+        drift(
+          path,
+          'file',
+          'an adoption surface this gate reconciles',
+          'absent',
+          'a surface that stops existing stops being checked; remove it from RESTATEMENT_SURFACES deliberately'
+        )
+      )
+      continue
+    }
+    problems.push(...findRestatedVersionDrift(source, marker, path))
+  }
+
+  return problems
+}

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1,9 +1,13 @@
 # ForgeFlow Handoff
 
 十二個 Story 全數交付，已於 PR #144 合併進 `main`（merge commit `04a88a44`），
-合併後的收尾為 PR #145（`a2a05cc2`）。目前進行中的是 DBCLI-013，收 ForgeFlow
-導入本身的尾——採用版本的對帳、發布前的盤點，以及把仍留在這份散文裡的風險移出去。
-沒有已知的產品缺口。
+合併後的收尾為 PR #145（`a2a05cc2`）。DBCLI-013 已交付，收的是 ForgeFlow 導入本身的尾——
+採用版本的對帳、發布前的盤點，以及把仍留在這份散文裡的風險移出去。沒有已知的產品
+缺口，也沒有選定中的下一個 Story。
+
+未結的是發布：DBCLI-001 到 012 的成果全部未發布，建議版本 8.0.0，留給下一個獨立的
+release Story。bump 之前 `SECURITY.md` 的支援列必須從 `7.x` 改成 `8.x`，否則
+`manifest:check`（`scripts/check-plugin-manifests.ts:164-176`）會擋下 release。
 
 ## 交付紀錄
 
@@ -115,7 +119,7 @@ revision 是否存在，所以不宣稱；能查的是這個 repository 對它�
 
 ```yaml
 workflow:
-  current_story: DBCLI-013
+  current_story: none
   next_story: pending
   completed_stories:
     - DBCLI-001
@@ -130,16 +134,17 @@ workflow:
     - DBCLI-010
     - DBCLI-011
     - DBCLI-012
+    - DBCLI-013
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
-  branch: main
-  # DBCLI-013 sits on top of this commit; it is the state the Story was
-  # developed against, not the state after it. `a2a05cc2` was the previous
-  # baseline and is an ancestor of this one.
-  commit: 7f534be5
-  dirty_worktree: true
+  branch: feat/dbcli-013-forgeflow-adoption-hardening
+  # The DBCLI-013 delivery commit on
+  # feat/dbcli-013-forgeflow-adoption-hardening, not yet merged to main.
+  # `7f534be5` is its parent and the last state on main.
+  commit: 907b0f69
+  dirty_worktree: false
   story_owned_paths:
     - specs/stories/DBCLI-013-forgeflow-adoption-hardening/
     - scripts/check-forgeflow-adoption.ts
@@ -151,6 +156,7 @@ baseline:
   known_unrelated_paths: []
 
 verification:
-  last_command: make verify
+  last_command: SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true make verify
   result: pass
+  detail: 6403 tests across 552 files, 0 fail, integration included (docker services up)
 ```

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1,8 +1,9 @@
 # ForgeFlow Handoff
 
 十二個 Story 全數交付，已於 PR #144 合併進 `main`（merge commit `04a88a44`），
-合併後的收尾為 PR #145（`a2a05cc2`）。沒有已知的產品缺口，也沒有選定中的
-下一個 Story。
+合併後的收尾為 PR #145（`a2a05cc2`）。目前進行中的是 DBCLI-013，收 ForgeFlow
+導入本身的尾——採用版本的對帳、發布前的盤點，以及把仍留在這份散文裡的風險移出去。
+沒有已知的產品缺口。
 
 ## 交付紀錄
 
@@ -23,9 +24,12 @@ DBCLI-001 的交付狀態已驗證並結案。它跨十份交接紀錄被記為�
 
 ## 流程版本
 
-採用 ForgeFlow 0.3.1（`specs/.forgeflow-adoption`）。0.3.1 新增上游的
-`story-check` 與 `handoff-check` 兩支靜態結構檢查——它們住在 ForgeFlow 的
-checkout 裡，CI 跑不到，而且文件明說它們不判斷宣告是否屬實。
+採用 ForgeFlow 0.3.2。權威記錄是 `specs/.forgeflow-adoption`，這裡只是複述，
+而複述正是 DBCLI-013 要修的東西：這段話在 marker 與 `specs/stories/README.md`
+都已經推進到 0.3.2 之後，還原樣說著 0.3.1，跨兩個已合併的 PR 沒有人看。
+
+0.3.1 新增上游的 `story-check` 與 `handoff-check` 兩支靜態結構檢查——它們住在
+ForgeFlow 的 checkout 裡，CI 跑不到，而且文件明說它們不判斷宣告是否屬實。
 
 `make verify` 因此多了一步 `bun run forgeflow:check`，補的是上游明說不做的那一
 層：把 `completed_stories` 與 repository 實況對帳。升級到 0.3.1 時，上游的
@@ -71,13 +75,47 @@ lowercase 也不收合 CJK 換行，`verification-receipt` 多一條標點貼合
 接受 1 與 2，v2 就是加上 `relationships` 的版本，同檔案的 `migrateSemanticContext`
 專門把 v1 升成 v2。誤判來自我當時想找一個形狀錯誤的產物、隨手用了 `version: 2`。
 允許的 key 集合隨版本走，所以 v1 產物帶 `relationships` 會被擋而非靜默忽略；
-`version: 3` 與字串 `"2"` 都會被拒。）
+`version: 3` 與字串 `"2"` 都會被拒。
+
+DBCLI-013 重驗了這個結論，成立。但重驗時發現真正該追蹤的不是那個懷疑，而是
+`grep -rn "equal 1 or 2" tests/` 沒有任何命中：這個接受集合完全沒有回歸測試。
+結論目前只靠一次原始碼閱讀與這段散文支撐，兩者都不會在有人改動 `parseContext`
+時發出聲音。已開成 issue #150，不再只留在這裡。)
+
+## DBCLI-013：採用版本的對帳
+
+`specs/.forgeflow-adoption` 與 `specs/stories/README.md` 在 `049d7d55` 推進到
+0.3.2 之後，這份文件仍宣告採用中的是 0.3.1，跨 `0c04d091`、`88ec1ad9`、
+`7f534be5` 三個已合併的狀態沒有任何東西比對過。版本從來不是行為的一部分，這正是
+它會漂的原因：沒有東西讀的欄位不記錄任何事情。
+
+`scripts/check-forgeflow-adoption.ts` 把 marker 定為唯一權威，README 必須以固定
+形式複述 version 與 revision 兩者，其餘採用面（本文件、Story template、本地
+`story-development` Skill）可以提到某個 ForgeFlow 版本，但不能指名另一個版本為
+採用中的版本。
+
+規則刻意畫得窄：只匹配緊接在 `ForgeFlow` 一詞之後的版本號。這些文件本來就會談論
+較早的 release——README 的「first adopted at 0.3.0」、本文件的「0.3.1 新增上游的
+`story-check`」與「升級到 0.3.1 時」——把句子裡任何位置的版本號都算成漂移的 gate，
+一週內就會被關掉。這是 `context-v2` 那次 `message.includes('reference')` 的教訓，
+換一個地方重演的機會。
+
+gate 分不出「宣告一個舊版本」與「引用一段宣告了舊版本的文字」——這一段原本
+逐字引用了那句漂掉的話，gate 立刻擋下來，於是改成不逐字引用。這是刻意留著的取捨：
+要分辨兩者需要理解語意，而一個會猜語意的 gate 比一個偶爾要求換句話說的 gate 危險
+得多。要引用時，把版本號寫在 `ForgeFlow` 一詞之外即可。
+
+gate 不碰網路。marker 記著一個上游 revision，但沒有任何東西去取它：離線查不到那個
+revision 是否存在，所以不宣稱；能查的是這個 repository 對它是否只給一個答案。
+
+既有的 `check-forgeflow-handoff.ts` 原封不動，兩支互不涵蓋——一支對帳交付宣稱，
+一支對帳流程版本。
 
 ## Lifecycle
 
 ```yaml
 workflow:
-  current_story: none
+  current_story: DBCLI-013
   next_story: pending
   completed_stories:
     - DBCLI-001
@@ -97,9 +135,19 @@ workflow:
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: a2a05cc2e11e0754339e734d1db5319ec6744693
-  dirty_worktree: false
-  story_owned_paths: []
+  # DBCLI-013 sits on top of this commit; it is the state the Story was
+  # developed against, not the state after it. `a2a05cc2` was the previous
+  # baseline and is an ancestor of this one.
+  commit: 7f534be5
+  dirty_worktree: true
+  story_owned_paths:
+    - specs/stories/DBCLI-013-forgeflow-adoption-hardening/
+    - scripts/check-forgeflow-adoption.ts
+    - scripts/lib/forgeflow-adoption.ts
+    - tests/contract/forgeflow-adoption.test.ts
+    - specs/handoff.md
+    - package.json
+    - CHANGELOG.md
   known_unrelated_paths: []
 
 verification:

--- a/specs/stories/DBCLI-013-forgeflow-adoption-hardening/acceptance.md
+++ b/specs/stories/DBCLI-013-forgeflow-adoption-hardening/acceptance.md
@@ -1,0 +1,63 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] `bun run forgeflow:check` runs adoption reconciliation and then handoff
+      reconciliation, and both pass on the delivered tree.
+* [x] The adoption gate prints one line naming the marker it read and the
+      surfaces it agreed with, and exits 0.
+* [x] `make verify` reaches `forgeflow:check` and passes.
+
+## Business Rules
+
+* [x] `specs/.forgeflow-adoption`, `specs/stories/README.md` and
+      `specs/handoff.md` all resolve to ForgeFlow 0.3.2.
+* [x] A well-formed marker parses to exactly `version` and `revision`; comments,
+      blank lines and surrounding whitespace are tolerated.
+* [x] The gate makes no network request and reads only repository files.
+* [x] Handoff reconciliation still reports 12 completed Stories: 11 backed by a
+      `Story:` commit trailer and DBCLI-001 backed by its recorded delivering
+      commit.
+
+## Failure Cases
+
+Each exits non-zero and names file, locator, expected and actual.
+
+* [x] Marker absent.
+* [x] Marker missing `version`.
+* [x] Marker missing `revision`.
+* [x] Marker `version` not MAJOR.MINOR.PATCH.
+* [x] Marker `revision` abbreviated rather than a full SHA.
+* [x] Marker carrying an unrecognised key.
+* [x] Marker declaring a key twice.
+* [x] Marker line that is not `key=value`.
+* [x] README declaring a different version.
+* [x] README declaring a different revision.
+* [x] README no longer declaring the adoption at all.
+* [x] `specs/handoff.md` declaring an older adopted version.
+* [x] Story template declaring a different version.
+* [x] Local `story-development` Skill declaring a different version.
+* [x] A reconciled adoption surface deleted.
+* [x] When the marker itself is unparseable, only the marker is reported — the
+      other surfaces are not compared against half an answer.
+
+## Regression Requirements
+
+* [x] A historical version written away from the word `ForgeFlow` — the
+      README's `first adopted at 0.3.0`, the handoff's `0.3.1 新增上游的
+      story-check` and `升級到 0.3.1 時` — is not reported.
+* [x] A marker checked out with CRLF line endings parses.
+* [x] A canonical README declaration wrapped across a line break is accepted.
+* [x] Every emitted message names a locatable place and both values, and
+      contains none of `unknown`, `invalid`, `something`, `somewhere`.
+* [x] One test reconciles the real working tree read-only, so fixture-only
+      coverage cannot hide live drift.
+
+## Verification Notes
+
+Focused: `bun test tests/contract/forgeflow-adoption.test.ts` and
+`bun run forgeflow:check`.
+
+Gate: `make verify` from the repository root. Its `test` step requires the
+docker-compose test services; a run without Docker is not a PASS and must be
+reported as such rather than described as passing.

--- a/specs/stories/DBCLI-013-forgeflow-adoption-hardening/story.md
+++ b/specs/stories/DBCLI-013-forgeflow-adoption-hardening/story.md
@@ -1,0 +1,120 @@
+# Story: DBCLI-013 ForgeFlow adoption hardening
+
+## Goal
+
+The repository gives one checkable answer to "which ForgeFlow is this on", and
+gives it wrong loudly rather than quietly. Today it gives three, and the two
+that disagree were both written by hand and read by nobody.
+
+## Context
+
+DBCLI-001 to DBCLI-012 are delivered and `bun run forgeflow:check` already
+reconciles the handoff's `completed_stories` against the repository. That gate
+was built after a delivery claim survived ten handoff revisions unchecked.
+
+The same failure then recurred one level up, on the process version rather than
+the delivery claims. `specs/.forgeflow-adoption` and `specs/stories/README.md`
+were advanced to 0.3.2 in `049d7d55`; `specs/handoff.md` kept saying
+`採用 ForgeFlow 0.3.1` through `0c04d091`, `88ec1ad9` and `7f534be5`. Nothing
+compared them, because nothing was asked to. The version was never load-bearing
+for behavior, which is precisely why it drifted: an unread field records
+nothing, and a field nothing checks is an unread field with extra steps.
+
+The adoption record is also the only pointer back to the upstream revision the
+Story contract, the template and the local `story-development` Skill were
+derived from. When it is wrong, the next person reconstructing why the template
+looks the way it does starts from the wrong upstream commit.
+
+## Classification
+
+Both declarations are required. `yes` makes the matching section below
+mandatory.
+
+* Security sensitive: no
+* Baseline conformance: no
+
+## Scope
+
+### In Scope
+
+* A repository-local gate that reconciles every adoption surface against
+  `specs/.forgeflow-adoption`, run inside the existing `forgeflow:check` and so
+  inside `make verify`.
+* Correcting the ForgeFlow version drift already present in `specs/handoff.md`.
+* Automated tests for the gate, over fixtures rather than the working tree.
+* Recording the `loadSemanticContext` `version: 2` question in a tracker issue
+  rather than leaving it in handoff prose.
+* A release-readiness assessment of DBCLI-001..012 against Semantic Versioning,
+  and the CHANGELOG entries that assessment shows are missing.
+* A branch-protection recommendation for `main`, written against the CI job
+  names that actually exist.
+
+### Out of Scope
+
+* Any change to dbcli product behavior, CLI surface, or JSON artifacts.
+* Any change to the ForgeFlowV2 upstream repository.
+* Bumping `package.json`, tagging, publishing, or creating a GitHub Release.
+* Applying branch protection or a repository ruleset.
+* Changing the intent or acceptance criteria of DBCLI-001..012.
+
+## Inputs
+
+* `specs/.forgeflow-adoption` — `key=value`, the authoritative record.
+* `specs/stories/README.md` — the canonical human-readable declaration.
+* `specs/handoff.md`, `specs/stories/_template/*.md`,
+  `.agents/skills/story-development/SKILL.md` — surfaces that may mention a
+  ForgeFlow version.
+
+## Outputs
+
+* `scripts/check-forgeflow-adoption.ts` — the executable gate.
+* `scripts/lib/forgeflow-adoption.ts` — its rules, as pure functions.
+* Exit code 0 with a one-line summary naming what agreed, or exit code 1 with
+  one line per disagreement.
+
+## Rules
+
+* R1: `specs/.forgeflow-adoption` is the single source of truth. Every other
+  surface is measured against it; it is measured against nothing.
+* R2: The marker must declare exactly `version` (MAJOR.MINOR.PATCH) and
+  `revision` (40 lowercase hex). An unknown key, a repeated key, or a line that
+  is not `key=value` fails — an unread field is the failure being prevented, so
+  the gate must not add one.
+* R3: `specs/stories/README.md` must carry the canonical declaration naming
+  both values, and both must equal the marker's.
+* R4: Every other adoption surface may mention a ForgeFlow version but must not
+  name a different one as the adopted release.
+* R5: R4 matches only a version written immediately after the word `ForgeFlow`.
+  These documents legitimately discuss earlier releases by number, and a gate
+  that reports true prose is a gate that gets switched off.
+* R6: The gate does not distinguish declaring an old version from quoting a
+  sentence that declared one. Prose that must quote drift writes the version
+  away from the word `ForgeFlow`. Telling the two apart requires reading intent,
+  and a gate that guesses intent is worse than one that occasionally asks for a
+  rephrase.
+* R7: The gate performs no network access. Whether the recorded revision exists
+  upstream is not checkable offline and is not claimed.
+* R8: Every failure names the file, a locator within it, the expected value and
+  the found value.
+* R9: The existing handoff reconciliation is preserved unchanged and neither
+  gate subsumes the other.
+
+## Expected Errors
+
+* Marker absent, unparseable, missing `version`, missing `revision`, carrying a
+  malformed value, an unknown key, or a duplicate key.
+* README missing the declaration, or declaring a different version or revision.
+* Handoff, template, or Skill naming a different adopted release.
+* An adoption surface that has been deleted.
+
+## Dependencies
+
+* `scripts/check-forgeflow-handoff.ts` — the sibling gate, unchanged.
+* `make verify` via `bun run forgeflow:check`.
+
+## Constraints
+
+* Tests must not mutate the tracked files the gate protects; drift cases are
+  built in a temporary tree.
+* No existing verification gate may be weakened, skipped, or removed.
+* The delivering commit carries the `Story: DBCLI-013` trailer.

--- a/tests/contract/forgeflow-adoption.test.ts
+++ b/tests/contract/forgeflow-adoption.test.ts
@@ -1,0 +1,373 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  collectAdoptionDrift,
+  findReadmeDeclarationDrift,
+  findRestatedVersionDrift,
+  formatAdoptionDrift,
+  MARKER_PATH,
+  parseAdoptionMarker,
+  README_PATH,
+  RESTATEMENT_SURFACES,
+  type AdoptionMarker,
+} from '../../scripts/lib/forgeflow-adoption'
+import { readFromRoot } from '../../scripts/check-forgeflow-adoption'
+
+const VERSION = '0.3.2'
+const REVISION = '7bbdf443ead484780e23df9abf055095d4c629e2'
+const OTHER_REVISION = 'afca7600db01279ddfe74ac030bd226444cc8b11'
+
+const marker: AdoptionMarker = { version: VERSION, revision: REVISION }
+
+const markerFile = (...lines: string[]): string => `${lines.join('\n')}\n`
+
+const readme = (version = VERSION, revision = REVISION): string =>
+  [
+    '# ForgeFlow Stories',
+    '',
+    `This repository adopted ForgeFlow ${version} from revision`,
+    `\`${revision}\`; \`specs/.forgeflow-adoption\` is the machine-readable record.`,
+    '',
+  ].join('\n')
+
+/**
+ * A fixture repository written under the OS temp directory.
+ *
+ * The gate reads the files it is protecting, so a test that mutated them to
+ * produce a failure would be corrupting the working tree to prove the gate
+ * notices corruption. Every drift case here is built in a throwaway tree
+ * instead.
+ */
+const trees: string[] = []
+
+async function fixtureRepo(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'forgeflow-adoption-'))
+  trees.push(root)
+  for (const [path, content] of Object.entries(files)) {
+    const absolute = join(root, path)
+    await mkdir(dirname(absolute), { recursive: true })
+    await writeFile(absolute, content)
+  }
+  return root
+}
+
+/** A tree in which every surface agrees, before the case under test edits it. */
+function healthyTree(): Record<string, string> {
+  const files: Record<string, string> = {
+    [MARKER_PATH]: markerFile(`version=${VERSION}`, `revision=${REVISION}`),
+    [README_PATH]: readme(),
+  }
+  for (const surface of RESTATEMENT_SURFACES) {
+    files[surface] = '# a surface that mentions no ForgeFlow version\n'
+  }
+  return files
+}
+
+const driftIn = async (files: Record<string, string>): Promise<string[]> =>
+  (await collectAdoptionDrift(readFromRoot(await fixtureRepo(files)))).map(formatAdoptionDrift)
+
+afterEach(async () => {
+  await Promise.all(trees.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('adoption marker', () => {
+  test('parses a well-formed marker', () => {
+    const result = parseAdoptionMarker(markerFile(`version=${VERSION}`, `revision=${REVISION}`))
+    expect(result.drift).toEqual([])
+    expect(result.marker).toEqual(marker)
+  })
+
+  test('tolerates comments, blank lines, and surrounding whitespace', () => {
+    const result = parseAdoptionMarker(
+      markerFile(
+        '# the upstream release this contract came from',
+        '',
+        `  version = ${VERSION} `,
+        '',
+        `revision=${REVISION}`
+      )
+    )
+    expect(result.drift).toEqual([])
+    expect(result.marker).toEqual(marker)
+  })
+
+  test('reports a missing version and returns no marker', () => {
+    const result = parseAdoptionMarker(markerFile(`revision=${REVISION}`))
+    expect(result.marker).toBeUndefined()
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — version: expected a semantic version such as 0.3.2, found absent (the field is missing)',
+    ])
+  })
+
+  test('reports a missing revision and returns no marker', () => {
+    const result = parseAdoptionMarker(markerFile(`version=${VERSION}`))
+    expect(result.marker).toBeUndefined()
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — revision: expected a 40-character upstream commit SHA, found absent (the field is missing)',
+    ])
+  })
+
+  test('rejects a version that is not a semantic version', () => {
+    const result = parseAdoptionMarker(markerFile('version=0.3', `revision=${REVISION}`))
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — version: expected a semantic version such as 0.3.2, found 0.3 (the value does not parse as MAJOR.MINOR.PATCH)',
+    ])
+  })
+
+  // An abbreviated SHA reads like a revision and identifies nothing durable:
+  // it is ambiguous by construction and can stop resolving as upstream grows.
+  test('rejects an abbreviated revision', () => {
+    const result = parseAdoptionMarker(markerFile(`version=${VERSION}`, 'revision=7bbdf44'))
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — revision: expected a 40-character upstream commit SHA, found 7bbdf44 (the value is not a full lowercase hexadecimal SHA, so it does not identify a revision)',
+    ])
+  })
+
+  test('rejects an unrecognised key rather than ignoring it', () => {
+    const result = parseAdoptionMarker(
+      markerFile(`version=${VERSION}`, `revision=${REVISION}`, 'upstream=ForgeFlowV2')
+    )
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — line 3: expected one of version, revision, found upstream (an unrecognised key is not read by anything, so it records nothing)',
+    ])
+  })
+
+  test('rejects a repeated key rather than picking one silently', () => {
+    const result = parseAdoptionMarker(
+      markerFile(`version=${VERSION}`, 'version=0.3.1', `revision=${REVISION}`)
+    )
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — version: expected exactly one declaration, found declared again on line 2 as "0.3.1" (a repeated key leaves which value is authoritative undefined)',
+    ])
+  })
+
+  test('rejects a line that declares nothing', () => {
+    const result = parseAdoptionMarker(
+      markerFile(`version=${VERSION}`, 'forgeflow 0.3.2', `revision=${REVISION}`)
+    )
+    expect(result.drift.map(formatAdoptionDrift)).toEqual([
+      'specs/.forgeflow-adoption — line 2: expected a `key=value` line, found forgeflow 0.3.2 (the marker is a key=value record; a line without `=` declares nothing)',
+    ])
+  })
+
+  // A CRLF checkout leaves \r at every line end, which would otherwise land
+  // inside the parsed value and fail the SHA pattern for the wrong reason.
+  test('reads a marker checked out with CRLF line endings', () => {
+    const source = markerFile(`version=${VERSION}`, `revision=${REVISION}`).replaceAll('\n', '\r\n')
+    expect(parseAdoptionMarker(source).marker).toEqual(marker)
+  })
+})
+
+describe('canonical README declaration', () => {
+  test('accepts the declaration when both values match the marker', () => {
+    expect(findReadmeDeclarationDrift(readme(), marker)).toEqual([])
+  })
+
+  test('reports a README declaring a different version', () => {
+    expect(findReadmeDeclarationDrift(readme('0.3.1'), marker).map(formatAdoptionDrift)).toEqual([
+      'specs/stories/README.md — declared version: expected 0.3.2, found 0.3.1 (disagrees with specs/.forgeflow-adoption)',
+    ])
+  })
+
+  test('reports a README declaring a different revision', () => {
+    expect(
+      findReadmeDeclarationDrift(readme(VERSION, OTHER_REVISION), marker).map(formatAdoptionDrift)
+    ).toEqual([
+      `specs/stories/README.md — declared revision: expected ${REVISION}, found ${OTHER_REVISION} (disagrees with specs/.forgeflow-adoption)`,
+    ])
+  })
+
+  test('reports a README that has stopped declaring the adoption at all', () => {
+    expect(
+      findReadmeDeclarationDrift('# ForgeFlow Stories\n\nCopy the template.\n', marker).map(
+        formatAdoptionDrift
+      )
+    ).toEqual([
+      `specs/stories/README.md — adoption declaration: expected a sentence reading: adopted ForgeFlow ${VERSION} from revision \`${REVISION}\`, found no such sentence (the README is the canonical restatement of the marker and must declare both values)`,
+    ])
+  })
+
+  // The sentence wraps in the real file. A line-oriented match would call the
+  // wrapped form missing, which is a false failure on the only file that is
+  // required to carry it.
+  test('accepts a declaration that wraps across a line break', () => {
+    const wrapped = `This repository adopted ForgeFlow ${VERSION} from revision\n\`${REVISION}\`.`
+    expect(findReadmeDeclarationDrift(wrapped, marker)).toEqual([])
+  })
+
+  // The README records the release this contract was FIRST adopted at as well
+  // as the current one. That earlier version is history, not a competing claim.
+  test('does not read the prior-adoption sentence as a competing declaration', () => {
+    const source = `${readme()}\nIt was first adopted at 0.3.0 (\`${OTHER_REVISION}\`).\n`
+    expect(findReadmeDeclarationDrift(source, marker)).toEqual([])
+    expect(findRestatedVersionDrift(source, marker, README_PATH)).toEqual([])
+  })
+})
+
+describe('restated versions on other surfaces', () => {
+  test('accepts a surface that mentions no ForgeFlow version', () => {
+    expect(findRestatedVersionDrift('# Handoff\n\nNothing to report.\n', marker, 'f.md')).toEqual(
+      []
+    )
+  })
+
+  test('accepts a surface restating the adopted version', () => {
+    expect(
+      findRestatedVersionDrift(`採用 ForgeFlow ${VERSION}（見 marker）。\n`, marker, 'f.md')
+    ).toEqual([])
+  })
+
+  test('reports a handoff declaring an older adoption version', () => {
+    expect(
+      findRestatedVersionDrift(
+        '# Handoff\n\n採用 ForgeFlow 0.3.1（`specs/.forgeflow-adoption`）。\n',
+        marker,
+        'specs/handoff.md'
+      ).map(formatAdoptionDrift)
+    ).toEqual([
+      'specs/handoff.md — line 3: expected ForgeFlow 0.3.2, found ForgeFlow 0.3.1 (specs/.forgeflow-adoption records 0.3.2; a sentence naming a different release as the adopted one is the drift this gate exists to catch)',
+    ])
+  })
+
+  test('reports a `v`-prefixed restatement', () => {
+    expect(
+      findRestatedVersionDrift('Runs on ForgeFlow v0.4.0.\n', marker, 'f.md').map(
+        formatAdoptionDrift
+      )[0]
+    ).toContain('found ForgeFlow 0.4.0')
+  })
+
+  // These documents legitimately discuss earlier releases by number. Matching a
+  // bare version anywhere in the sentence would report each of them, and a gate
+  // that cries wolf on true prose is a gate that gets deleted.
+  test.each([
+    ['0.3.1 新增上游的 `story-check` 與 `handoff-check`。'],
+    ['升級到 0.3.1 時，上游的 `handoff-check` 立刻抓出這份紀錄。'],
+    ['It was first adopted at 0.3.0.'],
+  ])('does not report a historical version written away from the word ForgeFlow: %s', (line) => {
+    expect(findRestatedVersionDrift(`${line}\n`, marker, 'f.md')).toEqual([])
+  })
+
+  test('reports every restatement, not only the first', () => {
+    const source = 'ForgeFlow 0.3.1 here.\nAnd ForgeFlow 0.2.0 here.\n'
+    expect(findRestatedVersionDrift(source, marker, 'f.md').map((item) => item.field)).toEqual([
+      'line 1',
+      'line 2',
+    ])
+  })
+})
+
+describe('whole-repository reconciliation', () => {
+  test('passes on a tree where every surface agrees', async () => {
+    expect(await driftIn(healthyTree())).toEqual([])
+  })
+
+  test('reports an absent marker', async () => {
+    const files = healthyTree()
+    delete files[MARKER_PATH]
+    expect(await driftIn(files)).toEqual([
+      'specs/.forgeflow-adoption — file: expected a key=value record of the adopted ForgeFlow release, found absent (nothing records which upstream revision the Story contract came from)',
+    ])
+  })
+
+  // A marker that does not parse cannot be compared against; reporting the
+  // other files too would point the reader at four innocent files.
+  test('reports only the marker when the marker itself is unreadable', async () => {
+    const files = healthyTree()
+    files[MARKER_PATH] = markerFile(`revision=${REVISION}`)
+    files[README_PATH] = readme('0.3.1')
+    const drift = await driftIn(files)
+    expect(drift).toHaveLength(1)
+    expect(drift[0]).toContain('specs/.forgeflow-adoption — version')
+  })
+
+  test('reports a README version that drifted from the marker', async () => {
+    const files = healthyTree()
+    files[README_PATH] = readme('0.3.1')
+    expect(await driftIn(files)).toEqual([
+      'specs/stories/README.md — declared version: expected 0.3.2, found 0.3.1 (disagrees with specs/.forgeflow-adoption)',
+    ])
+  })
+
+  test('reports a README revision that drifted from the marker', async () => {
+    const files = healthyTree()
+    files[README_PATH] = readme(VERSION, OTHER_REVISION)
+    expect(await driftIn(files)).toEqual([
+      `specs/stories/README.md — declared revision: expected ${REVISION}, found ${OTHER_REVISION} (disagrees with specs/.forgeflow-adoption)`,
+    ])
+  })
+
+  test('reports a handoff that still declares the previous adoption version', async () => {
+    const files = healthyTree()
+    files['specs/handoff.md'] = '# Handoff\n\n採用 ForgeFlow 0.3.1。\n'
+    expect(await driftIn(files)).toEqual([
+      'specs/handoff.md — line 3: expected ForgeFlow 0.3.2, found ForgeFlow 0.3.1 (specs/.forgeflow-adoption records 0.3.2; a sentence naming a different release as the adopted one is the drift this gate exists to catch)',
+    ])
+  })
+
+  test('reports undisclosed drift in the Story template', async () => {
+    const files = healthyTree()
+    files['specs/stories/_template/story.md'] = '# Story\n\nWritten against ForgeFlow 0.3.0.\n'
+    expect(await driftIn(files)).toEqual([
+      'specs/stories/_template/story.md — line 3: expected ForgeFlow 0.3.2, found ForgeFlow 0.3.0 (specs/.forgeflow-adoption records 0.3.2; a sentence naming a different release as the adopted one is the drift this gate exists to catch)',
+    ])
+  })
+
+  test('reports undisclosed drift in the local story-development Skill', async () => {
+    const files = healthyTree()
+    files['.agents/skills/story-development/SKILL.md'] = 'Implements ForgeFlow 0.3.1 Stories.\n'
+    expect(await driftIn(files)).toEqual([
+      '.agents/skills/story-development/SKILL.md — line 1: expected ForgeFlow 0.3.2, found ForgeFlow 0.3.1 (specs/.forgeflow-adoption records 0.3.2; a sentence naming a different release as the adopted one is the drift this gate exists to catch)',
+    ])
+  })
+
+  // A surface that quietly stops existing stops being reconciled, which is the
+  // same silent-drift failure one level up.
+  test('reports a surface that has been deleted', async () => {
+    const files = healthyTree()
+    delete files['.agents/skills/story-development/SKILL.md']
+    expect(await driftIn(files)).toEqual([
+      '.agents/skills/story-development/SKILL.md — file: expected an adoption surface this gate reconciles, found absent (a surface that stops existing stops being checked; remove it from RESTATEMENT_SURFACES deliberately)',
+    ])
+  })
+})
+
+describe('failure output is actionable', () => {
+  // The whole value of this gate is that a reader can fix the drift without
+  // opening a diff, so every message must name a locatable place and both
+  // values. A message like "adoption drift detected" would pass a length
+  // assertion and be useless.
+  test('every drift names a file, a locator, an expected value, and an actual value', async () => {
+    const cases: Record<string, string>[] = [
+      { ...healthyTree(), [MARKER_PATH]: markerFile(`version=${VERSION}`) },
+      { ...healthyTree(), [README_PATH]: readme('0.3.1') },
+      { ...healthyTree(), 'specs/handoff.md': '採用 ForgeFlow 0.1.0。\n' },
+    ]
+
+    for (const files of cases) {
+      const root = await fixtureRepo(files)
+      const drift = await collectAdoptionDrift(readFromRoot(root))
+      expect(drift.length).toBeGreaterThan(0)
+      for (const item of drift) {
+        expect(item.file).toMatch(/\.(md|forgeflow-adoption)$/)
+        expect(item.field).not.toBe('')
+        expect(item.expected).not.toBe('')
+        expect(item.actual).not.toBe('')
+        // "unknown", "invalid" and friends tell a reader nothing they can act on.
+        expect(formatAdoptionDrift(item)).not.toMatch(/\b(unknown|invalid|something|somewhere)\b/i)
+        expect(formatAdoptionDrift(item)).toContain(item.file)
+      }
+    }
+  })
+})
+
+describe('the working tree itself', () => {
+  // The unit cases above run on fixtures, so nothing there would notice the
+  // real repository drifting. This is the one case that reads it — read-only.
+  test('the repository under test has no adoption drift', async () => {
+    const root = join(import.meta.dir, '..', '..')
+    expect((await collectAdoptionDrift(readFromRoot(root))).map(formatAdoptionDrift)).toEqual([])
+  })
+})


### PR DESCRIPTION
## 摘要

DBCLI-013：把 ForgeFlow 的「採用中版本」從散落在文件裡的散文，變成一個可對帳、由 gate 檢查的欄位；順帶盤點未發布的 Story 成果。

`specs/.forgeflow-adoption` 與 `specs/stories/README.md` 在 `049d7d55` 推進到 0.3.2 之後，`specs/handoff.md` 仍宣告 0.3.1，跨三個已合併狀態沒有東西比對過。版本從來不是行為的一部分，這正是它會漂的原因。

## 變更內容

- `scripts/lib/forgeflow-adoption.ts` + `scripts/check-forgeflow-adoption.ts`：新 gate，以 marker 檔為唯一權威。README 必須以固定形式複述 version 與 revision；其餘採用面（handoff、Story template、本地 story-development Skill）可提到某版本，但不得指名另一版本為採用中。
- 規則刻意畫窄：只匹配緊接在 `ForgeFlow` 一詞之後的版本號，避免把「first adopted at 0.3.0」這類正常敘述誤判成漂移。已知取捨：gate 分不出「宣告舊版本」與「引用一段宣告舊版本的文字」——保留此取捨，會猜語意的 gate 更危險。
- gate 不碰網路；`check-forgeflow-handoff.ts` 原封不動，兩支互不涵蓋。
- `CHANGELOG.md`：`v7.0.1`（`224ee59d`）早於 Story 合併點 `04a88a44`，DBCLI-001～012 成果全部未發布。補上 Unreleased 區段，逐條標明來源 Story。建議版本 8.0.0（六處會拒絕先前被接受的輸入或改變 JSON 判決值）。**本次不 bump、不 tag、不發布。**
- `specs/handoff.md`：更新到 DBCLI-013 交付後狀態。baseline 指向交付 commit 本身而非 main HEAD——此分支尚未合併。
- Story 文件：`specs/stories/DBCLI-013-*/story.md`、`acceptance.md`。

## 測試計畫

- `tests/contract/forgeflow-adoption.test.ts`（373 行）涵蓋 marker 解析、README 複述形式、各採用面的漂移偵測與窄規則邊界。
- `make verify` 需在合併前通過。

🤖 Generated with Claude Code

https://claude.ai/code/session_01A4BhCJzHT1vJmVg14eoieG
