### PR TITLE
feat: [ capabilities ] DBCLI-PLAT-001 Agent Integration Contract v1

### DIFF
--- a/.cursor/rules/dbcli.mdc
+++ b/.cursor/rules/dbcli.mdc
@@ -139,6 +139,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -422,6 +448,7 @@ Full flags and edge cases: see [reference.md](../skills/dbcli/reference.md#init)
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/.cursor/rules/dbcli.mdc
+++ b/.cursor/rules/dbcli.mdc
@@ -157,8 +157,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/.github/skills/dbcli/SKILL.md
+++ b/.github/skills/dbcli/SKILL.md
@@ -157,8 +157,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/.github/skills/dbcli/SKILL.md
+++ b/.github/skills/dbcli/SKILL.md
@@ -139,6 +139,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -422,6 +448,7 @@ Full flags and edge cases: see [reference.md](reference.md#init).
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -154,8 +154,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -136,6 +136,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -419,6 +445,7 @@ Full flags and edge cases: see [reference.md](.windsurf/skills/dbcli/reference.m
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ ForgeFlow Story DBCLI-001 到 DBCLI-012 全數交付但尚未發布：`v7.0.1`�
 版本建議 **8.0.0**。理由不是變更量，而是三處會拒絕先前被接受的輸入、以及一處會
 改變 JSON 判決值——SemVer 對這四項的答案都是 MAJOR，詳見下方 Breaking。
 
+### Added
+
+- **`dbcli capabilities` 與 `dbcli capabilities check`：外部 Skill 現在問得到「這個
+  工具能做什麼」。** Catalog 是靜態、有自己的 `schemaVersion`、依 id 排序，同一個
+  build 兩次輸出 byte-identical；`check --require <ids>` 只讀本機設定的 engine 與
+  permission。兩者都不建立資料庫連線，也不動檔案系統，這一點由 import graph 的
+  contract test 結構性地保證，不是靠註解宣稱。純型別與純函式從
+  `@carllee1983/dbcli/core` 匯出。
+
+  Capability 描述的是工具的原子能力（`schema.read`、`data.delete`），不是職務或
+  方法——後者屬於組合 dbcli 的 Role Skill 與 Method Skill。每一項 engine 與 risk
+  宣稱都由既有的 `ENGINE_CAPABILITIES` 推導，不另立第二張表；contract test 雙向
+  檢查 catalog 與實際 Commander tree 不會漂移。
+
+  Fail closed 是預設：不認得的 id 回 `unknown` 而不會被解析成長得像的那一個，缺少
+  設定回 `unavailable` + `context-unavailable` 而不是拿 `DEFAULT_CONFIG` 的
+  localhost PostgreSQL 充數。Exit code `0` / `1` / `2`。
+
+  v1 涵蓋 engine capability matrix 管轄的 34 個 command key；另外 16 個指令
+  （`explain`、`plan`、`impact`、`assert`、`verify`、`evidence` 等）不在其中，
+  因為替它們寫 engine 支援度等於憑讀碼捏造未經稽核的宣稱。它們回 `unknown`，
+  擴充 matrix 是後續 Story。（DBCLI-PLAT-001，ADR-0022）
+
 ### Breaking
 
 - **query-only 的最後一道界線改由資料庫提供。** PostgreSQL / MySQL / MariaDB 上

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ ForgeFlow Story DBCLI-001 到 DBCLI-012 全數交付但尚未發布：`v7.0.1`�
   設定回 `unavailable` + `context-unavailable` 而不是拿 `DEFAULT_CONFIG` 的
   localhost PostgreSQL 充數。Exit code `0` / `1` / `2`。
 
+  `DBCLI_AGENT_MODE=1` 是 context 的一部分，不是免責聲明能蓋過去的東西。它無條件
+  拒絕所有設定、權限與憑證變更，而且不連線就完全可知——差別在**拒絕是何時決定的**：
+  blacklist 與人類同意在執行當下決定，契約無從代言；agent mode 在這裡就決定了。
+  `connection.select`、`connection.init`、`blacklist.manage` 因此在 agent mode 下
+  回 `unavailable` + `agent-mode`，不管權限寫的是不是 admin。
+
+  「沒有設定」與「有設定但解不開」是兩件事。`{"$env":...}` 密碼指向未設定變數的
+  設定檔是存在且可讀的，回報「找不到設定」是對使用者機器說假話——`context-unresolvable`
+  因此獨立成一個原因，且不外洩錯誤訊息裡的檔案路徑。
+
   v1 涵蓋 engine capability matrix 管轄的 34 個 command key；另外 16 個指令
   （`explain`、`plan`、`impact`、`assert`、`verify`、`evidence` 等）不在其中，
   因為替它們寫 engine 支援度等於憑讀碼捏造未經稽核的宣稱。它們回 `unknown`，

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -139,18 +139,31 @@ Answering "what can this tool do". It is not a permission grant: a capability
 appearing in the catalog says the binary is able to do it, not that anyone may.
 
 **Capability availability**:
-Whether the *locally configured* engine and permission would refuse a
-capability — `available`, `unavailable`, or `unknown`. It is a statement about
+Whether the *locally configured* engine, agent mode and permission would refuse
+a capability — `available`, `unavailable`, or `unknown`. It is a statement about
 this machine's configuration, evaluated without connecting to a database. It is
 distinct from approval: blacklist, write gate, confirmation and audit all still
 run at execution time, and human consent is not modelled at all. `admin` in a
 config file is a permission level, not a DBA sign-off.
 
 **Context unavailable**:
-There is no readable local configuration, so availability could not be
-established. It is neither `available` nor `unknown`: the requirement was
-understood, the environment was not. The default configuration is never
-reported as though it were configured.
+There is no local configuration here, so availability could not be established.
+It is neither `available` nor `unknown`: the requirement was understood, the
+environment was not. The default configuration is never reported as though it
+were configured.
+
+**Context unresolvable**:
+A configuration exists and could not be turned into an engine and a permission
+— an `{"$env": "..."}` reference naming an unset variable, for instance. It is
+a different fact from *context unavailable*, and reporting it as one would
+state something false about the machine. Both fail closed.
+
+**Environment gate**:
+A refusal decided before execution and knowable without connecting — agent
+mode is the only one today. It is distinct from an execution-time gate
+(blacklist, write gate, confirmation, audit), which capability availability
+deliberately does not speak for. The dividing line is *when* the refusal is
+decided: what is decidable here is the contract's responsibility to report.
 
 ## Skill layering
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,3 +114,61 @@ anything was verified.
 Whether an explicit proxy event file offered to an impact assessment could be
 used — `available`, `absent`, `invalid`, or `unavailable`. It describes the
 source, not a finding about the database, and it is always advisory.
+
+## Agent integration language
+
+**Capability**:
+One atomic dbcli ability with a stable dotted id — `schema.read`,
+`data.delete`. It names what the *tool* can do. A job or a method
+(`dba.tune-production`, `crud.scaffold`) is not a capability; it belongs to the
+Role Skill or Method Skill that composes dbcli.
+
+**Capability catalog**:
+The complete, versioned, statically known set of capabilities. It is derived
+from the engine capability matrix rather than declared beside it, so it cannot
+claim engine support the matrix does not grant. Reading it requires no database
+connection.
+
+**Capability contract version**:
+`CAPABILITY_CONTRACT_SCHEMA_VERSION`. It moves when the catalog's shape
+changes and never because the npm package version moved, following the same
+rule as the evidence artifact versions.
+
+**Discovery**:
+Answering "what can this tool do". It is not a permission grant: a capability
+appearing in the catalog says the binary is able to do it, not that anyone may.
+
+**Capability availability**:
+Whether the *locally configured* engine and permission would refuse a
+capability — `available`, `unavailable`, or `unknown`. It is a statement about
+this machine's configuration, evaluated without connecting to a database. It is
+distinct from approval: blacklist, write gate, confirmation and audit all still
+run at execution time, and human consent is not modelled at all. `admin` in a
+config file is a permission level, not a DBA sign-off.
+
+**Context unavailable**:
+There is no readable local configuration, so availability could not be
+established. It is neither `available` nor `unknown`: the requirement was
+understood, the environment was not. The default configuration is never
+reported as though it were configured.
+
+## Skill layering
+
+**Tool** (`dbcli`):
+What can be done at all.
+
+**Tool Skill** (the dbcli Skill):
+How to operate dbcli safely.
+
+**Method Skill**:
+How a method of working proceeds — CQRS, event sourcing, migration practice.
+
+**Role Skill**:
+How a job proceeds — DBA operations, CRUD engineering, review.
+
+**Project governance** (`AGENTS.md`):
+Which Skills apply here, how they are routed, and where the permission
+boundaries lie.
+
+Role, Method and project knowledge never enter dbcli core. dbcli answers only
+for the first two layers.

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -157,8 +157,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -139,6 +139,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -422,6 +448,7 @@ Full flags and edge cases: see [reference.md](reference.md#init).
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/assets/SKILL.zh-TW.md
+++ b/assets/SKILL.zh-TW.md
@@ -126,8 +126,11 @@ dbcli capabilities check --require data.delete --format json      # machine-read
 Tool Skill 只負責安全地操作 dbcli。
 
 - `schemaVersion` 是 capability contract 的版本，**不是** npm 套件版本。
-- 狀態有 `available`、`unavailable`（原因為 `engine`、`permission` 或
-  `context-unavailable`）與 `unknown`。拼錯的 id 一律 fail closed，絕不猜測。
+- 狀態有 `available`、`unavailable`（原因為 `engine`、`agent-mode`、`permission`、
+  `context-unavailable` 或 `context-unresolvable`）與 `unknown`。拼錯的 id 一律 fail
+  closed，絕不猜測。
+- 在 `DBCLI_AGENT_MODE=1` 之下，會變更設定的能力一律 `unavailable`、原因 `agent-mode`，
+  不管權限等級寫什麼。
 - Exit code：`0` 全部可用、`1` 有任一不可用或未知、`2` 輸入無效。
 - **`available` 不等於已核准。** Blacklist、write gate、確認與 audit 在執行時仍然會跑，
   設定檔裡的 `admin` 是權限等級，不是 DBA 的簽核。

--- a/assets/SKILL.zh-TW.md
+++ b/assets/SKILL.zh-TW.md
@@ -109,6 +109,31 @@ blacklist、schema、permission、dry-run、production 選取或寫入確認閘�
 除非人類明確要求，絕不可建立、更新或 migrate 此檔案；語意詞彙不能取代 schema 確認或正常的
 query/write 安全閘門。
 
+## 能力探索 (Capability discovery)
+
+在組合工作流之前，先問 dbcli 在這裡能做什麼，不要用猜的。Catalog 是靜態的，check 只讀本機
+設定——**兩者都不會建立資料庫連線。**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+一個 capability 是 dbcli 的單一原子能力（`schema.read`、`data.delete`），不是職務也不是方法。
+`dba.tune-production` 與 `crud.scaffold` 屬於組合 dbcli 的 Role Skill 或 Method Skill——這份
+Tool Skill 只負責安全地操作 dbcli。
+
+- `schemaVersion` 是 capability contract 的版本，**不是** npm 套件版本。
+- 狀態有 `available`、`unavailable`（原因為 `engine`、`permission` 或
+  `context-unavailable`）與 `unknown`。拼錯的 id 一律 fail closed，絕不猜測。
+- Exit code：`0` 全部可用、`1` 有任一不可用或未知、`2` 輸入無效。
+- **`available` 不等於已核准。** Blacklist、write gate、確認與 audit 在執行時仍然會跑，
+  設定檔裡的 `admin` 是權限等級，不是 DBA 的簽核。
+- v1 涵蓋 engine capability matrix 管轄的指令；不在其中的一律回 `unknown`，而不是給出未經
+  稽核的引擎宣稱。
+
 ## Agent Task Packs
 
 當使用者要求一個資料庫工作流（例如「診斷這個慢查詢」、「審計權限」、「審視長時間執行的操作」），**優先選用已發布的任務模板，而非憑記憶自行組合步驟。**
@@ -329,6 +354,7 @@ dbcli init --conn-name prod --env-file .env.production --use-env-refs --skip-tes
 |---------|-----------------|---------|
 | `init` | n/a | 建立 `.dbcli`（v1 單一或 v2 多連線，透過 `--conn-name` / `--env-file`）。**通常由真人執行** — 不要為了清掉 `{"$env"}` 參照而重跑；該格式是刻意設計。 |
 | `use` | n/a | 顯示 / 切換預設命名連線（僅 v2）。 |
+| `capabilities` | n/a | 靜態 capability catalog 與 `check --require <ids>` 需求閘門。不連線資料庫。`--format text\|json\|markdown`（`check` 為 `text\|json`）。Exit `0`/`1`/`2`。 |
 | `list` | query-only+ | 資料表（SQL）、collections（MongoDB）、keys（Redis）或 indices（Elasticsearch）。 |
 | `schema` | query-only+ | SQL：單表或全掃描存入 `.dbcli/schemas/`。MongoDB：sampled。ES：flattened mapping。Redis：僅單一 key（type / TTL / size）。支援 `--recovery`。 |
 | `query` | query-only+ | SQL、Mongo JSON（`--collection`）、Redis 指令、ES DSL / Lucene（`--collection`）。`--format table\|json\|csv\|html`、`--ui` 開啟瀏覽器互動式 dashboard。`--fields`（欄位投影）、`--truncate`（欄位值寬度）、`-f/--query-file`（從檔案或 stdin 讀查詢）、`--use a,b`（唯讀扇出）。支援 `--recovery`。`--slow-ms <n>` 設定被動慢查詢提示的門檻（預設 1000，`0` 關閉）：達到門檻時 table 輸出多一行 `Performance hint` footer、JSON 多出 `metadata.performanceAdvisory`；它不執行任何額外診斷，且在 `--recovery` 下被抑制。與 `proxy` 的同名旗標不同。見 **查詢工作流程旗標**。 |

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
+++ b/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
@@ -1,0 +1,120 @@
+---
+status: accepted
+date: 2026-09-03
+---
+
+# The capability catalog is derived from the engine matrix, not declared beside it
+
+An external Skill — a CRUD Skill, a CQRS Skill, a DBA Operator Skill — needs to
+ask dbcli what it can do *before* it starts working, and get an answer it can
+parse. Today it cannot: the only machine-readable description of dbcli's
+abilities is `--help`, which is prose, and `dbcli status`, which describes one
+connection rather than the tool.
+
+The obvious shape for that answer is a versioned capability catalog. The
+dangerous shape is a *second* hand-written table of what each command supports
+per engine, sitting next to the one that already exists.
+
+`src/adapters/capabilities.ts` already holds `ENGINE_CAPABILITIES`: six engines
+× thirty-four command keys, each carrying `{status, tier, note}`. It is read by
+`doctor`, by the engine-support documentation, and by its own tests. A parallel
+catalog listing engines per capability would be the same claim written twice,
+and the two copies would disagree the first time an engine gained support for
+something — silently, because nothing would compare them.
+
+## Decision
+
+**`ENGINE_CAPABILITIES` is the authority for every engine and risk claim in the
+capability catalog.** `src/core/capabilities/registry.ts` declares only what the
+matrix does not know — the capability's id, its human description, its CLI
+command path, and its minimum permission — and *derives* the rest:
+
+| Catalog field | Derived from |
+| --- | --- |
+| `engines` | matrix entries whose status is `supported` or `limited` |
+| `engineIndependent` | every engine's status is `not-applicable` |
+| `risk` | the matrix `tier`, folded into the Task Pack risk vocabulary |
+| `sideEffect` | the matrix `tier`, verbatim |
+| `supportsJson` | the live Commander tree: the command has a JSON output option |
+| `supportsEvidence` | the command's static import graph reaches `src/core/evidence-receipt` |
+
+A capability therefore cannot claim engine support the matrix does not grant,
+and cannot be added without a matrix key to derive from.
+
+**v1 enumerates exactly the thirty-four capabilities the matrix backs.** dbcli
+registers fifty top-level commands; sixteen of them — `explain`, `plan`,
+`impact`, `assert`, `verify`, `verification`, `evidence`, `contract`,
+`semantic`, `design`, `snapshot`, `backfill`, `proxy`, `recovery`, `password`,
+`use`'s newer subcommands — have no matrix row. Writing rows for them here
+would mean minting engine-support claims from a reading of the code rather than
+from the prior audit the matrix represents, which is precisely the kind of
+plausible-but-unchecked assertion a discovery contract must not carry. They are
+absent from v1 and named as such in the spec; extending the matrix to cover
+them is its own Story.
+
+A contract test enforces the boundary in both directions: every
+`COMMAND_CAPABILITY_KEYS` entry has at least one capability, and every
+capability names a live Commander command path.
+
+**`postgresql` is the engine vocabulary.** `DatabaseSystem` says `postgresql`;
+the Task Pack `AgentTaskEngine` says `postgres`. The catalog uses
+`DatabaseSystem` because that is the name the config file, the adapters and the
+matrix all use. The Task Pack fork is left untouched — reconciling it is
+DBCLI-PLAT-008 — and no third spelling is introduced.
+
+**The contract lives in `src/core`, not `src/agent-core`.** This is forced, not
+chosen: `scripts/check-agent-core-purity.ts` fails any file under
+`src/agent-core/` containing the word `postgresql`, and a catalog that names
+engines cannot satisfy that. It is exported through
+`@carllee1983/dbcli/core` — which already carries `Permission` and
+`DatabaseSystem` — and the purity gate is left exactly as strict as it was.
+
+**`capabilities` and `capabilities check` never open a connection.** Discovery
+answers from the static catalog; the check reads the local config through the
+one existing config reader and evaluates engine and permission against it. A
+contract test asserts the capability modules' import graph never reaches
+`src/adapters`' connection factories, so this is a structural property rather
+than a habit.
+
+## What the catalog deliberately does not mean
+
+- **`capabilities` is discovery, not a grant.** Listing `data.delete` says the
+  binary can delete; it says nothing about whether this config, this engine, or
+  this human permits it.
+- **`available` is not approval.** `capabilities check` reports that the
+  configured permission and engine would not refuse the operation. Blacklist,
+  write gate, confirmation and audit all still run at execution time, and a
+  human's consent is not modelled here at all.
+- **`admin` is a config value, not a DBA sign-off.** The permission ladder
+  describes what SQL the tool will pass through; it does not describe who agreed
+  to it.
+- **Unknown fails closed.** A requirement naming an id the catalog does not hold
+  is `unknown`, never `available`, and never guessed at by spelling proximity. A
+  typo that silently resolved to a neighbouring capability would be worse than a
+  refusal.
+- **Missing config is `unavailable`, not `unknown`.** With no config there is no
+  engine and no permission to evaluate, so the capability is known but its
+  availability is not established. Reporting that as `unknown` would blur a
+  question about the *requirement* with a question about the *environment*.
+
+## Consequences
+
+- Adding a capability without a `COMMAND_CAPABILITY_KEYS` entry fails the
+  contract test. Support for a new command is declared in the matrix first.
+- Changing a matrix `tier` changes a published capability's `risk`. That is the
+  intent — one edit, one truth — but it makes the matrix a contract surface, so
+  a tier change is now a contract change.
+- `CAPABILITY_CONTRACT_SCHEMA_VERSION` moves when the catalog's shape changes and
+  never because the npm version moved, following ADR-0013.
+- Catalog output is sorted by id and contains no host, port, connection string,
+  credential or data row. A test asserts the serialized output against a
+  credential-shaped fixture.
+
+**Falsified if:** a capability in `src/core/capabilities/registry.ts` declares an
+`engines` or `risk` value literally instead of deriving it from
+`ENGINE_CAPABILITIES` in `src/adapters/capabilities.ts`, or a
+`COMMAND_CAPABILITY_KEYS` entry gains no corresponding capability, or
+`src/core/capabilities/` acquires an import of `@/adapters/index` or a database
+adapter module, or `src/commands/capabilities.ts` reads config through anything
+other than `src/core/config.ts`, or `postgres` appears as an engine name in
+`src/core/capabilities/`.

--- a/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
+++ b/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
@@ -32,6 +32,7 @@ command path, and its minimum permission — and *derives* the rest:
 | Catalog field | Derived from |
 | --- | --- |
 | `engines` | matrix entries whose status is `supported` or `limited` |
+| `limitedEngines` | matrix entries whose status is `limited`, kept apart so the distinction survives |
 | `engineIndependent` | every engine's status is `not-applicable` |
 | `risk` | the matrix `tier`, folded into the Task Pack risk vocabulary |
 | `sideEffect` | the matrix `tier`, verbatim |
@@ -85,6 +86,15 @@ than a habit.
   configured permission and engine would not refuse the operation. Blacklist,
   write gate, confirmation and audit all still run at execution time, and a
   human's consent is not modelled here at all.
+- **But an environment gate is not covered by that disclaimer.** The line is
+  *when* the refusal is decided. Blacklist and human consent are decided at
+  execution time, so the contract cannot speak for them. `DBCLI_AGENT_MODE=1`
+  is decided *here*: it refuses every configuration, permission and credential
+  change unconditionally, and is fully knowable without connecting. Reporting
+  `available` for `connection.select` under it was the one promise this
+  contract made that its primary consumer — an agent — would act on and find
+  false. Agent mode therefore sits in the context alongside engine and
+  permission, with its own `agent-mode` reason.
 - **`admin` is a config value, not a DBA sign-off.** The permission ladder
   describes what SQL the tool will pass through; it does not describe who agreed
   to it.
@@ -96,6 +106,13 @@ than a habit.
   engine and no permission to evaluate, so the capability is known but its
   availability is not established. Reporting that as `unknown` would blur a
   question about the *requirement* with a question about the *environment*.
+- **"No config" and "config I cannot resolve" are different facts.** A config
+  whose `{"$env": "..."}` password names an unset variable is present and
+  perfectly readable; the one config reader simply resolves credentials — which
+  this command does not need — before it will answer. Reporting that as "no
+  configuration was found" is the contract stating a falsehood about the
+  user's machine, so `context-unresolvable` is a separate reason from
+  `context-unavailable`. Both fail closed; only one of them is ever true.
 
 ## Consequences
 
@@ -110,6 +127,22 @@ than a habit.
   credential or data row. A test asserts the serialized output against a
   credential-shaped fixture.
 
+### The one place the contract knowingly overstates availability
+
+`dbcli schema` persists the schema it reads into `config.json`, and that write
+sits behind the same agent-mode guard. Under `DBCLI_AGENT_MODE=1` the read
+succeeds and the persistence step is refused, so `schema.read` reports
+`available` while a real invocation partially fails.
+
+Marking the three `schema` capabilities `mutatesConfiguration` would make them
+`unavailable` under agent mode, which overstates the refusal far more than this
+understates it — an agent would conclude it cannot read schema at all. The
+honest fix is elsewhere: a schema *cache* write is not a change to connection
+identity, permission or credentials, and arguably should never have been behind
+the identity guard. That is DBCLI-PLAT-012.
+`INCIDENTAL_CONFIG_WRITERS` in `tests/contract/capability-contract.test.ts`
+names the exemption so it cannot become a silent gap.
+
 **Falsified if:** a capability in `src/core/capabilities/registry.ts` declares an
 `engines` or `risk` value literally instead of deriving it from
 `ENGINE_CAPABILITIES` in `src/adapters/capabilities.ts`, or a
@@ -117,4 +150,7 @@ than a habit.
 `src/core/capabilities/` acquires an import of `@/adapters/index` or a database
 adapter module, or `src/commands/capabilities.ts` reads config through anything
 other than `src/core/config.ts`, or `postgres` appears as an engine name in
-`src/core/capabilities/`.
+`src/core/capabilities/`, or `minimumPermission` is written literally for a
+capability that maps to a SQL statement type instead of coming from
+`minimumPermissionFor`, or a capability declares `mutatesConfiguration: true`
+whose command calls none of the config writers.

--- a/docs/plans/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/plans/2026-09-04-agent-integration-contract-v1.md
@@ -32,12 +32,18 @@ This plan covers the first vertical slice only. Everything after it is backlog.
 7. `dbcli capabilities` emits text, JSON and markdown, deterministically, touching nothing on disk — covered by: `tests/integration/capabilities-command.test.ts`
 8. `dbcli capabilities check` honours `--config` and the root `--use`, returns exit codes `0`/`1`/`2`, and echoes no credential or endpoint — covered by: `tests/integration/capabilities-command.test.ts`
 9. The contract is reachable and round-trip validatable from `@carllee1983/dbcli/core` — covered by: `tests/unit/core-public.test.ts`
-10. `requiresConnection: true` is not independently proven; only the `false` direction is checked, since a false offline claim is the one that misleads — unverified: no test asserts that a connection-requiring command actually opens one
+10. Agent mode makes configuration-changing capabilities unavailable, and leaves the rest alone — covered by: `tests/unit/core/capabilities/check.test.ts`, `tests/integration/capabilities-command.test.ts`
+11. `mutatesConfiguration` is never claimed by a capability whose command writes no configuration — covered by: `tests/contract/capability-contract.test.ts`
+12. A config that exists but will not resolve is reported as such, and leaks no filesystem path — covered by: `tests/integration/capabilities-command.test.ts`
+13. `minimumPermission` comes from the runtime permission ladder rather than a transcription — covered by: `tests/unit/core/capabilities/registry.test.ts`
+14. `DATABASE_SYSTEMS` matches the keys of `ENGINE_CAPABILITIES` — covered by: `tests/unit/adapters/database-systems-roster.test.ts`
+15. `requiresConnection: true` is not independently proven; only the `false` direction is checked, since a false offline claim is the one that misleads — unverified: no test asserts that a connection-requiring command actually opens one
+16. Under `DBCLI_AGENT_MODE=1`, `schema.read` reports `available` although the command's schema-cache persistence step is refused — known deviation: marking the `schema` capabilities would tell an agent schema cannot be read at all, a larger error in the opposite direction; DBCLI-PLAT-012 removes the cause
 
-## Two things this slice got wrong first, and what caught them
+## Five things this slice got wrong first, and what caught them
 
-Recorded because both were the *contract lying*, which is the failure mode this
-work exists to prevent, and in both cases a test found it rather than a reader.
+Recorded because every one was the *contract lying*, which is the failure mode
+this work exists to prevent, and not one was found by reading the code.
 
 1. **`capabilities check` reported `engine: postgresql, permission: query-only`
    in a directory with no config at all.** `configModule.read` returns
@@ -49,6 +55,23 @@ work exists to prevent, and in both cases a test found it rather than a reader.
    `migrate` and `blacklist` were claimed to offer JSON when only their
    subcommands do; `use` was claimed not to when it does. The bidirectional
    parity test against the live Commander tree found all four.
+3. **`connectionName` was `null` for a v2 default connection**, because it read
+   `--use` rather than what the reader resolved. Found by probing an env-ref
+   MongoDB config for credential leakage; nothing leaked, but the verdict was
+   unattributable.
+4. **`available` was reported under `DBCLI_AGENT_MODE=1` for capabilities that
+   agent mode refuses outright** — `connection.select`, `connection.init`,
+   `blacklist.manage`. Found in code review. This was the worst of the five: the
+   contract's primary consumer is the agent the flag describes, and this was the
+   one promise it would have acted on and found false. Agent mode is now a
+   context field with its own reason, and a contract test derives the marked set
+   from the command layer's real config-writing calls.
+5. **A bare `catch` collapsed five situations into one false warning.** An
+   unset `{"$env":...}` password, a v1 config given `--use`, a production
+   connection needing an explicit selector, an agent-mode integrity failure and
+   corrupt JSON all reported "no configuration was readable". Only the last is
+   even close to true. Also found in review. `context-unresolvable` is now a
+   separate reason, and a non-`ConfigError` is rethrown instead of swallowed.
 
 ## Not done, deliberately
 

--- a/docs/plans/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/plans/2026-09-04-agent-integration-contract-v1.md
@@ -1,0 +1,67 @@
+# Implementation plan — Agent Integration Contract v1
+
+Design record: [`docs/specs/2026-09-04-agent-integration-contract-v1.md`](../specs/2026-09-04-agent-integration-contract-v1.md).
+Decision: [ADR-0022](../adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md).
+Story: `specs/stories/DBCLI-PLAT-001-capability-contract/`.
+
+This plan covers the first vertical slice only. Everything after it is backlog.
+
+## Delivered in this slice
+
+1. `DATABASE_SYSTEMS` roster in `src/adapters/types.ts`, with a compile-time
+   exhaustiveness assertion so a new engine cannot be added to the union
+   without appearing in the runtime list.
+2. `src/core/permission/rank.ts` — the permission ladder extracted so the
+   capability contract reuses one authority instead of copying it.
+   `permission-guard.ts` re-exports it; no caller changes.
+3. `src/core/capabilities/` — `types`, `registry`, `check`, `schema`, `index`.
+4. `src/commands/capabilities.ts`, registered on both the eager and lazy paths.
+5. Agent-facing export through `src/core/public.ts`.
+6. Tests: unit, contract, integration, and public-surface.
+7. Documentation: reference, both SKILL locales, all four `docs/user` files,
+   ten generated platform mirrors, CONTEXT, CHANGELOG.
+
+**Acceptance criteria:**
+
+1. The catalog derives every engine and risk claim from `ENGINE_CAPABILITIES`, and every matrix key is covered — covered by: `tests/unit/core/capabilities/registry.test.ts`
+2. Output is deterministic, uniquely keyed, and free of credentials, hosts and endpoints — covered by: `tests/unit/core/capabilities/registry.test.ts`
+3. The strict schema rejects unknown fields and unknown schema versions — covered by: `tests/unit/core/capabilities/registry.test.ts`
+4. Unknown ids, unsupported engines, insufficient permission and missing config all fail closed — covered by: `tests/unit/core/capabilities/check.test.ts`
+5. Every catalogued command path exists in the live Commander tree, and `supportsJson` matches it in both directions — covered by: `tests/contract/capability-contract.test.ts`
+6. Capability discovery loads no database adapter, and a capability claiming no connection has a command whose import graph loads none either — covered by: `tests/contract/capability-contract.test.ts`
+7. `dbcli capabilities` emits text, JSON and markdown, deterministically, touching nothing on disk — covered by: `tests/integration/capabilities-command.test.ts`
+8. `dbcli capabilities check` honours `--config` and the root `--use`, returns exit codes `0`/`1`/`2`, and echoes no credential or endpoint — covered by: `tests/integration/capabilities-command.test.ts`
+9. The contract is reachable and round-trip validatable from `@carllee1983/dbcli/core` — covered by: `tests/unit/core-public.test.ts`
+10. `requiresConnection: true` is not independently proven; only the `false` direction is checked, since a false offline claim is the one that misleads — unverified: no test asserts that a connection-requiring command actually opens one
+
+## Two things this slice got wrong first, and what caught them
+
+Recorded because both were the *contract lying*, which is the failure mode this
+work exists to prevent, and in both cases a test found it rather than a reader.
+
+1. **`capabilities check` reported `engine: postgresql, permission: query-only`
+   in a directory with no config at all.** `configModule.read` returns
+   `DEFAULT_CONFIG` when none exists. Fixed by establishing config existence
+   first; asserted by "a missing config reports context unavailable rather than
+   assuming a default", which also asserts the string `postgresql` is absent
+   from that output.
+2. **`supportsJson` was hand-listed and wrong for four commands.** `queries`,
+   `migrate` and `blacklist` were claimed to offer JSON when only their
+   subcommands do; `use` was claimed not to when it does. The bidirectional
+   parity test against the live Commander tree found all four.
+
+## Not done, deliberately
+
+* No existing `--format json` output was changed.
+* No Operation Envelope, correlation id or evidence expansion.
+* Task Packs remain `plan-only`; `safety.requires` is untouched.
+* `ENGINE_CAPABILITIES` was not extended, so sixteen commands are absent from
+  the catalog and return `unknown`. That is a known, documented boundary
+  (DBCLI-PLAT-011), not an oversight.
+
+## Rollback
+
+Every commit carries a `Story: DBCLI-PLAT-001` trailer on a dedicated branch.
+Reverting the branch removes the command, the core module and the docs; the
+only edits to pre-existing behaviour are the `permission-guard.ts` re-export
+and the `DATABASE_SYSTEMS` addition, both additive.

--- a/docs/specs/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/specs/2026-09-04-agent-integration-contract-v1.md
@@ -44,7 +44,17 @@ derives the rest. `risk` folds the existing six-value `SideEffectTier` into the
 four-value Task Pack risk vocabulary (`readonly`, `dry-run`, `write`,
 `unknown`); `sideEffect` carries the unfolded tier alongside, because
 collapsing `local-write` and `db-write` into `write` hides the distinction a
-caller most needs.
+caller most needs. `limitedEngines` does the same job for engine support: the
+matrix distinguishes `limited` from `supported`, and folding both into
+`engines` would throw that away — `data.delete` works on Redis, but not the way
+it works on PostgreSQL.
+
+`minimumPermission` is derived too, wherever a derivation exists.
+`minimumPermissionFor` in `permission-guard.ts` is the table the *runtime*
+refusal consults; a capability that maps to a SQL statement type declares the
+type and takes the level from there. Transcribing four levels into the registry
+would have been a second permission ladder, and the argument against a second
+engine table applies unchanged.
 
 ### Scope of v1, and why it stops there
 
@@ -93,11 +103,52 @@ or `null`.
 | `available` | `null` | Engine and permission would not refuse. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | Below the capability's minimum level. |
-| `unavailable` | `context-unavailable` | No readable local config. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` and the capability changes configuration. |
+| `unavailable` | `context-unavailable` | No local config here. |
+| `unavailable` | `context-unresolvable` | A config exists and would not resolve into an engine and a permission. |
 | `unknown` | `unknown-capability` | No such id. Never guessed at. |
 
-Engine is checked before permission, so the reason names the blocker that
-raising a level would not fix.
+Blockers are checked least-fixable first — engine, then agent mode, then
+permission — so the reason names the one actually in the way. Engine cannot be
+changed for this connection at all; agent mode cannot be lifted from inside the
+process subject to it; permission is a config edit.
+
+### Agent mode is a context field, not an execution-time concern
+
+`DBCLI_AGENT_MODE=1` makes `assertConfigMutationApproved()` refuse every
+configuration, permission and credential change unconditionally. That is
+knowable without connecting, so it belongs beside engine and permission.
+
+The "available is not approval" disclaimer does not stretch to cover it, and
+the distinction is *when the refusal is decided*: blacklist rules and human
+consent are decided at execution time, which the contract cannot speak for;
+agent mode is decided here. `connection.init`, `connection.select` and
+`blacklist.manage` carry `mutatesConfiguration: true` — the capabilities where
+changing configuration *is* the capability — and a contract test derives that
+set from the command layer's real calls rather than trusting the declaration.
+
+**The known overstatement:** `dbcli schema` persists its result into
+`config.json` behind the same guard, so under agent mode `schema.read` reports
+`available` while a real invocation's persistence step fails. Marking the three
+`schema` capabilities would make them `unavailable` and tell an agent it cannot
+read schema at all — a much larger error in the opposite direction. The real fix
+is that a schema *cache* write is not a change of connection identity and should
+not sit behind the identity guard: DBCLI-PLAT-012.
+
+### "No config" and "config I cannot resolve" are different facts
+
+Conflating them was a defect, not a simplification. A config whose
+`{"$env": "..."}` password names an unset variable is present and readable; the
+one config reader resolves credentials — which this command never needs — before
+it will answer. Reporting "no configuration was found" there states something
+false about the user's machine. `context-unresolvable` is therefore its own
+reason, and the error's message is not surfaced because it carries filesystem
+paths.
+
+Five situations previously collapsed into one false warning: an unresolvable
+env-ref, a v1 config given `--use`, a production connection needing an explicit
+selector, an agent-mode integrity failure, and genuinely corrupt JSON. Only the
+last is "unreadable"; none is "absent". All still fail closed.
 
 **Duplicate ids are de-duplicated in first-seen order** and reported in
 `warnings`. Refusing would punish two Skills concatenating requirement lists;
@@ -160,3 +211,4 @@ DBCLI-PLAT-008 owns it.
 | DBCLI-PLAT-009 | Skill author integration kit. |
 | DBCLI-PLAT-010 | External consumer contract tests: a CRUD Skill, a CQRS Skill and a DBA Operator Skill as out-of-repo consumers. Their behaviour is never implemented inside dbcli. |
 | DBCLI-PLAT-011 | Extend `ENGINE_CAPABILITIES` to the sixteen commands v1 could not describe. |
+| DBCLI-PLAT-012 | Move schema-cache persistence out from behind the agent-mode *identity* guard, so `schema` stops being a configuration writer. |

--- a/docs/specs/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/specs/2026-09-04-agent-integration-contract-v1.md
@@ -1,0 +1,162 @@
+# DBCLI Agent Integration Contract v1 — design record
+
+**Status**: accepted for the capability slice; the remaining stories are planned, not built.
+**Decision record**: [ADR-0022](../adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md)
+
+## The problem
+
+An external Skill cannot currently find out what dbcli can do. `--help` is
+prose, `status` describes one connection rather than the tool, and nothing
+gives an ability a stable name a Skill can pin.
+
+## Product layering
+
+```
+Story + Project AGENTS.md + Role Skill + Method Skill + Tool Skill + dbcli
+```
+
+| Layer | Answers | Example |
+| --- | --- | --- |
+| dbcli | What can be done at all | `schema.read`, `data.delete` |
+| dbcli Skill (Tool Skill) | How to operate dbcli safely | confirm the blacklist, never guess a column |
+| Method Skill | How this method works | CQRS: verify write model, read model, projection |
+| Role Skill | How this job works | DBA: gather diagnostics, assess risk, verify |
+| AGENTS.md | Project governance, routing, boundaries | which Skills apply here |
+
+Consequence: **CRUD, CQRS and DBA knowledge never enters dbcli core.** A
+capability id that names a job (`dba.tune-production`) belongs to a Skill, and
+a unit test rejects such ids.
+
+## Capability contract v1
+
+A **capability** is an atomic tool ability with a stable dotted id.
+
+Fields: `id`, `description`, `command`, `risk`, `sideEffect`, `engines`,
+`engineIndependent`, `minimumPermission`, `requiresConnection`, `supportsJson`,
+`supportsEvidence`.
+
+### Single authority
+
+`ENGINE_CAPABILITIES` (`src/adapters/capabilities.ts`) is the authority for
+every engine and risk claim. `src/core/capabilities/registry.ts` declares only
+identity, command path, minimum permission and `requiresConnection`, and
+derives the rest. `risk` folds the existing six-value `SideEffectTier` into the
+four-value Task Pack risk vocabulary (`readonly`, `dry-run`, `write`,
+`unknown`); `sideEffect` carries the unfolded tier alongside, because
+collapsing `local-write` and `db-write` into `write` hides the distinction a
+caller most needs.
+
+### Scope of v1, and why it stops there
+
+The matrix governs thirty-four command keys. dbcli registers fifty top-level
+commands. The sixteen without a matrix row — `explain`, `plan`, `impact`,
+`assert`, `verify`, `verification`, `evidence`, `contract`, `semantic`,
+`design`, `snapshot`, `backfill`, `proxy`, `recovery`, `password`, and the
+newer `use` subcommands — are **absent from v1**. Writing rows for them would
+mean minting per-engine support claims from a reading of the code rather than
+from the prior audit the matrix represents. A discovery contract that carries
+unaudited claims is worse than one that admits a boundary: asking for
+`query.explain` returns `unknown`, which fails closed. Extending the matrix is
+DBCLI-PLAT-011.
+
+A contract test enforces the boundary both ways: every matrix key has a
+capability, and every capability names a live Commander command path.
+
+### `supportsJson` is narrower than it looks
+
+`blacklist`, `migrate` and `queries` are absent from the JSON surface even
+though `blacklist list --format json` works. JSON lives on their *subcommands*,
+and a capability may only claim what the path it names offers. Per-subcommand
+granularity is DBCLI-PLAT-005's problem, not v1's.
+
+### Engine vocabulary
+
+`DatabaseSystem` (`postgresql`) is canonical. `AgentTaskEngine`
+(`src/core/agent-tasks/types.ts`) says `postgres`. The fork is left in place
+and reconciled by DBCLI-PLAT-008; no third spelling is introduced.
+
+### Where it lives
+
+`src/core/capabilities/`, exported through `@carllee1983/dbcli/core`. Not
+`src/agent-core/`: `scripts/check-agent-core-purity.ts` fails any file there
+containing `postgresql`, and a catalog naming engines cannot satisfy that. The
+gate is left as strict as it was.
+
+## `capabilities check`
+
+Evaluates a requirement list against the **local config only**. No connection
+is opened; `src/core/capabilities/check.ts` is a pure function handed a context
+or `null`.
+
+| Status | Reason | Meaning |
+| --- | --- | --- |
+| `available` | `null` | Engine and permission would not refuse. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | Below the capability's minimum level. |
+| `unavailable` | `context-unavailable` | No readable local config. |
+| `unknown` | `unknown-capability` | No such id. Never guessed at. |
+
+Engine is checked before permission, so the reason names the blocker that
+raising a level would not fix.
+
+**Duplicate ids are de-duplicated in first-seen order** and reported in
+`warnings`. Refusing would punish two Skills concatenating requirement lists;
+answering twice would make `results` a multiset the caller has to fold. Neither
+is guessable, so it is stated here.
+
+**An empty list is refused**, exit `2`. A requirement list that accidentally
+evaluated to "nothing required" would report `ok: true` and read as a green
+light.
+
+Exit codes: `0` all available · `1` any unavailable or unknown · `2` invalid
+input.
+
+### `connectionName` names what was resolved
+
+`context.connectionName` carries `effectiveConnectionName` from the config
+reader, not the value of `--use`. On a v2 config with no selector those differ:
+a named default connection is in effect while `--use` is unset, and reporting
+`null` there would leave the verdict unattributable to the connection that
+produced it. A v1 single-connection config has no name and correctly reports
+`null`. The name is a label the user chose; the endpoint behind it never
+appears.
+
+### Config absence is not a default
+
+`configModule.read` answers a missing config with `DEFAULT_CONFIG` — a
+localhost PostgreSQL at query-only — so `init` has something to start from.
+The command establishes existence first, against the same storage path the
+reader resolves. Without that, this command would state in JSON that a
+database nobody configured supports the requested capability.
+
+## What the contract deliberately does not mean
+
+* `capabilities` is discovery, not a permission grant.
+* `available` is not approval. Blacklist, write gate, confirmation and audit
+  all still run at execution time; human consent is not modelled at all.
+* `admin` is a config value, not a DBA sign-off.
+* A Task Pack plan (`status: "planned"`) is not a verification result.
+* `CAPABILITY_CONTRACT_SCHEMA_VERSION` is not the npm package version.
+
+## Task Pack boundary
+
+Task Packs stay `plan-only`. `safety.requires` remains an unvalidated
+`string[]` (`src/core/agent-tasks/parser.ts:156`). Migrating it to capability
+ids is **not** done here: builtin, shared and local packs in the field carry
+free-form strings, and validating them now would break packs this Story has no
+mandate to change. The migration direction is: accept both forms, warn on a
+non-capability string, then require ids at a future contract version.
+DBCLI-PLAT-008 owns it.
+
+## Follow-up stories
+
+| Story | Scope |
+| --- | --- |
+| DBCLI-PLAT-004 | Operation Envelope v1: `schemaVersion`, `ok`, `operation`, `status`, `context`, `data`, `warnings`, `evidence`, `recovery`. Additive and opt-in; existing `--format json` output is not rewritten in place. The opt-in mechanism needs its own ADR. |
+| DBCLI-PLAT-005 | Opt-in agent JSON mode, including per-subcommand JSON granularity. |
+| DBCLI-PLAT-006 | Cross-command correlation id tying commands to a Story, incident, change request, migration or backfill. Correlation metadata must not bypass audit, redaction or evidence validation. |
+| DBCLI-PLAT-007 | Bounded evidence receipts for `inspect`, `report`, `schema`, `plan`, `lint`, `explain`, `impact`. Never stores raw rows, credentials, connection strings, unmasked SQL, raw error bodies or unbounded stdout/stderr. |
+| DBCLI-PLAT-008 | Task Pack `safety.requires` validated against capability ids, and the `postgres`/`postgresql` reconciliation. |
+| DBCLI-PLAT-009 | Skill author integration kit. |
+| DBCLI-PLAT-010 | External consumer contract tests: a CRUD Skill, a CQRS Skill and a DBA Operator Skill as out-of-repo consumers. Their behaviour is never implemented inside dbcli. |
+| DBCLI-PLAT-011 | Extend `ENGINE_CAPABILITIES` to the sixteen commands v1 could not describe. |

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -259,10 +259,26 @@ dbcli password prod --password "$NEW" --skip-test --format json</code></pre>
                     <tr><td><code>schema</code></td><td>Inspect structure and refresh local metadata cache.</td></tr>
                     <tr><td><code>inspect</code></td><td>Full context snapshot (objects, perms, suggested actions).</td></tr>
                     <tr><td><code>status</code></td><td>Config and connectivity health summary.</td></tr>
+                    <tr><td><code>capabilities</code></td><td>Static capability catalog — what dbcli can do. No database connection.</td></tr>
+                    <tr><td><code>capabilities check</code></td><td>Check required capability ids against the local config. Never connects.</td></tr>
                 </tbody>
             </table>
             <p><code>dbcli blacklist list --format json</code> emits one machine-readable document with <code>tables</code>, <code>columns</code>, and <code>warnings</code>; malformed MongoDB blacklist paths are returned in the structured <code>warnings</code> array instead of being mixed into stdout as human diagnostics.</p>
             <p>For PostgreSQL, <code>schema</code> uses exact <code>public</code> catalog identity throughout: full catalog/schema/table joins prevent reused constraint names from contaminating another table, composite foreign-key columns remain in declaration order, composite primary-key order comes from the exact table OID and index ordinality, and estimates are scoped to the exact <code>public</code> relation. Row counts qualify and quote both <code>"public"</code> and the exact table name, escaping embedded quotes so mixed-case and punctuation-bearing identifiers remain distinct and safe. Referenced schema/table spelling is preserved from the catalog.</p>
+
+            <h4 class="mt-8 font-bold text-text-main">Capability discovery for Skills</h4>
+            <p><code>dbcli capabilities</code> answers &ldquo;what can this tool do?&rdquo; in a versioned, parseable shape, so an external Skill can decide before it starts working. <code>dbcli capabilities check --require &lt;ids&gt;</code> then answers &ldquo;are those available <em>here</em>?&rdquo; against the local configuration. Neither opens a database connection.</p>
+            <pre><code>dbcli capabilities --format json
+dbcli capabilities check --require schema.read,query.read --format json</code></pre>
+            <p>A <strong>capability</strong> is one atomic dbcli ability — <code>schema.read</code>, <code>data.delete</code>. It is never a job or a method: <code>dba.tune-production</code> and <code>crud.scaffold</code> belong to the Role Skill or Method Skill that composes dbcli. The layering is <code>Story + AGENTS.md + Role Skill + Method Skill + Tool Skill + dbcli</code>, and dbcli only ever answers for the last two.</p>
+            <p>Four things the output deliberately does not mean:</p>
+            <ul>
+                <li><strong>Discovery is not a grant.</strong> A listed capability says the binary can do it, not that you may.</li>
+                <li><strong><code>available</code> is not approval.</strong> It says engine and permission would not refuse. Blacklist, write gate, confirmation and audit all still run, and no human has agreed to anything. <code>admin</code> in a config file is a permission level, not a DBA sign-off.</li>
+                <li><strong><code>schemaVersion</code> is not the package version.</strong> Pin the contract version, not <code>7.x</code>.</li>
+                <li><strong>A Task Pack plan is not a result.</strong> <code>status: "planned"</code> remains distinct from a verification outcome.</li>
+            </ul>
+            <p>Statuses are <code>available</code>, <code>unavailable</code> (reason <code>engine</code>, <code>permission</code>, or <code>context-unavailable</code>) and <code>unknown</code>. An unrecognised id fails closed and is never resolved to a similar-looking one. Exit codes: <code>0</code> all available, <code>1</code> any unavailable or unknown, <code>2</code> invalid input.</p>
 
             <h4 class="mt-8 font-bold text-text-main"><code>inspect</code> output for agents</h4>
             <p><code>dbcli inspect</code> returns two parallel arrays so an agent can orient on the very first call:</p>

--- a/docs/user/en/index.html
+++ b/docs/user/en/index.html
@@ -278,7 +278,8 @@ dbcli capabilities check --require schema.read,query.read --format json</code></
                 <li><strong><code>schemaVersion</code> is not the package version.</strong> Pin the contract version, not <code>7.x</code>.</li>
                 <li><strong>A Task Pack plan is not a result.</strong> <code>status: "planned"</code> remains distinct from a verification outcome.</li>
             </ul>
-            <p>Statuses are <code>available</code>, <code>unavailable</code> (reason <code>engine</code>, <code>permission</code>, or <code>context-unavailable</code>) and <code>unknown</code>. An unrecognised id fails closed and is never resolved to a similar-looking one. Exit codes: <code>0</code> all available, <code>1</code> any unavailable or unknown, <code>2</code> invalid input.</p>
+            <p>Statuses are <code>available</code>, <code>unavailable</code> and <code>unknown</code>. The <code>unavailable</code> reasons are <code>engine</code>, <code>agent-mode</code>, <code>permission</code>, <code>context-unavailable</code> and <code>context-unresolvable</code>, reported least-fixable first so the reason names the blocker actually in the way. Under <code>DBCLI_AGENT_MODE=1</code>, capabilities that change configuration are refused whatever the permission level says. <code>context-unresolvable</code> is deliberately distinct from <code>context-unavailable</code>: a config whose <code>{"$env": "..."}</code> password names an unset variable is present and readable, and claiming there is no config would be false.</p>
+            <p>An unrecognised id fails closed and is never resolved to a similar-looking one. Exit codes: <code>0</code> all available, <code>1</code> any unavailable or unknown, <code>2</code> invalid input.</p>
 
             <h4 class="mt-8 font-bold text-text-main"><code>inspect</code> output for agents</h4>
             <p><code>dbcli inspect</code> returns two parallel arrays so an agent can orient on the very first call:</p>

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -315,12 +315,47 @@ Blocked under `DBCLI_AGENT_MODE=1` like every other credential mutation.
 | `schema [table]` | Displays schema details for a specific object or scans the entire database. |
 | `inspect` | Provides a read-only snapshot for AI agents (objects, permissions, suggestions). |
 | `status` | Shows a safe summary of the current configuration (no credentials). |
+| `capabilities` | Lists the static capability catalog — what dbcli can do — without connecting to a database. |
+| `capabilities check` | Checks required capability ids against the local config's engine and permission. Never connects. |
 
 `dbcli blacklist list --format json` emits one machine-readable document with
 `tables`, `columns`, and `warnings`; malformed MongoDB blacklist paths are reported in
 the structured `warnings` array rather than mixed into stdout as human diagnostics.
 
 For PostgreSQL, `schema` uses exact `public` catalog identity throughout: full catalog/schema/table joins prevent reused constraint names from contaminating another table, composite foreign-key columns remain in declaration order, composite primary-key order comes from the exact table OID and index ordinality, and estimates are scoped to the exact `public` relation. Row counts qualify and quote both `"public"` and the exact table name, escaping embedded quotes so mixed-case and punctuation-bearing identifiers remain distinct and safe. Referenced schema/table spelling is preserved from the catalog.
+
+#### Capability discovery for Skills
+
+`dbcli capabilities` answers "what can this tool do?" in a versioned, parseable shape, so
+an external Skill can decide before it starts working. `dbcli capabilities check --require
+<ids>` then answers "are those available *here*?" against the local configuration. Neither
+opens a database connection.
+
+```bash
+dbcli capabilities --format json
+dbcli capabilities check --require schema.read,query.read --format json
+```
+
+A **capability** is one atomic dbcli ability — `schema.read`, `data.delete`. It is never a
+job or a method: `dba.tune-production` and `crud.scaffold` belong to the Role Skill or
+Method Skill that composes dbcli. The layering is `Story + AGENTS.md + Role Skill + Method
+Skill + Tool Skill + dbcli`, and dbcli only ever answers for the last two.
+
+Four things the output deliberately does not mean:
+
+*   **Discovery is not a grant.** A listed capability says the binary can do it, not that
+    you may.
+*   **`available` is not approval.** It says engine and permission would not refuse.
+    Blacklist, write gate, confirmation and audit all still run, and no human has agreed to
+    anything. `admin` in a config file is a permission level, not a DBA sign-off.
+*   **`schemaVersion` is not the package version.** Pin the contract version, not `7.x`.
+*   **A Task Pack plan is not a result.** `status: "planned"` remains distinct from a
+    verification outcome.
+
+Statuses are `available`, `unavailable` (reason `engine`, `permission`, or
+`context-unavailable`) and `unknown`. An unrecognised id fails closed and is never resolved
+to a similar-looking one. Exit codes: `0` all available, `1` any unavailable or unknown,
+`2` invalid input.
 
 #### `inspect` output for agents
 

--- a/docs/user/en/index.md
+++ b/docs/user/en/index.md
@@ -352,10 +352,16 @@ Four things the output deliberately does not mean:
 *   **A Task Pack plan is not a result.** `status: "planned"` remains distinct from a
     verification outcome.
 
-Statuses are `available`, `unavailable` (reason `engine`, `permission`, or
-`context-unavailable`) and `unknown`. An unrecognised id fails closed and is never resolved
-to a similar-looking one. Exit codes: `0` all available, `1` any unavailable or unknown,
-`2` invalid input.
+Statuses are `available`, `unavailable` and `unknown`. The `unavailable` reasons are
+`engine`, `agent-mode`, `permission`, `context-unavailable` and `context-unresolvable`,
+reported least-fixable first so the reason names the blocker actually in the way. Under
+`DBCLI_AGENT_MODE=1`, capabilities that change configuration are refused whatever the
+permission level says. `context-unresolvable` is deliberately distinct from
+`context-unavailable`: a config whose `{"$env": "..."}` password names an unset variable is
+present and readable, and claiming there is no config would be false.
+
+An unrecognised id fails closed and is never resolved to a similar-looking one. Exit codes:
+`0` all available, `1` any unavailable or unknown, `2` invalid input.
 
 #### `inspect` output for agents
 

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -259,10 +259,26 @@ dbcli password prod --password "$NEW" --skip-test --format json</code></pre>
                     <tr><td><code>schema</code></td><td>顯示結構並重新整理本地元資料快取。</td></tr>
                     <tr><td><code>inspect</code></td><td>上下文快照（物件、權限、建議行動）。</td></tr>
                     <tr><td><code>status</code></td><td>配置與連線健康度摘要。</td></tr>
+                    <tr><td><code>capabilities</code></td><td>靜態 capability catalog（dbcli 能做什麼）。不連線資料庫。</td></tr>
+                    <tr><td><code>capabilities check</code></td><td>依本機設定檢查所需的 capability id。不建立連線。</td></tr>
                 </tbody>
             </table>
             <p><code>dbcli blacklist list --format json</code> 會在 stdout 輸出一個 machine-readable 文件，包含 <code>tables</code>、<code>columns</code> 與 <code>warnings</code>；不合法的 MongoDB blacklist path 會放進結構化的 <code>warnings</code> 陣列，不會把人類可讀診斷混入 stdout。</p>
             <p>在 PostgreSQL 中，<code>schema</code> 全程使用精確的 <code>public</code> catalog identity：完整的 catalog/schema/table join 可避免重複使用的 constraint 名稱污染另一張表，複合 foreign key 欄位會維持宣告順序，複合 primary key 的順序來自精確 table OID 與 index ordinality，estimate 也限定於精確的 <code>public</code> relation。Row count 會同時 qualify 並 quote <code>"public"</code> 與精確 table name，內嵌 quote 會被 escape，因此混合大小寫或含標點的 identifier 仍可安全區分；被參照 schema/table 的 catalog 原始拼字也會保留。</p>
+
+            <h4 class="mt-8 font-bold text-text-main">給 Skill 的能力探索</h4>
+            <p><code>dbcli capabilities</code> 用一個有版本、可解析的形狀回答「這個工具能做什麼」，讓外部 Skill 在動工之前就能決定。<code>dbcli capabilities check --require &lt;ids&gt;</code> 接著依本機設定回答「這裡有沒有」。兩者都不會建立資料庫連線。</p>
+            <pre><code>dbcli capabilities --format json
+dbcli capabilities check --require schema.read,query.read --format json</code></pre>
+            <p>一個 <strong>capability</strong> 是 dbcli 的單一原子能力——<code>schema.read</code>、<code>data.delete</code>。它絕不是職務或方法：<code>dba.tune-production</code> 與 <code>crud.scaffold</code> 屬於組合 dbcli 的 Role Skill 或 Method Skill。分層是 <code>Story + AGENTS.md + Role Skill + Method Skill + Tool Skill + dbcli</code>，而 dbcli 只回答最後兩層。</p>
+            <p>輸出刻意不代表的四件事：</p>
+            <ul>
+                <li><strong>Discovery 不是授權。</strong> 列出一項能力只表示這個程式做得到，不表示你可以做。</li>
+                <li><strong><code>available</code> 不等於已核准。</strong> 它只說 engine 與 permission 不會拒絕。Blacklist、write gate、確認與 audit 仍然全部會跑，也沒有任何人類同意過什麼。設定檔裡的 <code>admin</code> 是權限等級，不是 DBA 的簽核。</li>
+                <li><strong><code>schemaVersion</code> 不是套件版本。</strong> 要 pin 的是 contract 版本，不是 <code>7.x</code>。</li>
+                <li><strong>Task Pack 的 plan 不是結果。</strong> <code>status: "planned"</code> 與驗證結果始終是兩回事。</li>
+            </ul>
+            <p>狀態有 <code>available</code>、<code>unavailable</code>（原因為 <code>engine</code>、<code>permission</code> 或 <code>context-unavailable</code>）與 <code>unknown</code>。無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：<code>0</code> 全部可用、<code>1</code> 有任一不可用或未知、<code>2</code> 輸入無效。</p>
 
             <h4 class="mt-8 font-bold text-text-main"><code>inspect</code> 給 agent 的輸出</h4>
             <p><code>dbcli inspect</code> 回傳兩個平行陣列，讓 agent 在第一次呼叫就能定位：</p>

--- a/docs/user/zh-TW/index.html
+++ b/docs/user/zh-TW/index.html
@@ -278,7 +278,8 @@ dbcli capabilities check --require schema.read,query.read --format json</code></
                 <li><strong><code>schemaVersion</code> 不是套件版本。</strong> 要 pin 的是 contract 版本，不是 <code>7.x</code>。</li>
                 <li><strong>Task Pack 的 plan 不是結果。</strong> <code>status: "planned"</code> 與驗證結果始終是兩回事。</li>
             </ul>
-            <p>狀態有 <code>available</code>、<code>unavailable</code>（原因為 <code>engine</code>、<code>permission</code> 或 <code>context-unavailable</code>）與 <code>unknown</code>。無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：<code>0</code> 全部可用、<code>1</code> 有任一不可用或未知、<code>2</code> 輸入無效。</p>
+            <p>狀態有 <code>available</code>、<code>unavailable</code> 與 <code>unknown</code>。<code>unavailable</code> 的原因有 <code>engine</code>、<code>agent-mode</code>、<code>permission</code>、<code>context-unavailable</code> 與 <code>context-unresolvable</code>，依「最難修的排前面」回報，讓 reason 指到真正擋路的那一個。在 <code>DBCLI_AGENT_MODE=1</code> 之下，會變更設定的能力一律被拒，不管權限等級寫什麼。<code>context-unresolvable</code> 與 <code>context-unavailable</code> 刻意分開：<code>{"$env": "..."}</code> 密碼指向未設定變數的設定檔是存在且可讀的，宣稱「沒有設定」是假話。</p>
+            <p>無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：<code>0</code> 全部可用、<code>1</code> 有任一不可用或未知、<code>2</code> 輸入無效。</p>
 
             <h4 class="mt-8 font-bold text-text-main"><code>inspect</code> 給 agent 的輸出</h4>
             <p><code>dbcli inspect</code> 回傳兩個平行陣列，讓 agent 在第一次呼叫就能定位：</p>

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -312,9 +312,14 @@ dbcli capabilities check --require schema.read,query.read --format json
 *   **`schemaVersion` 不是套件版本。** 要 pin 的是 contract 版本，不是 `7.x`。
 *   **Task Pack 的 plan 不是結果。** `status: "planned"` 與驗證結果始終是兩回事。
 
-狀態有 `available`、`unavailable`（原因為 `engine`、`permission` 或 `context-unavailable`）
-與 `unknown`。無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：
-`0` 全部可用、`1` 有任一不可用或未知、`2` 輸入無效。
+狀態有 `available`、`unavailable` 與 `unknown`。`unavailable` 的原因有 `engine`、
+`agent-mode`、`permission`、`context-unavailable` 與 `context-unresolvable`，依「最難修的
+排前面」回報，讓 reason 指到真正擋路的那一個。在 `DBCLI_AGENT_MODE=1` 之下，會變更設定的
+能力一律被拒，不管權限等級寫什麼。`context-unresolvable` 與 `context-unavailable` 刻意分開：
+`{"$env": "..."}` 密碼指向未設定變數的設定檔是存在且可讀的，宣稱「沒有設定」是假話。
+
+無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：`0` 全部可用、
+`1` 有任一不可用或未知、`2` 輸入無效。
 
 #### `inspect` 給 agent 的輸出
 

--- a/docs/user/zh-TW/index.md
+++ b/docs/user/zh-TW/index.md
@@ -279,12 +279,42 @@ v1 設定則會改寫 `.env.local` 裡的 `DBCLI_PASSWORD`，與 v1 的讀取邏
 | `schema [table]` | 顯示特定物件的結構，或掃描整個資料庫並快取元資料。 |
 | `inspect` | 為 AI 代理提供唯讀的上下文快照（物件、權限、指令建議）。 |
 | `status` | 顯示目前配置的安全摘要（不含機密資訊）。 |
+| `capabilities` | 列出靜態 capability catalog（dbcli 能做什麼），不連線資料庫。 |
+| `capabilities check` | 依本機設定的 engine 與 permission 檢查所需的 capability id。不建立連線。 |
 
 `dbcli blacklist list --format json` 會在 stdout 輸出一個 machine-readable 文件，包含
 `tables`、`columns` 與 `warnings`；不合法的 MongoDB blacklist path 會放進結構化的
 `warnings` 陣列，不會把人類可讀診斷混入 stdout。
 
 在 PostgreSQL 中，`schema` 全程使用精確的 `public` catalog identity：完整的 catalog/schema/table join 可避免重複使用的 constraint 名稱污染另一張表，複合 foreign key 欄位會維持宣告順序，複合 primary key 的順序來自精確 table OID 與 index ordinality，estimate 也限定於精確的 `public` relation。Row count 會同時 qualify 並 quote `"public"` 與精確 table name，內嵌 quote 會被 escape，因此混合大小寫或含標點的 identifier 仍可安全區分；被參照 schema/table 的 catalog 原始拼字也會保留。
+
+#### 給 Skill 的能力探索
+
+`dbcli capabilities` 用一個有版本、可解析的形狀回答「這個工具能做什麼」，讓外部 Skill 在動工
+之前就能決定。`dbcli capabilities check --require <ids>` 接著依本機設定回答「這裡有沒有」。
+兩者都不會建立資料庫連線。
+
+```bash
+dbcli capabilities --format json
+dbcli capabilities check --require schema.read,query.read --format json
+```
+
+一個 **capability** 是 dbcli 的單一原子能力——`schema.read`、`data.delete`。它絕不是職務或方法：
+`dba.tune-production` 與 `crud.scaffold` 屬於組合 dbcli 的 Role Skill 或 Method Skill。分層是
+`Story + AGENTS.md + Role Skill + Method Skill + Tool Skill + dbcli`，而 dbcli 只回答最後兩層。
+
+輸出刻意不代表的四件事：
+
+*   **Discovery 不是授權。** 列出一項能力只表示這個程式做得到，不表示你可以做。
+*   **`available` 不等於已核准。** 它只說 engine 與 permission 不會拒絕。Blacklist、write
+    gate、確認與 audit 仍然全部會跑，也沒有任何人類同意過什麼。設定檔裡的 `admin` 是權限
+    等級，不是 DBA 的簽核。
+*   **`schemaVersion` 不是套件版本。** 要 pin 的是 contract 版本，不是 `7.x`。
+*   **Task Pack 的 plan 不是結果。** `status: "planned"` 與驗證結果始終是兩回事。
+
+狀態有 `available`、`unavailable`（原因為 `engine`、`permission` 或 `context-unavailable`）
+與 `unknown`。無法辨識的 id 一律 fail closed，絕不會被解析成長得像的那一個。Exit code：
+`0` 全部可用、`1` 有任一不可用或未知、`2` 輸入無效。
 
 #### `inspect` 給 agent 的輸出
 

--- a/plugins/dbcli-agent/skills/dbcli/SKILL.md
+++ b/plugins/dbcli-agent/skills/dbcli/SKILL.md
@@ -157,8 +157,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/plugins/dbcli-agent/skills/dbcli/SKILL.md
+++ b/plugins/dbcli-agent/skills/dbcli/SKILL.md
@@ -139,6 +139,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -422,6 +448,7 @@ Full flags and edge cases: see [reference.md](reference.md#init).
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/skills/dbcli/SKILL.md
+++ b/skills/dbcli/SKILL.md
@@ -157,8 +157,11 @@ method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method S
 composes dbcli — this Tool Skill only covers operating dbcli safely.
 
 - `schemaVersion` is the capability contract version, **not** the npm package version.
-- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
-  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Statuses are `available`, `unavailable` (reason `engine`, `agent-mode`, `permission`,
+  `context-unavailable` or `context-unresolvable`) and `unknown`. A misspelled id fails
+  closed and is never guessed.
+- Under `DBCLI_AGENT_MODE=1`, capabilities that change configuration are `unavailable`
+  with reason `agent-mode` whatever the permission level says.
 - Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
 - **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
   at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.

--- a/skills/dbcli/SKILL.md
+++ b/skills/dbcli/SKILL.md
@@ -139,6 +139,32 @@ their descriptive evidence policy; it never authorizes an assertion or query. If
 migrate that file without an explicit human request; semantic vocabulary never replaces
 schema confirmation or the normal query/write safety gates.
 
+## Capability discovery
+
+Before composing a workflow, ask dbcli what it can do here rather than assuming. The
+catalog is static and the check reads only the local config — **neither opens a database
+connection.**
+
+```bash
+dbcli capabilities --format json                                  # full catalog
+dbcli capabilities --format markdown                              # table for docs
+dbcli capabilities check --require schema.read,query.read         # gate your workflow
+dbcli capabilities check --require data.delete --format json      # machine-readable
+```
+
+A capability is one atomic dbcli ability (`schema.read`, `data.delete`), never a job or a
+method. `dba.tune-production` and `crud.scaffold` belong to the Role or Method Skill that
+composes dbcli — this Tool Skill only covers operating dbcli safely.
+
+- `schemaVersion` is the capability contract version, **not** the npm package version.
+- Statuses are `available`, `unavailable` (reason `engine`, `permission` or
+  `context-unavailable`) and `unknown`. A misspelled id fails closed and is never guessed.
+- Exit codes: `0` all available, `1` any unavailable or unknown, `2` bad input.
+- **`available` is not approval.** Blacklist, write gate, confirmation and audit still run
+  at execution time, and `admin` in a config file is a permission level, not a DBA sign-off.
+- v1 covers the commands the engine capability matrix governs; anything outside it returns
+  `unknown` rather than an unaudited engine claim.
+
 ## Agent Task Packs
 
 When the user asks for a database workflow ("diagnose this slow query", "audit
@@ -422,6 +448,7 @@ Full flags and edge cases: see [reference.md](reference.md#init).
 |---------|-----------------|---------|
 | `init` | n/a | Create `.dbcli` (v1 single or v2 multi via `--conn-name` / `--env-file`). **Usually run by the human** — do NOT re-run to strip `{"$env"}` references; that format is intentional. |
 | `use` | n/a | Show/switch default named connection (v2 only). |
+| `capabilities` | n/a | Static capability catalog + `check --require <ids>` requirement gate. No database connection. `--format text\|json\|markdown` (`check` is `text\|json`). Exit `0`/`1`/`2`. |
 | `list` | query-only+ | Tables (SQL), collections (MongoDB), keys (Redis), or indices (Elasticsearch). |
 | `schema` | query-only+ | SQL: per-table or full scan into `.dbcli/schemas/`. MongoDB: sampled. ES: flattened mapping. Redis: per-key only (type/TTL/size). Supports `--recovery`. |
 | `query` | query-only+ | SQL, Mongo JSON (`--collection`), Redis command, or ES DSL/Lucene (`--collection`). `--format table\|json\|csv\|html`, `--ui` to open the interactive dashboard in a browser. `--fields` (projection), `--truncate` (cell width), `-f/--query-file` (read query from file or stdin), `--use a,b` (read-only fan-out). Supports `--recovery`. `--slow-ms <n>` sets the passive slow-query hint threshold (default 1000, `0` off): at or above it, table output gains a `Performance hint` footer and JSON gains `metadata.performanceAdvisory`; it runs no extra diagnostics and is suppressed under `--recovery`. Distinct from the `proxy` flag of the same name. See **Query workflow flags**. |

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -1691,8 +1691,10 @@ dbcli capabilities --format markdown     # table, for docs
 ```
 
 Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
-`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
-`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+`engines`, `limitedEngines`, `engineIndependent`, `minimumPermission`,
+`requiresConnection`, `mutatesConfiguration`, `supportsJson` and
+`supportsEvidence`. `limitedEngines` is the subset of `engines` the support
+matrix marks *limited* rather than fully supported. Output is sorted by `id`, so two runs of
 the same build are byte-identical.
 
 `schemaVersion` is the **capability contract** version, not the npm package
@@ -1730,7 +1732,9 @@ Each result is `available`, `unavailable` or `unknown`:
 | `available` | `null` | The configured engine and permission would not refuse it. |
 | `unavailable` | `engine` | The configured engine does not support it. |
 | `unavailable` | `permission` | The configured permission level is below its minimum. |
-| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unavailable` | `agent-mode` | `DBCLI_AGENT_MODE=1` is set and the capability changes configuration, permission or credentials — refused unconditionally. |
+| `unavailable` | `context-unavailable` | No local config here, so there is nothing to evaluate against. |
+| `unavailable` | `context-unresolvable` | A config exists but could not be resolved into an engine and a permission — an `{"$env": "..."}` reference pointing at an unset variable, for instance. Distinct from "no config", because saying there is none would be false. |
 | `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
 
 A duplicate id in `--require` is de-duplicated in first-seen order and reported
@@ -1739,10 +1743,18 @@ in `warnings`; `required` and `results` each hold it once.
 **Exit codes:** `0` every requirement available · `1` any unavailable or
 unknown · `2` invalid input or an unreadable format.
 
-**`available` is not approval.** It says the gate would not refuse on engine and
-permission grounds. Blacklist, write gate, confirmation and audit all still run
+Blockers are reported least-fixable first — engine, then agent mode, then
+permission — so `reason` names the one actually in the way.
+
+**`available` is not approval.** It says the gate would not refuse on engine,
+agent-mode and permission grounds. Blacklist, write gate, confirmation and audit all still run
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
+
+One known overstatement: `dbcli schema` persists its result into `config.json`,
+and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
+reports `available` there, because the read itself works and marking it
+unavailable would suggest schema cannot be read at all.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -43,6 +43,7 @@ never the right move.
 [snapshot](#snapshot) ·
 [assert](#assert) ·
 [proxy](#proxy) ·
+[capabilities](#capabilities) ·
 [status](#status) ·
 [inspect](#inspect) ·
 [report](#report) ·
@@ -1672,6 +1673,78 @@ Every actionable block carries machine-readable next steps so an agent can move 
 
 **Engines:** MySQL / MariaDB / PostgreSQL
 **Permission:** n/a (acts as a TCP relay; does not use dbcli's SQL permission model)
+
+### capabilities
+
+Discovery. Lists the static dbcli capability catalog — what this tool can do,
+described in a versioned shape an external Skill can parse before it starts
+working. It never opens a database connection and never writes anything.
+
+A **capability** names one atomic dbcli ability (`schema.read`, `data.delete`).
+It is not a job and not a method: `dba.tune-production` or `crud.scaffold`
+belong to the Role or Method Skill that composes dbcli, never to dbcli itself.
+
+```bash
+dbcli capabilities                       # human-readable (default)
+dbcli capabilities --format json         # for agents and Skills
+dbcli capabilities --format markdown     # table, for docs
+```
+
+Each entry carries `id`, `description`, `command`, `risk`, `sideEffect`,
+`engines`, `engineIndependent`, `minimumPermission`, `requiresConnection`,
+`supportsJson` and `supportsEvidence`. Output is sorted by `id`, so two runs of
+the same build are byte-identical.
+
+`schemaVersion` is the **capability contract** version, not the npm package
+version. Pin `schemaVersion`, never `7.x`.
+
+**Scope of v1:** the catalog covers the commands the engine capability matrix
+governs. Commands outside it — `explain`, `plan`, `impact`, `assert`, `verify`,
+`evidence`, `contract`, `semantic`, `design`, `snapshot`, `backfill`, `proxy` —
+are absent rather than described with engine claims nothing has audited. Ask for
+one and you get `unknown`, which fails closed.
+
+**Permission:** query-only+ (no connection is made)
+
+#### capabilities check
+
+Asks whether the capabilities you need are available *here* — against this
+machine's local configuration only. It reads engine and permission from the
+config; it does not connect to the database to find out.
+
+```bash
+dbcli capabilities check --require schema.read,query.read
+dbcli capabilities check --require schema.read,data.delete --format json
+dbcli --use staging capabilities check --require schema.read --format json
+```
+
+| Flag | Purpose |
+|---|---|
+| `--require <ids>` | Comma-separated capability ids. Required; an empty list is refused rather than reported as ok. |
+| `--format <type>` | `text` (default) or `json`. |
+
+Each result is `available`, `unavailable` or `unknown`:
+
+| Status | Reason | Means |
+|---|---|---|
+| `available` | `null` | The configured engine and permission would not refuse it. |
+| `unavailable` | `engine` | The configured engine does not support it. |
+| `unavailable` | `permission` | The configured permission level is below its minimum. |
+| `unavailable` | `context-unavailable` | No readable local config, so there is nothing to evaluate against. |
+| `unknown` | `unknown-capability` | No such capability id. Never guessed at — a typo is refused, not resolved to a neighbour. |
+
+A duplicate id in `--require` is de-duplicated in first-seen order and reported
+in `warnings`; `required` and `results` each hold it once.
+
+**Exit codes:** `0` every requirement available · `1` any unavailable or
+unknown · `2` invalid input or an unreadable format.
+
+**`available` is not approval.** It says the gate would not refuse on engine and
+permission grounds. Blacklist, write gate, confirmation and audit all still run
+at execution time, and no human has agreed to anything. `admin` in a config file
+is a permission level, not a DBA sign-off.
+
+**Permission:** query-only+ (no connection is made)
 
 ### status
 

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -16,11 +16,23 @@ Agent Integration Contract v1 的第一個垂直切片。`dbcli capabilities` �
 「這裡有沒有」，兩者都不建立資料庫連線。設計記錄在
 `docs/specs/2026-09-04-agent-integration-contract-v1.md`，決定在 ADR-0022。
 
-這個 Story 最值得留下的一句：**contract 說謊的兩次都是測試抓到的，不是人看出來的。**
-一次是缺設定時 `capabilities check` 拿 `DEFAULT_CONFIG` 的 localhost PostgreSQL
-當成真的環境回報；一次是手寫的 `supportsJson` 有四個指令是錯的。兩者都不會讓
-任何既有測試變紅，只會讓一份對外契約長期說錯話——所以這個切片的價值不在新指令，
-在那兩支對著實際 Commander tree 與實際 import graph 雙向比對的 contract test。
+這個 Story 最值得留下的一句：**contract 說謊了五次，沒有一次是讀碼看出來的。**
+缺設定時拿 `DEFAULT_CONFIG` 的 localhost PostgreSQL 當真實環境回報；手寫的
+`supportsJson` 四個指令是錯的；v2 預設連線的 `connectionName` 回 null；agent mode
+下對 `connection.select` 回 `available`；一個裸 catch 把五種狀況壓成同一句假話。
+前三個是測試與探測抓到的，後兩個是 code review 抓到的。
+
+其中 agent mode 那個最值得記住。原本的辯護是 ADR 寫的「available 不是核准」，
+但那條免責聲明蓋不住它——差別在**拒絕是何時決定的**：blacklist 與人類同意在執行
+當下決定，契約無從代言；`DBCLI_AGENT_MODE=1` 在這裡就決定了，而且不連線就完全可知。
+對著這份契約的主要客群（agent）宣稱一件下一個指令就會推翻的事，是這份契約唯一
+會被真正依賴的假承諾。
+
+留下一個已知的過度宣稱，寫進 ADR 與 acceptance：`dbcli schema` 會把讀到的 schema
+持久化進 `config.json`，那個寫入也在 agent mode 的閘門後面，所以 `schema.read`
+在 agent mode 下回 `available` 但實際跑會在持久化那步失敗。標成 unavailable 會讓
+agent 以為完全讀不到 schema，反方向的錯更大。真正的修法是 schema *快取*的寫入
+本來就不該擋在「連線身分」的閘門後面：DBCLI-PLAT-012。
 
 已知邊界，不是疏漏：`ENGINE_CAPABILITIES` 只涵蓋 34 個 command key，dbcli 有 50 個
 top-level 指令。`explain`、`plan`、`impact`、`assert`、`verify`、`evidence` 等 16 個
@@ -166,6 +178,7 @@ baseline:
   dirty_worktree: false
   story_owned_paths:
     - specs/stories/DBCLI-PLAT-001-capability-contract/
+    - tests/unit/adapters/database-systems-roster.test.ts
     - docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
     - docs/specs/2026-09-04-agent-integration-contract-v1.md
     - docs/plans/2026-09-04-agent-integration-contract-v1.md
@@ -194,7 +207,7 @@ verification:
   last_command: bun test + 13 static gates + build + build:determinism
   result: pass
   detail: >-
-    6488 pass / 27 skip / 0 fail across 556 files. The 27 skips are the
+    6509 pass / 27 skip / 0 fail across 557 files, after the code-review fixes. The 27 skips are the
     Elasticsearch, live-DB and MySQL integration suites, which have no local
     services; no DBCLI-PLAT-001 assertion depends on one. release:check was NOT
     run to completion — it fails at step 1/9 on a `bun audit` network timeout,

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -9,6 +9,27 @@
 release Story。bump 之前 `SECURITY.md` 的支援列必須從 `7.x` 改成 `8.x`，否則
 `manifest:check`（`scripts/check-plugin-manifests.ts:164-176`）會擋下 release。
 
+## 進行中：DBCLI-PLAT-001
+
+Agent Integration Contract v1 的第一個垂直切片。`dbcli capabilities` 與
+`dbcli capabilities check` 讓外部 Skill 在動工前問得到「這個工具能做什麼」、
+「這裡有沒有」，兩者都不建立資料庫連線。設計記錄在
+`docs/specs/2026-09-04-agent-integration-contract-v1.md`，決定在 ADR-0022。
+
+這個 Story 最值得留下的一句：**contract 說謊的兩次都是測試抓到的，不是人看出來的。**
+一次是缺設定時 `capabilities check` 拿 `DEFAULT_CONFIG` 的 localhost PostgreSQL
+當成真的環境回報；一次是手寫的 `supportsJson` 有四個指令是錯的。兩者都不會讓
+任何既有測試變紅，只會讓一份對外契約長期說錯話——所以這個切片的價值不在新指令，
+在那兩支對著實際 Commander tree 與實際 import graph 雙向比對的 contract test。
+
+已知邊界，不是疏漏：`ENGINE_CAPABILITIES` 只涵蓋 34 個 command key，dbcli 有 50 個
+top-level 指令。`explain`、`plan`、`impact`、`assert`、`verify`、`evidence` 等 16 個
+不在 catalog 裡，問它們會得到 `unknown`。替它們寫 engine 支援度等於憑讀碼捏造未經
+稽核的宣稱，這正是這份契約要避免的事。擴充 matrix 是 DBCLI-PLAT-011。
+
+後續 backlog（DBCLI-PLAT-004 到 011）只寫進 spec，沒有實作。Task Pack 仍是
+`plan-only`，`safety.requires` 沒有動。
+
 ## 交付紀錄
 
 DBCLI-001 到 DBCLI-012 都在 `feat/forgeflow-stories-002-006` 上完成，該分支
@@ -119,7 +140,7 @@ revision 是否存在，所以不宣稱；能查的是這個 repository 對它�
 
 ```yaml
 workflow:
-  current_story: none
+  current_story: DBCLI-PLAT-001
   next_story: pending
   completed_stories:
     - DBCLI-001
@@ -135,28 +156,47 @@ workflow:
     - DBCLI-011
     - DBCLI-012
     - DBCLI-013
-  status: done
+  status: in_progress
 
 baseline:
   repository: CarlLee1983/dbcli
-  branch: feat/dbcli-013-forgeflow-adoption-hardening
-  # The DBCLI-013 delivery commit on
-  # feat/dbcli-013-forgeflow-adoption-hardening, not yet merged to main.
-  # `7f534be5` is its parent and the last state on main.
-  commit: 907b0f69
+  branch: feat/dbcli-plat-001-capability-contract
+  # The last state on main when DBCLI-PLAT-001 started.
+  commit: d1237f93
   dirty_worktree: false
   story_owned_paths:
-    - specs/stories/DBCLI-013-forgeflow-adoption-hardening/
-    - scripts/check-forgeflow-adoption.ts
-    - scripts/lib/forgeflow-adoption.ts
-    - tests/contract/forgeflow-adoption.test.ts
-    - specs/handoff.md
-    - package.json
+    - specs/stories/DBCLI-PLAT-001-capability-contract/
+    - docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
+    - docs/specs/2026-09-04-agent-integration-contract-v1.md
+    - docs/plans/2026-09-04-agent-integration-contract-v1.md
+    - src/core/capabilities/
+    - src/core/permission/rank.ts
+    - src/commands/capabilities.ts
+    - tests/unit/core/capabilities/
+    - tests/contract/capability-contract.test.ts
+    - tests/integration/capabilities-command.test.ts
+    - src/adapters/types.ts
+    - src/core/permission-guard.ts
+    - src/core/public.ts
+    - src/program.ts
+    - src/program-lazy.ts
+    - tests/unit/core-public.test.ts
+    - assets/SKILL.md
+    - assets/SKILL.zh-TW.md
+    - assets/reference.md
+    - docs/user/
+    - CONTEXT.md
     - CHANGELOG.md
+    - specs/handoff.md
   known_unrelated_paths: []
 
 verification:
-  last_command: SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true make verify
+  last_command: bun test + 13 static gates + build + build:determinism
   result: pass
-  detail: 6403 tests across 552 files, 0 fail, integration included (docker services up)
+  detail: >-
+    6488 pass / 27 skip / 0 fail across 556 files. The 27 skips are the
+    Elasticsearch, live-DB and MySQL integration suites, which have no local
+    services; no DBCLI-PLAT-001 assertion depends on one. release:check was NOT
+    run to completion — it fails at step 1/9 on a `bun audit` network timeout,
+    before any repository check executes.
 ```

--- a/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
+++ b/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
@@ -1,0 +1,74 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] `dbcli capabilities --format json` emits `schemaVersion: 1` and a non-empty
+      capability array — `tests/integration/capabilities-command.test.ts`
+* [x] `dbcli capabilities --format markdown` emits a table — same file
+* [x] `dbcli capabilities` defaults to human-readable output — same file
+* [x] `dbcli capabilities check --require schema.read,query.read` reports
+      `available` and exits `0` on a supported engine with sufficient
+      permission — same file
+* [x] The agent-facing exports are reachable from `@carllee1983/dbcli/core` —
+      `tests/unit/core-public.test.ts`
+
+## Business Rules
+
+* [x] Engine lists equal the `supported`/`limited` rows of
+      `ENGINE_CAPABILITIES` — `tests/unit/core/capabilities/registry.test.ts`
+* [x] `risk` is derived from the published side-effect tier — same file
+* [x] Every `COMMAND_CAPABILITY_KEYS` entry is covered by a capability, and
+      every capability names a real matrix key — same file
+* [x] Ids are unique, sorted, and name abilities rather than jobs — same file
+* [x] Output is byte-identical across calls and independent of input order —
+      same file and `tests/unit/core/capabilities/check.test.ts`
+* [x] The strict schema rejects unknown fields and unknown schema versions —
+      `tests/unit/core/capabilities/registry.test.ts`
+* [x] Every catalogued command path exists in the live Commander tree —
+      `tests/contract/capability-contract.test.ts`
+* [x] `supportsJson` equals what the live tree offers, in both directions —
+      same file
+* [x] A capability claiming `requiresConnection: false` has a command whose
+      import graph loads no adapter — same file
+
+## Failure Cases
+
+* [x] An unknown id is `unknown` with reason `unknown-capability`, exit `1` —
+      `tests/unit/core/capabilities/check.test.ts`,
+      `tests/integration/capabilities-command.test.ts`
+* [x] An unsupported engine is `unavailable` with reason `engine`, exit `1` —
+      same files
+* [x] An insufficient permission is `unavailable` with reason `permission`,
+      exit `1` — same files
+* [x] A missing config yields `context: null` and reason
+      `context-unavailable`, and never reports the default config's engine —
+      same files
+* [x] An empty `--require` exits `2` rather than reporting `ok` — same files
+* [x] An unsupported `--format` exits `2` —
+      `tests/integration/capabilities-command.test.ts`
+* [x] A duplicate id is de-duplicated and warned about — same files
+
+## Regression Requirements
+
+* [x] Capability discovery loads no database adapter and creates no connection —
+      `tests/contract/capability-contract.test.ts`
+* [x] Neither command mutates the working directory —
+      `tests/integration/capabilities-command.test.ts`
+* [x] No credential, host or endpoint appears in either output — same file and
+      `tests/unit/core/capabilities/registry.test.ts`
+* [x] The engine vocabulary stays `postgresql` —
+      `tests/unit/core/capabilities/registry.test.ts`
+* [x] `agent-core` purity, core no-stdout, CLI contract, skill parity, platform
+      parity and plugin sync gates all still pass — `make verify`
+
+## Verification Notes
+
+The full suite runs without external database services; the Elasticsearch,
+live-DB and MySQL integration suites skip. Every assertion above holds without
+them: no case in this Story needs a reachable database, which is the point.
+
+## Addendum — connection attribution
+
+* [x] A v2 default connection is named in `context.connectionName` even with no
+      `--use` — `tests/integration/capabilities-command.test.ts`
+* [x] A v1 single-connection config reports `connectionName: null` — same file

--- a/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
+++ b/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
@@ -67,6 +67,36 @@ The full suite runs without external database services; the Elasticsearch,
 live-DB and MySQL integration suites skip. Every assertion above holds without
 them: no case in this Story needs a reachable database, which is the point.
 
+## Addendum — code review follow-ups
+
+* [x] Agent mode is part of the evaluated context, and configuration-changing
+      capabilities are `unavailable` with reason `agent-mode` regardless of
+      permission — `tests/unit/core/capabilities/check.test.ts`,
+      `tests/integration/capabilities-command.test.ts`
+* [x] `mutatesConfiguration` is never claimed by a capability whose command
+      writes no configuration — `tests/contract/capability-contract.test.ts`
+* [x] A present-but-unresolvable config reports `context-unresolvable`, never
+      "no configuration was found", and leaks no filesystem path —
+      `tests/integration/capabilities-command.test.ts`
+* [x] `minimumPermission` derives from `minimumPermissionFor` rather than a
+      transcribed ladder — `tests/unit/core/capabilities/registry.test.ts`
+* [x] `limitedEngines` is the matrix `limited` subset, and is non-empty
+      somewhere — same file
+* [x] `DATABASE_SYSTEMS` matches the keys of `ENGINE_CAPABILITIES` —
+      `tests/unit/adapters/database-systems-roster.test.ts`
+* [x] "Mutates nothing on disk" is asserted recursively —
+      `tests/integration/capabilities-command.test.ts`
+
+### Known deviation
+
+Under `DBCLI_AGENT_MODE=1`, `schema.read` / `schema.read-object` /
+`schema.scan` report `available` although `dbcli schema` persists into
+`config.json` and that write is refused. Marking them would make an agent
+conclude schema cannot be read at all — a larger error in the opposite
+direction. It deviates from R2's spirit rather than its letter (the capability
+command does write config, incidentally). DBCLI-PLAT-012 moves cache
+persistence out from behind the identity guard, which removes the cause.
+
 ## Addendum — connection attribution
 
 * [x] A v2 default connection is named in `context.connectionName` even with no

--- a/specs/stories/DBCLI-PLAT-001-capability-contract/story.md
+++ b/specs/stories/DBCLI-PLAT-001-capability-contract/story.md
@@ -1,0 +1,102 @@
+# Story: DBCLI-PLAT-001 Capability Contract, Discovery and Requirement Check
+
+## Goal
+
+An external Skill — a CRUD Skill, a CQRS Skill, a DBA Operator Skill — can ask
+dbcli what it is able to do, and whether those abilities are available in this
+project, before it starts working, and can parse the answer.
+
+## Context
+
+dbcli provides atomic database abilities. It does not carry job knowledge. The
+layering is `Story + Project AGENTS.md + Role Skill + Method Skill + Tool Skill
++ dbcli`: dbcli answers "what can be done", the dbcli Skill answers "how to
+operate dbcli safely", and Role/Method Skills answer "how this job works".
+
+Today the only machine-readable description of dbcli's abilities is `--help`,
+which is prose. `src/adapters/capabilities.ts` already holds a per-engine ×
+per-command support matrix, but nothing exposes it to a caller and nothing
+gives an ability a stable name.
+
+The trap this Story exists to avoid is writing a *second* table of what each
+command supports per engine. Two tables disagree the first time an engine gains
+support for something, silently.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: no
+
+## Scope
+
+### In Scope
+
+* A versioned capability contract in `src/core/capabilities/`, deriving every
+  engine and risk claim from `ENGINE_CAPABILITIES`.
+* `dbcli capabilities` with `text`, `json` and `markdown` output.
+* `dbcli capabilities check --require <ids>` with `text` and `json` output.
+* Agent-facing export of the pure types and functions through
+  `@carllee1983/dbcli/core`.
+* Unit, contract and integration tests, and an ADR.
+* User documentation in both languages and both formats, plus Skill mirrors.
+
+### Out of Scope
+
+* Changing any existing command's `--format json` output.
+* An Operation Envelope, correlation id, or evidence expansion.
+* Executing Task Packs, or validating `safety.requires` against capability ids.
+* Extending `ENGINE_CAPABILITIES` to the commands it does not yet cover.
+* CRUD, CQRS or DBA behaviour inside dbcli core.
+
+## Inputs
+
+* `--require <ids>`: a comma-separated, non-empty list of capability ids.
+* `--format <type>`.
+* The local dbcli configuration, read for engine and permission only.
+* The global `--use` / `--config` / `--global` connection selectors.
+
+## Outputs
+
+* A capability catalog: `schemaVersion` plus capabilities sorted by id.
+* A check report: `schemaVersion`, `ok`, `required`, `context`, `results`,
+  `warnings`.
+* Exit codes `0` (all available), `1` (any unavailable or unknown), `2`
+  (invalid input).
+
+## Rules
+
+* R1: Every `engines` and `risk` value is derived from `ENGINE_CAPABILITIES`;
+  none is written literally in the capability registry.
+* R2: Neither command opens a database connection or mutates the filesystem.
+* R3: An unknown capability id is `unknown`, never `available`, and is never
+  resolved to a similar-looking id.
+* R4: With no readable local config the context is `null` and every known
+  capability is `unavailable` with reason `context-unavailable`. The default
+  config is never reported as if it were configured.
+* R5: Output is deterministic: sorted by id, byte-identical across runs of the
+  same build, and independent of `--require` argument order.
+* R6: No credential, host, port, connection string or data row appears in any
+  output.
+* R7: The engine vocabulary is `DatabaseSystem` (`postgresql`). No third
+  spelling is introduced.
+* R8: `CAPABILITY_CONTRACT_SCHEMA_VERSION` is independent of the npm version.
+
+## Expected Errors
+
+* Empty `--require`, or an empty element within it: exit `2`.
+* An unsupported `--format` value: exit `2`.
+* A duplicate id in `--require`: de-duplicated in first-seen order, reported in
+  `warnings`, exit unaffected.
+
+## Dependencies
+
+* `src/adapters/capabilities.ts` — the engine support matrix.
+* `src/core/permission/rank.ts` — the permission ladder.
+* `src/core/config.ts` — the single config reader.
+
+## Constraints
+
+* The contract may not live under `src/agent-core/`: the purity gate forbids
+  the word `postgresql` there.
+* No second database execution path, and no weakening of permission,
+  blacklist, write gate, audit, redaction or deny-by-default behaviour.

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -11,6 +11,38 @@ export type DatabaseSystem =
   | 'redis'
   | 'elasticsearch'
 
+/**
+ * Every supported system, in the order engine-facing output enumerates them.
+ *
+ * `DatabaseSystem` is a type and vanishes at runtime, so code that must iterate
+ * the roster — the capability catalog, engine-support tables — previously
+ * rebuilt its own list. The `satisfies` clause below is what makes this one
+ * authoritative: adding a member to the union without adding it here is a type
+ * error, and `tests/unit/adapters/capabilities.test.ts` asserts it matches the
+ * keys of `ENGINE_CAPABILITIES`.
+ */
+export const DATABASE_SYSTEMS = Object.freeze([
+  'postgresql',
+  'mysql',
+  'mariadb',
+  'mongodb',
+  'redis',
+  'elasticsearch',
+] as const) satisfies readonly DatabaseSystem[]
+
+/**
+ * Compile-time exhaustiveness for the roster above.
+ *
+ * `satisfies` alone only rejects a *wrong* member; it says nothing about a
+ * *missing* one, which is the direction that actually breaks callers. This
+ * alias stops compiling the moment a `DatabaseSystem` member is absent from
+ * `DATABASE_SYSTEMS`, and names the missing member in the error.
+ */
+type AssertNever<T extends never> = T
+export type DatabaseSystemRosterIsExhaustive = AssertNever<
+  Exclude<DatabaseSystem, (typeof DATABASE_SYSTEMS)[number]>
+>
+
 export type SqlDatabaseSystem = Extract<DatabaseSystem, 'postgresql' | 'mysql' | 'mariadb'>
 
 export type SqlExecutionMode = 'normal' | 'native-read-only'

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -18,8 +18,8 @@ export type DatabaseSystem =
  * the roster — the capability catalog, engine-support tables — previously
  * rebuilt its own list. The `satisfies` clause below is what makes this one
  * authoritative: adding a member to the union without adding it here is a type
- * error, and `tests/unit/adapters/capabilities.test.ts` asserts it matches the
- * keys of `ENGINE_CAPABILITIES`.
+ * error, and `tests/unit/adapters/database-systems-roster.test.ts` asserts it
+ * matches the keys of `ENGINE_CAPABILITIES`.
  */
 export const DATABASE_SYSTEMS = Object.freeze([
   'postgresql',

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -1,0 +1,220 @@
+/**
+ * `dbcli capabilities` — discovery, and only discovery.
+ *
+ * The catalog is static: this command answers from `src/core/capabilities`
+ * without opening a connection, and `capabilities check` evaluates a
+ * requirement list against the *local config* alone. Neither reaches a
+ * database, and neither writes anything.
+ *
+ * Listing a capability is not a grant. `available` says the configured engine
+ * and permission would not refuse the operation; the blacklist, the write gate,
+ * the confirmation prompt and the audit log all still run at execution time,
+ * and a human's approval is not modelled here at all.
+ */
+
+import { join } from 'node:path'
+import { Command } from 'commander'
+import {
+  buildCapabilityCatalog,
+  checkCapabilities,
+  parseRequirements,
+  type Capability,
+  type CapabilityCheckContext,
+  type CapabilityCheckReport,
+} from '@/core/capabilities'
+import { configModule } from '@/core/config'
+import { resolveConfigStoragePath } from '@/core/config-binding'
+import { resolveConfigPath } from '@/utils/config-path'
+import { validateFormat } from '@/utils/validation'
+import { DATABASE_SYSTEMS, type DatabaseSystem } from '@/adapters/types'
+
+const CATALOG_FORMATS = ['text', 'json', 'markdown'] as const
+const CHECK_FORMATS = ['text', 'json'] as const
+
+/** Invalid input or unreadable config. Distinct from "a requirement failed". */
+const EXIT_INVALID_INPUT = 2
+/** At least one requirement is unavailable or unknown. */
+const EXIT_REQUIREMENTS_UNMET = 1
+
+function isDatabaseSystem(value: unknown): value is DatabaseSystem {
+  return typeof value === 'string' && (DATABASE_SYSTEMS as readonly string[]).includes(value)
+}
+
+/**
+ * Read engine and permission from the local config, or `null` when there is
+ * none to read.
+ *
+ * `loadLayeredSchema: false` keeps this off the schema cache: a capability
+ * check has no use for table structure, and loading it would make a discovery
+ * command's cost depend on the size of the database it is describing. Only
+ * `permission` and `connection.system` are read; nothing else from the config
+ * reaches the output.
+ */
+async function configExists(configPath: string): Promise<boolean> {
+  const storagePath = await resolveConfigStoragePath(configPath)
+  if (await Bun.file(join(storagePath, 'config.json')).exists()) return true
+  return Bun.file(configPath).exists()
+}
+
+async function resolveContext(command: Command): Promise<CapabilityCheckContext | null> {
+  try {
+    const configPath = resolveConfigPath(command)
+
+    // `configModule.read` answers a missing config with DEFAULT_CONFIG — a
+    // localhost PostgreSQL at query-only — so that `init` has something to
+    // start from. Reporting engine and permission from those defaults would
+    // have this command state, in JSON, that a database nobody configured
+    // supports the requested capability. Existence is therefore established
+    // first, against the same storage path the reader itself resolves.
+    if (!(await configExists(configPath))) return null
+
+    const config = await configModule.read(configPath, undefined, {
+      loadLayeredSchema: false,
+    })
+    const system = config.connection?.system
+    if (!isDatabaseSystem(system)) return null
+
+    return {
+      engine: system,
+      permission: config.permission,
+      // The connection the reader actually resolved, not the one `--use` asked
+      // for. On a v2 config with no selector those differ: the default named
+      // connection is in effect and `--use` is unset, and reporting `null`
+      // there would leave the verdict unattributable to the connection that
+      // produced it.
+      connectionName: config.effectiveConnectionName ?? null,
+    }
+  } catch {
+    // A missing, unreadable or invalid config is context-unavailable, not an
+    // error: the caller asked what dbcli could do here, and "nothing is
+    // configured here" is the honest answer. It never reads as available.
+    return null
+  }
+}
+
+function renderCatalogText(capabilities: readonly Capability[], schemaVersion: number): string {
+  const lines = [
+    `dbcli capability contract v${schemaVersion} — ${capabilities.length} capabilities`,
+    '',
+    'Discovery only: a listed capability is not permission to run it.',
+    '',
+  ]
+  for (const capability of capabilities) {
+    lines.push(`${capability.id}  [${capability.risk}]`)
+    lines.push(`  ${capability.description}`)
+    lines.push(
+      `  command: dbcli ${capability.command}    permission: ${capability.minimumPermission}` +
+        `    connection: ${capability.requiresConnection ? 'required' : 'not required'}`
+    )
+    lines.push(
+      `  engines: ${capability.engineIndependent ? 'any (engine-independent)' : capability.engines.join(', ')}`
+    )
+    lines.push('')
+  }
+  return lines.join('\n').trimEnd()
+}
+
+function renderCatalogMarkdown(capabilities: readonly Capability[], schemaVersion: number): string {
+  const lines = [
+    `# dbcli capability contract v${schemaVersion}`,
+    '',
+    'A capability names an atomic dbcli ability. Composing capabilities into a job',
+    'belongs to the Skill calling dbcli, not to dbcli. Listing a capability is',
+    'discovery, not a permission grant.',
+    '',
+    '| id | risk | command | permission | connection | engines |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ]
+  for (const capability of capabilities) {
+    const engines = capability.engineIndependent ? 'any' : capability.engines.join(', ')
+    lines.push(
+      `| \`${capability.id}\` | ${capability.risk} | \`dbcli ${capability.command}\` | ` +
+        `${capability.minimumPermission} | ${capability.requiresConnection ? 'required' : 'no'} | ${engines} |`
+    )
+  }
+  lines.push('')
+  for (const capability of capabilities) {
+    lines.push(`- \`${capability.id}\` — ${capability.description}`)
+  }
+  return lines.join('\n')
+}
+
+function renderCheckText(report: CapabilityCheckReport): string {
+  const lines: string[] = []
+  if (report.context) {
+    lines.push(
+      `Context: engine ${report.context.engine}, permission ${report.context.permission}` +
+        (report.context.connectionName ? `, connection ${report.context.connectionName}` : '')
+    )
+  } else {
+    lines.push('Context: unavailable (no readable dbcli configuration)')
+  }
+  lines.push('')
+  for (const result of report.results) {
+    lines.push(
+      `${result.status.padEnd(11)} ${result.id}${result.reason ? `  (${result.reason})` : ''}`
+    )
+  }
+  if (report.warnings.length > 0) {
+    lines.push('')
+    for (const warning of report.warnings) lines.push(`warning: ${warning}`)
+  }
+  lines.push('')
+  lines.push(
+    report.ok ? 'All required capabilities are available.' : 'Some requirements are not met.'
+  )
+  return lines.join('\n')
+}
+
+export const capabilitiesCommand = new Command('capabilities')
+  .description('List the static dbcli capability catalog (no database connection)')
+  // Both this command and `check` take `--format`. Without positional options
+  // Commander binds `capabilities check --format json` to the parent, and the
+  // subcommand silently runs with its default — a JSON consumer would receive
+  // prose. See the same opt-in on the root program.
+  .enablePositionalOptions()
+  .option('--format <type>', 'Output format: text, json, markdown', 'text')
+  .action((options: { format: string }) => {
+    try {
+      validateFormat(options.format, CATALOG_FORMATS, 'capabilities')
+      const catalog = buildCapabilityCatalog()
+
+      if (options.format === 'json') {
+        console.log(JSON.stringify(catalog, null, 2))
+      } else if (options.format === 'markdown') {
+        console.log(renderCatalogMarkdown(catalog.capabilities, catalog.schemaVersion))
+      } else {
+        console.log(renderCatalogText(catalog.capabilities, catalog.schemaVersion))
+      }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`)
+      process.exit(EXIT_INVALID_INPUT)
+    }
+  })
+
+capabilitiesCommand
+  .command('check')
+  .description('Check whether required capabilities are available here (no database connection)')
+  .requiredOption('--require <ids>', 'Comma-separated capability ids, e.g. schema.read,query.read')
+  .option('--format <type>', 'Output format: text, json', 'text')
+  .action(async (options: { require: string; format: string }, command: Command) => {
+    let parsed
+    try {
+      validateFormat(options.format, CHECK_FORMATS, 'capabilities check')
+      parsed = parseRequirements(options.require)
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`)
+      process.exit(EXIT_INVALID_INPUT)
+    }
+
+    const context = await resolveContext(command)
+    const report = checkCapabilities(parsed.ids, context, parsed.warnings)
+
+    if (options.format === 'json') {
+      console.log(JSON.stringify(report, null, 2))
+    } else {
+      console.log(renderCheckText(report))
+    }
+
+    if (!report.ok) process.exit(EXIT_REQUIREMENTS_UNMET)
+  })

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -21,7 +21,9 @@ import {
   type Capability,
   type CapabilityCheckContext,
   type CapabilityCheckReport,
+  type CapabilityContextFailure,
 } from '@/core/capabilities'
+import { ConfigError } from '@/utils/errors'
 import { configModule } from '@/core/config'
 import { resolveConfigStoragePath } from '@/core/config-binding'
 import { resolveConfigPath } from '@/utils/config-path'
@@ -40,6 +42,14 @@ function isDatabaseSystem(value: unknown): value is DatabaseSystem {
   return typeof value === 'string' && (DATABASE_SYSTEMS as readonly string[]).includes(value)
 }
 
+/** The report's one echoed user string; bounded so the echo cannot be unbounded. */
+const MAX_CONNECTION_LABEL = 200
+
+function truncateLabel(name: string | undefined): string | null {
+  if (!name) return null
+  return name.length <= MAX_CONNECTION_LABEL ? name : `${name.slice(0, MAX_CONNECTION_LABEL)}…`
+}
+
 /**
  * Read engine and permission from the local config, or `null` when there is
  * none to read.
@@ -56,39 +66,56 @@ async function configExists(configPath: string): Promise<boolean> {
   return Bun.file(configPath).exists()
 }
 
-async function resolveContext(command: Command): Promise<CapabilityCheckContext | null> {
+interface ResolvedContext {
+  readonly context: CapabilityCheckContext | null
+  readonly failure: CapabilityContextFailure
+}
+
+async function resolveContext(command: Command): Promise<ResolvedContext> {
+  const configPath = resolveConfigPath(command)
+
+  // `configModule.read` answers a missing config with DEFAULT_CONFIG — a
+  // localhost PostgreSQL at query-only — so that `init` has something to start
+  // from. Reporting engine and permission from those defaults would have this
+  // command state, in JSON, that a database nobody configured supports the
+  // requested capability. Existence is therefore established first, against the
+  // same storage path the reader itself resolves.
+  if (!(await configExists(configPath))) return { context: null, failure: 'absent' }
+
   try {
-    const configPath = resolveConfigPath(command)
-
-    // `configModule.read` answers a missing config with DEFAULT_CONFIG — a
-    // localhost PostgreSQL at query-only — so that `init` has something to
-    // start from. Reporting engine and permission from those defaults would
-    // have this command state, in JSON, that a database nobody configured
-    // supports the requested capability. Existence is therefore established
-    // first, against the same storage path the reader itself resolves.
-    if (!(await configExists(configPath))) return null
-
     const config = await configModule.read(configPath, undefined, {
       loadLayeredSchema: false,
     })
     const system = config.connection?.system
-    if (!isDatabaseSystem(system)) return null
+    if (!isDatabaseSystem(system)) return { context: null, failure: 'unresolvable' }
 
     return {
-      engine: system,
-      permission: config.permission,
-      // The connection the reader actually resolved, not the one `--use` asked
-      // for. On a v2 config with no selector those differ: the default named
-      // connection is in effect and `--use` is unset, and reporting `null`
-      // there would leave the verdict unattributable to the connection that
-      // produced it.
-      connectionName: config.effectiveConnectionName ?? null,
+      context: {
+        engine: system,
+        permission: config.permission,
+        // The connection the reader actually resolved, not the one `--use`
+        // asked for. On a v2 config with no selector those differ: the default
+        // named connection is in effect and `--use` is unset, and reporting
+        // `null` there would leave the verdict unattributable to the connection
+        // that produced it.
+        connectionName: truncateLabel(config.effectiveConnectionName),
+        agentMode: process.env.DBCLI_AGENT_MODE === '1',
+      },
+      failure: 'absent',
     }
-  } catch {
-    // A missing, unreadable or invalid config is context-unavailable, not an
-    // error: the caller asked what dbcli could do here, and "nothing is
-    // configured here" is the honest answer. It never reads as available.
-    return null
+  } catch (error) {
+    // A config that exists but will not resolve is `unresolvable`, never
+    // `absent`. The two were conflated at first, and the result was this
+    // command telling a caller "no configuration was readable" when the config
+    // was present and fine and only an `{"$env": "..."}` password pointed at an
+    // unset variable — a credential this command does not even need. Saying
+    // there is no config when there is one is the contract stating a falsehood,
+    // which is exactly what it exists to prevent.
+    //
+    // The error's own message is deliberately not surfaced: it carries
+    // filesystem paths, and a discovery command emits no paths.
+    if (error instanceof ConfigError) return { context: null, failure: 'unresolvable' }
+    throw error
   }
 }
 
@@ -144,10 +171,11 @@ function renderCheckText(report: CapabilityCheckReport): string {
   if (report.context) {
     lines.push(
       `Context: engine ${report.context.engine}, permission ${report.context.permission}` +
-        (report.context.connectionName ? `, connection ${report.context.connectionName}` : '')
+        (report.context.connectionName ? `, connection ${report.context.connectionName}` : '') +
+        (report.context.agentMode ? ', agent mode' : '')
     )
   } else {
-    lines.push('Context: unavailable (no readable dbcli configuration)')
+    lines.push('Context: unavailable (see warnings below)')
   }
   lines.push('')
   for (const result of report.results) {
@@ -204,11 +232,16 @@ capabilitiesCommand
       parsed = parseRequirements(options.require)
     } catch (error) {
       console.error(`Error: ${(error as Error).message}`)
+      // `process.exit` is typed `never`, which is the only reason `parsed` reads
+      // as defined below. A stub or wrapper that does not terminate would throw
+      // a TypeError after the error was already printed; the explicit return
+      // costs nothing and removes the dependency on that typing.
       process.exit(EXIT_INVALID_INPUT)
+      return
     }
 
-    const context = await resolveContext(command)
-    const report = checkCapabilities(parsed.ids, context, parsed.warnings)
+    const { context, failure } = await resolveContext(command)
+    const report = checkCapabilities(parsed.ids, context, parsed.warnings, failure)
 
     if (options.format === 'json') {
       console.log(JSON.stringify(report, null, 2))

--- a/src/core/capabilities/check.ts
+++ b/src/core/capabilities/check.ts
@@ -1,11 +1,11 @@
 /**
  * Capability requirement checking.
  *
- * Pure: it is handed a context (or `null`) and a requirement list, and returns
- * a report. It never reads a file, an environment variable or a socket — the
- * command layer resolves the context from the local config and passes it in.
- * That separation is what makes "capability check never connects to a database"
- * a property of the module rather than a promise in the docs.
+ * Pure: it is handed a context (or a reason there is none) and a requirement
+ * list, and returns a report. It never reads a file, an environment variable or
+ * a socket — the command layer resolves the context from the local config and
+ * passes it in. That separation is what makes "capability check never connects
+ * to a database" a property of the module rather than a promise in the docs.
  */
 
 import { permissionAtLeast } from '@/core/permission/rank'
@@ -15,6 +15,7 @@ import {
   type CapabilityCheckContext,
   type CapabilityCheckReport,
   type CapabilityCheckResultEntry,
+  type CapabilityContextFailure,
 } from './types'
 
 export class CapabilityRequirementError extends Error {
@@ -46,13 +47,12 @@ export interface ParsedRequirements {
 export function parseRequirements(raw: string): ParsedRequirements {
   const parts = raw.split(',').map((part) => part.trim())
 
+  // `String.split` never yields an empty array, so an all-whitespace input
+  // arrives here as a single empty element. One branch covers both.
   if (parts.some((part) => part === '')) {
     throw new CapabilityRequirementError(
       '--require contains an empty capability id; give a comma-separated list such as "schema.read,query.read"'
     )
-  }
-  if (parts.length === 0) {
-    throw new CapabilityRequirementError('--require needs at least one capability id')
   }
 
   const ids: string[] = []
@@ -71,7 +71,21 @@ export function parseRequirements(raw: string): ParsedRequirements {
   }
 }
 
-function evaluate(id: string, context: CapabilityCheckContext | null): CapabilityCheckResultEntry {
+/**
+ * Evaluate one requirement.
+ *
+ * Blockers are checked least-fixable first, so `reason` names the one that
+ * actually stands in the way. Engine cannot be changed at all for this
+ * connection; agent mode cannot be lifted from inside the process that is
+ * subject to it; permission is a config edit. Reporting `permission` to someone
+ * whose engine does not support the operation would send them to fix the wrong
+ * thing.
+ */
+function evaluate(
+  id: string,
+  context: CapabilityCheckContext | null,
+  failure: CapabilityContextFailure
+): CapabilityCheckResultEntry {
   const capability = findCapability(id)
 
   // Fail closed, and never guess. A misspelling that resolved to a neighbouring
@@ -81,10 +95,20 @@ function evaluate(id: string, context: CapabilityCheckContext | null): Capabilit
 
   // Known capability, nothing to evaluate it against. It is not `unknown` —
   // the requirement was understood — and it is emphatically not `available`.
-  if (!context) return { id, status: 'unavailable', reason: 'context-unavailable' }
+  if (!context) {
+    return {
+      id,
+      status: 'unavailable',
+      reason: failure === 'absent' ? 'context-unavailable' : 'context-unresolvable',
+    }
+  }
 
   if (!capability.engineIndependent && !capability.engines.includes(context.engine)) {
     return { id, status: 'unavailable', reason: 'engine' }
+  }
+
+  if (context.agentMode && capability.mutatesConfiguration) {
+    return { id, status: 'unavailable', reason: 'agent-mode' }
   }
 
   if (!permissionAtLeast(context.permission, capability.minimumPermission)) {
@@ -97,13 +121,21 @@ function evaluate(id: string, context: CapabilityCheckContext | null): Capabilit
 export function checkCapabilities(
   required: readonly string[],
   context: CapabilityCheckContext | null,
-  warnings: readonly string[] = []
+  warnings: readonly string[] = [],
+  contextFailure: CapabilityContextFailure = 'absent'
 ): CapabilityCheckReport {
-  const results = required.map((id) => evaluate(id, context))
+  const results = required.map((id) => evaluate(id, context, contextFailure))
   const allWarnings = [...warnings]
+
   if (!context) {
     allWarnings.push(
-      'No local dbcli configuration was readable, so engine and permission could not be evaluated.'
+      contextFailure === 'absent'
+        ? 'No dbcli configuration was found here, so engine and permission could not be evaluated.'
+        : 'A dbcli configuration exists here but could not be resolved into an engine and a permission, so nothing was evaluated against it.'
+    )
+  } else if (context.agentMode) {
+    allWarnings.push(
+      'Agent mode is active (DBCLI_AGENT_MODE=1): configuration, permission and credential changes are refused regardless of permission level.'
     )
   }
 

--- a/src/core/capabilities/check.ts
+++ b/src/core/capabilities/check.ts
@@ -1,0 +1,118 @@
+/**
+ * Capability requirement checking.
+ *
+ * Pure: it is handed a context (or `null`) and a requirement list, and returns
+ * a report. It never reads a file, an environment variable or a socket — the
+ * command layer resolves the context from the local config and passes it in.
+ * That separation is what makes "capability check never connects to a database"
+ * a property of the module rather than a promise in the docs.
+ */
+
+import { permissionAtLeast } from '@/core/permission/rank'
+import { findCapability } from './registry'
+import {
+  CAPABILITY_CONTRACT_SCHEMA_VERSION,
+  type CapabilityCheckContext,
+  type CapabilityCheckReport,
+  type CapabilityCheckResultEntry,
+} from './types'
+
+export class CapabilityRequirementError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CapabilityRequirementError'
+    Object.setPrototypeOf(this, CapabilityRequirementError.prototype)
+  }
+}
+
+export interface ParsedRequirements {
+  readonly ids: readonly string[]
+  readonly warnings: readonly string[]
+}
+
+/**
+ * Parse `--require a,b,a` into an ordered, unique id list.
+ *
+ * A repeated id is de-duplicated rather than refused, and the duplication is
+ * reported as a warning. Refusing would punish the common case of two Skills
+ * concatenating their requirement lists, and answering the same id twice would
+ * make `results` a multiset that a consumer has to fold itself. Neither
+ * behaviour is guessable, so it is stated here and in the spec.
+ *
+ * Empty input, or any empty element, is refused: a requirement list that
+ * accidentally evaluated to "nothing required" would report `ok: true` and read
+ * as a green light.
+ */
+export function parseRequirements(raw: string): ParsedRequirements {
+  const parts = raw.split(',').map((part) => part.trim())
+
+  if (parts.some((part) => part === '')) {
+    throw new CapabilityRequirementError(
+      '--require contains an empty capability id; give a comma-separated list such as "schema.read,query.read"'
+    )
+  }
+  if (parts.length === 0) {
+    throw new CapabilityRequirementError('--require needs at least one capability id')
+  }
+
+  const ids: string[] = []
+  const duplicates: string[] = []
+  for (const part of parts) {
+    if (ids.includes(part)) {
+      if (!duplicates.includes(part)) duplicates.push(part)
+      continue
+    }
+    ids.push(part)
+  }
+
+  return {
+    ids,
+    warnings: duplicates.map((id) => `Duplicate capability id '${id}' in --require was ignored.`),
+  }
+}
+
+function evaluate(id: string, context: CapabilityCheckContext | null): CapabilityCheckResultEntry {
+  const capability = findCapability(id)
+
+  // Fail closed, and never guess. A misspelling that resolved to a neighbouring
+  // capability would hand a caller an `available` for something it did not ask
+  // for, which is strictly worse than a refusal it can read and correct.
+  if (!capability) return { id, status: 'unknown', reason: 'unknown-capability' }
+
+  // Known capability, nothing to evaluate it against. It is not `unknown` —
+  // the requirement was understood — and it is emphatically not `available`.
+  if (!context) return { id, status: 'unavailable', reason: 'context-unavailable' }
+
+  if (!capability.engineIndependent && !capability.engines.includes(context.engine)) {
+    return { id, status: 'unavailable', reason: 'engine' }
+  }
+
+  if (!permissionAtLeast(context.permission, capability.minimumPermission)) {
+    return { id, status: 'unavailable', reason: 'permission' }
+  }
+
+  return { id, status: 'available', reason: null }
+}
+
+export function checkCapabilities(
+  required: readonly string[],
+  context: CapabilityCheckContext | null,
+  warnings: readonly string[] = []
+): CapabilityCheckReport {
+  const results = required.map((id) => evaluate(id, context))
+  const allWarnings = [...warnings]
+  if (!context) {
+    allWarnings.push(
+      'No local dbcli configuration was readable, so engine and permission could not be evaluated.'
+    )
+  }
+
+  return {
+    schemaVersion: CAPABILITY_CONTRACT_SCHEMA_VERSION,
+    ok: results.every((result) => result.status === 'available'),
+    required: [...required],
+    context,
+    results,
+    warnings: allWarnings,
+  }
+}

--- a/src/core/capabilities/index.ts
+++ b/src/core/capabilities/index.ts
@@ -1,0 +1,44 @@
+/**
+ * The dbcli Capability Contract.
+ *
+ * A capability names an atomic tool ability. Composing those abilities into a
+ * job — CRUD engineering, CQRS projection work, DBA operations — is the
+ * business of the Skill that calls dbcli, and deliberately not of dbcli. See
+ * ADR-0022.
+ */
+
+export {
+  CAPABILITY_CONTRACT_SCHEMA_VERSION,
+  type Capability,
+  type CapabilityCatalog,
+  type CapabilityRisk,
+  type CapabilityCheckContext,
+  type CapabilityCheckReport,
+  type CapabilityCheckResultEntry,
+  type CapabilityCheckStatus,
+  type CapabilityUnavailableReason,
+} from './types'
+
+export {
+  CAPABILITIES,
+  buildCapabilityCatalog,
+  findCapability,
+  listCapabilityIds,
+  riskForSideEffect,
+  COMMAND_SURFACE,
+  CAPABILITY_DECLARATIONS,
+  DECLARED_CAPABILITY_KEYS,
+} from './registry'
+
+export {
+  CapabilityRequirementError,
+  checkCapabilities,
+  parseRequirements,
+  type ParsedRequirements,
+} from './check'
+
+export {
+  CapabilityContractError,
+  parseCapabilityCatalog,
+  parseCapabilityCheckReport,
+} from './schema'

--- a/src/core/capabilities/index.ts
+++ b/src/core/capabilities/index.ts
@@ -13,6 +13,7 @@ export {
   type CapabilityCatalog,
   type CapabilityRisk,
   type CapabilityCheckContext,
+  type CapabilityContextFailure,
   type CapabilityCheckReport,
   type CapabilityCheckResultEntry,
   type CapabilityCheckStatus,

--- a/src/core/capabilities/registry.ts
+++ b/src/core/capabilities/registry.ts
@@ -16,6 +16,7 @@ import {
 } from '@/adapters/capabilities'
 import { DATABASE_SYSTEMS, type DatabaseSystem } from '@/adapters/types'
 import type { Permission } from '@/types'
+import { minimumPermissionFor, type StatementType } from '@/core/permission-guard'
 import { CAPABILITY_CONTRACT_SCHEMA_VERSION, type Capability, type CapabilityRisk } from './types'
 
 /**
@@ -33,8 +34,22 @@ interface CapabilityDeclaration {
   readonly key: CommandCapabilityKey
   readonly command: string
   readonly description: string
-  readonly minimumPermission: Permission
+  /**
+   * The SQL statement type this capability's primary path issues, when there is
+   * one. Given it, `minimumPermission` is derived from `TIER_GRANTS` — the same
+   * table the runtime refusal uses — rather than transcribed here, so the two
+   * cannot drift. `permission` is for the capabilities no statement type
+   * describes; those are covered by unit tests instead.
+   */
+  readonly statementType?: StatementType
+  readonly permission?: Permission
   readonly requiresConnection: boolean
+  /**
+   * Whether the capability changes connection identity, permission or
+   * credentials. Asserted against the real import graph by
+   * `tests/contract/capability-contract.test.ts`, not trusted from here.
+   */
+  readonly mutatesConfiguration?: boolean
 }
 
 /**
@@ -51,16 +66,18 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'init',
     command: 'init',
     description: 'Create or update a local connection configuration interactively.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
+    mutatesConfiguration: true,
   },
   {
     id: 'connection.select',
     key: 'use',
     command: 'use',
     description: 'Switch the default named connection in a v2 configuration.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
+    mutatesConfiguration: true,
   },
   {
     id: 'connection.status',
@@ -68,7 +85,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     command: 'status',
     description:
       'Report the configured engine, permission and blacklist counts without credentials.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -76,7 +93,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'doctor',
     command: 'doctor',
     description: 'Run engine-specific connectivity and configuration diagnostics.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -84,7 +101,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'list',
     command: 'list',
     description: 'List the tables, collections or indices visible to the connection.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -92,7 +109,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'schema',
     command: 'schema',
     description: 'Read visible schema metadata for one object or the whole database.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -100,7 +117,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'schemaSingle',
     command: 'schema',
     description: 'Read the column or field structure of a single named object.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -108,7 +125,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'schemaFullScan',
     command: 'schema',
     description: 'Scan every visible object and refresh the local schema cache.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -116,7 +133,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'diff',
     command: 'diff',
     description: 'Compare schema snapshots and report structural differences.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -124,7 +141,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'migrate',
     command: 'migrate',
     description: 'Apply guarded DDL changes such as columns, indexes and constraints.',
-    minimumPermission: 'admin',
+    statementType: 'ALTER',
     requiresConnection: true,
   },
   {
@@ -132,7 +149,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'query',
     command: 'query',
     description: 'Run a read query through the permission, blacklist and audit gates.',
-    minimumPermission: 'query-only',
+    statementType: 'SELECT',
     requiresConnection: true,
   },
   {
@@ -140,7 +157,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'lint',
     command: 'lint',
     description: 'Statically analyse SQL without connecting to the database.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -148,7 +165,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'queryOutput',
     command: 'query',
     description: 'Render query results as a table, JSON or CSV.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -156,7 +173,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'queryLimitGuard',
     command: 'query',
     description: 'Bound result size automatically and report the limit that was applied.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -164,7 +181,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'shell',
     command: 'shell',
     description: 'Open an interactive gated query shell.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -172,7 +189,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'q',
     command: 'q',
     description: 'Execute a saved read-only query snippet with parameters.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -180,7 +197,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'queries',
     command: 'queries',
     description: 'Create, edit, search and validate saved query snippets.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -188,7 +205,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'insert',
     command: 'insert',
     description: 'Insert rows or documents through the write gate.',
-    minimumPermission: 'read-write',
+    statementType: 'INSERT',
     requiresConnection: true,
   },
   {
@@ -196,7 +213,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'update',
     command: 'update',
     description: 'Update rows or documents through the write gate.',
-    minimumPermission: 'read-write',
+    statementType: 'UPDATE',
     requiresConnection: true,
   },
   {
@@ -204,7 +221,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'delete',
     command: 'delete',
     description: 'Delete rows or documents through the write gate.',
-    minimumPermission: 'data-admin',
+    statementType: 'DELETE',
     requiresConnection: true,
   },
   {
@@ -212,7 +229,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'export',
     command: 'export',
     description: 'Export query or object contents to a file, subject to the blacklist.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -220,7 +237,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'check',
     command: 'check',
     description: 'Check data health: nulls, orphans, duplicates and empty strings.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -228,15 +245,16 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'blacklist',
     command: 'blacklist',
     description: 'Inspect and edit the table, column and key rules that hide sensitive data.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
+    mutatesConfiguration: true,
   },
   {
     id: 'context.inspect',
     key: 'inspect',
     command: 'inspect',
     description: 'Produce a bounded agent context snapshot of the configured database.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -244,7 +262,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'report',
     command: 'report',
     description: 'Produce a diagnostic report about the configured database.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -252,7 +270,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'guide',
     command: 'guide',
     description: 'Suggest the next deterministic command for a stated goal.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: true,
   },
   {
@@ -260,7 +278,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'recover',
     command: 'recover',
     description: 'Read the saved recovery envelope and plan or apply safe remediation steps.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -268,7 +286,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'auditTail',
     command: 'audit tail',
     description: 'Read recent audit entries from the local log.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -276,7 +294,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'auditShow',
     command: 'audit show',
     description: 'Look up one audit entry by id prefix or recovery reference.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -284,7 +302,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'auditHealth',
     command: 'audit health',
     description: 'Report audit log health and rotation state.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -292,7 +310,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'auditClear',
     command: 'audit clear',
     description: 'Remove the local audit log files for a connection.',
-    minimumPermission: 'admin',
+    permission: 'admin',
     requiresConnection: false,
   },
   {
@@ -300,7 +318,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'skill',
     command: 'skill',
     description: 'Write the dbcli skill and task-pack assets into a platform directory.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -308,7 +326,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'completion',
     command: 'completion',
     description: 'Emit a shell completion script for the current command tree.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
   {
@@ -316,7 +334,7 @@ const DECLARATIONS: readonly CapabilityDeclaration[] = [
     key: 'upgrade',
     command: 'upgrade',
     description: 'Check whether a newer dbcli release is available.',
-    minimumPermission: 'query-only',
+    permission: 'query-only',
     requiresConnection: false,
   },
 ]
@@ -348,6 +366,7 @@ export function riskForSideEffect(tier: SideEffectTier): CapabilityRisk {
 
 function enginesFor(key: CommandCapabilityKey): {
   engines: readonly DatabaseSystem[]
+  limitedEngines: readonly DatabaseSystem[]
   engineIndependent: boolean
 } {
   const statuses = DATABASE_SYSTEMS.map((system) => ({
@@ -359,12 +378,15 @@ function enginesFor(key: CommandCapabilityKey): {
   // at all, so every configured engine can run it. Listing none would read as
   // "supported nowhere", which is the opposite of what the matrix is saying.
   if (statuses.every((entry) => entry.status === 'not-applicable')) {
-    return { engines: [...DATABASE_SYSTEMS], engineIndependent: true }
+    return { engines: [...DATABASE_SYSTEMS], limitedEngines: [], engineIndependent: true }
   }
 
   return {
     engines: statuses
       .filter((entry) => entry.status === 'supported' || entry.status === 'limited')
+      .map((entry) => entry.system),
+    limitedEngines: statuses
+      .filter((entry) => entry.status === 'limited')
       .map((entry) => entry.system),
     engineIndependent: false,
   }
@@ -416,7 +438,7 @@ export interface CommandSurfaceFacts {
 /**
  * Which command paths expose a JSON output option, and which emit an evidence
  * receipt. Static, and asserted against the live Commander tree and the real
- * import graph by `tests/contract/capability-command-parity.test.ts`.
+ * import graph by `tests/contract/capability-contract.test.ts`.
  */
 export const COMMAND_SURFACE: CommandSurfaceFacts = Object.freeze({
   jsonCommands: Object.freeze(
@@ -452,8 +474,22 @@ export const COMMAND_SURFACE: CommandSurfaceFacts = Object.freeze({
   evidenceCommands: Object.freeze(new Set<string>()) as ReadonlySet<string>,
 })
 
+/**
+ * The permission below which the capability is refused.
+ *
+ * Derived from `minimumPermissionFor` — the same `TIER_GRANTS` table the runtime
+ * refusal consults — whenever the capability maps to a SQL statement type.
+ * Transcribing those four levels here would be a second permission ladder, and
+ * a second ladder diverges the first time a tier is added.
+ */
+function minimumPermissionOf(declaration: CapabilityDeclaration): Permission {
+  if (declaration.statementType) return minimumPermissionFor(declaration.statementType)
+  if (declaration.permission) return declaration.permission
+  throw new Error(`capability ${declaration.id} declares neither statementType nor permission`)
+}
+
 function build(declaration: CapabilityDeclaration, surface: CommandSurfaceFacts): Capability {
-  const { engines, engineIndependent } = enginesFor(declaration.key)
+  const { engines, limitedEngines, engineIndependent } = enginesFor(declaration.key)
   const sideEffect = sideEffectFor(declaration.key, engines)
 
   return Object.freeze({
@@ -463,9 +499,11 @@ function build(declaration: CapabilityDeclaration, surface: CommandSurfaceFacts)
     risk: riskForSideEffect(sideEffect),
     sideEffect,
     engines: Object.freeze([...engines]),
+    limitedEngines: Object.freeze([...limitedEngines]),
     engineIndependent,
-    minimumPermission: declaration.minimumPermission,
+    minimumPermission: minimumPermissionOf(declaration),
     requiresConnection: declaration.requiresConnection,
+    mutatesConfiguration: declaration.mutatesConfiguration ?? false,
     supportsJson: surface.jsonCommands.has(declaration.command),
     supportsEvidence: surface.evidenceCommands.has(declaration.command),
   })

--- a/src/core/capabilities/registry.ts
+++ b/src/core/capabilities/registry.ts
@@ -1,0 +1,510 @@
+/**
+ * The dbcli Capability Catalog.
+ *
+ * Per ADR-0022, `ENGINE_CAPABILITIES` in `src/adapters/capabilities.ts` is the
+ * authority for every engine and risk claim here. This module declares only
+ * what that matrix cannot know — the capability's id, its description, the CLI
+ * command path it maps to, and the permission level below which it is refused —
+ * and derives the rest. Nothing in this file may hard-code an engine list.
+ */
+
+import {
+  COMMAND_CAPABILITY_KEYS,
+  ENGINE_CAPABILITIES,
+  type CommandCapabilityKey,
+  type SideEffectTier,
+} from '@/adapters/capabilities'
+import { DATABASE_SYSTEMS, type DatabaseSystem } from '@/adapters/types'
+import type { Permission } from '@/types'
+import { CAPABILITY_CONTRACT_SCHEMA_VERSION, type Capability, type CapabilityRisk } from './types'
+
+/**
+ * Everything the matrix does not carry.
+ *
+ * `requiresConnection` is declared rather than derived because no existing
+ * structure records it: `status` says whether an engine supports the command,
+ * not whether running it opens a socket. The claim that matters — a capability
+ * saying it does *not* need a connection — is the one a caller would be misled
+ * by, so `tests/contract/capability-contract.test.ts` proves it against the
+ * command's static import graph rather than trusting this table.
+ */
+interface CapabilityDeclaration {
+  readonly id: string
+  readonly key: CommandCapabilityKey
+  readonly command: string
+  readonly description: string
+  readonly minimumPermission: Permission
+  readonly requiresConnection: boolean
+}
+
+/**
+ * Declared in source order for readability; the exported catalog is sorted by
+ * id, so this order is never observable.
+ *
+ * Ids read `<domain>.<ability>` and name what the *tool* can do. A job title or
+ * a method ("dba.tune", "cqrs.project") would belong to a Skill composing dbcli,
+ * never to dbcli itself.
+ */
+const DECLARATIONS: readonly CapabilityDeclaration[] = [
+  {
+    id: 'connection.init',
+    key: 'init',
+    command: 'init',
+    description: 'Create or update a local connection configuration interactively.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'connection.select',
+    key: 'use',
+    command: 'use',
+    description: 'Switch the default named connection in a v2 configuration.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'connection.status',
+    key: 'status',
+    command: 'status',
+    description:
+      'Report the configured engine, permission and blacklist counts without credentials.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'connection.diagnose',
+    key: 'doctor',
+    command: 'doctor',
+    description: 'Run engine-specific connectivity and configuration diagnostics.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.list-tables',
+    key: 'list',
+    command: 'list',
+    description: 'List the tables, collections or indices visible to the connection.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.read',
+    key: 'schema',
+    command: 'schema',
+    description: 'Read visible schema metadata for one object or the whole database.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.read-object',
+    key: 'schemaSingle',
+    command: 'schema',
+    description: 'Read the column or field structure of a single named object.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.scan',
+    key: 'schemaFullScan',
+    command: 'schema',
+    description: 'Scan every visible object and refresh the local schema cache.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.diff',
+    key: 'diff',
+    command: 'diff',
+    description: 'Compare schema snapshots and report structural differences.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'schema.migrate',
+    key: 'migrate',
+    command: 'migrate',
+    description: 'Apply guarded DDL changes such as columns, indexes and constraints.',
+    minimumPermission: 'admin',
+    requiresConnection: true,
+  },
+  {
+    id: 'query.read',
+    key: 'query',
+    command: 'query',
+    description: 'Run a read query through the permission, blacklist and audit gates.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'query.lint',
+    key: 'lint',
+    command: 'lint',
+    description: 'Statically analyse SQL without connecting to the database.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'query.format',
+    key: 'queryOutput',
+    command: 'query',
+    description: 'Render query results as a table, JSON or CSV.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'query.limit-guard',
+    key: 'queryLimitGuard',
+    command: 'query',
+    description: 'Bound result size automatically and report the limit that was applied.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'query.shell',
+    key: 'shell',
+    command: 'shell',
+    description: 'Open an interactive gated query shell.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'snippet.run',
+    key: 'q',
+    command: 'q',
+    description: 'Execute a saved read-only query snippet with parameters.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'snippet.manage',
+    key: 'queries',
+    command: 'queries',
+    description: 'Create, edit, search and validate saved query snippets.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'data.insert',
+    key: 'insert',
+    command: 'insert',
+    description: 'Insert rows or documents through the write gate.',
+    minimumPermission: 'read-write',
+    requiresConnection: true,
+  },
+  {
+    id: 'data.update',
+    key: 'update',
+    command: 'update',
+    description: 'Update rows or documents through the write gate.',
+    minimumPermission: 'read-write',
+    requiresConnection: true,
+  },
+  {
+    id: 'data.delete',
+    key: 'delete',
+    command: 'delete',
+    description: 'Delete rows or documents through the write gate.',
+    minimumPermission: 'data-admin',
+    requiresConnection: true,
+  },
+  {
+    id: 'data.export',
+    key: 'export',
+    command: 'export',
+    description: 'Export query or object contents to a file, subject to the blacklist.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'data.health-check',
+    key: 'check',
+    command: 'check',
+    description: 'Check data health: nulls, orphans, duplicates and empty strings.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'blacklist.manage',
+    key: 'blacklist',
+    command: 'blacklist',
+    description: 'Inspect and edit the table, column and key rules that hide sensitive data.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'context.inspect',
+    key: 'inspect',
+    command: 'inspect',
+    description: 'Produce a bounded agent context snapshot of the configured database.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'diagnostic.report',
+    key: 'report',
+    command: 'report',
+    description: 'Produce a diagnostic report about the configured database.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'guide.plan',
+    key: 'guide',
+    command: 'guide',
+    description: 'Suggest the next deterministic command for a stated goal.',
+    minimumPermission: 'query-only',
+    requiresConnection: true,
+  },
+  {
+    id: 'recovery.plan',
+    key: 'recover',
+    command: 'recover',
+    description: 'Read the saved recovery envelope and plan or apply safe remediation steps.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'audit.tail',
+    key: 'auditTail',
+    command: 'audit tail',
+    description: 'Read recent audit entries from the local log.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'audit.show',
+    key: 'auditShow',
+    command: 'audit show',
+    description: 'Look up one audit entry by id prefix or recovery reference.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'audit.health',
+    key: 'auditHealth',
+    command: 'audit health',
+    description: 'Report audit log health and rotation state.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'audit.clear',
+    key: 'auditClear',
+    command: 'audit clear',
+    description: 'Remove the local audit log files for a connection.',
+    minimumPermission: 'admin',
+    requiresConnection: false,
+  },
+  {
+    id: 'skill.install',
+    key: 'skill',
+    command: 'skill',
+    description: 'Write the dbcli skill and task-pack assets into a platform directory.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'shell-completion.generate',
+    key: 'completion',
+    command: 'completion',
+    description: 'Emit a shell completion script for the current command tree.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+  {
+    id: 'package.upgrade-check',
+    key: 'upgrade',
+    command: 'upgrade',
+    description: 'Check whether a newer dbcli release is available.',
+    minimumPermission: 'query-only',
+    requiresConnection: false,
+  },
+]
+
+/**
+ * Fold the six-value side-effect tier into the four-value risk vocabulary the
+ * Agent Task Pack contract already uses.
+ *
+ * `local-write` and `db-write` both become `write`; the caller that needs them
+ * apart reads `sideEffect`, which is carried unfolded. `interactive` is `write`
+ * rather than `unknown` because a REPL's ceiling is whatever the session's
+ * permission allows, and describing that as unknown would understate it.
+ */
+export function riskForSideEffect(tier: SideEffectTier): CapabilityRisk {
+  switch (tier) {
+    case 'readonly':
+    case 'none':
+      return 'readonly'
+    case 'dry-run':
+      return 'dry-run'
+    case 'local-write':
+    case 'db-write':
+    case 'interactive':
+      return 'write'
+    default:
+      return 'unknown'
+  }
+}
+
+function enginesFor(key: CommandCapabilityKey): {
+  engines: readonly DatabaseSystem[]
+  engineIndependent: boolean
+} {
+  const statuses = DATABASE_SYSTEMS.map((system) => ({
+    system,
+    status: ENGINE_CAPABILITIES[system][key].status,
+  }))
+
+  // `not-applicable` everywhere means the command does not consult the engine
+  // at all, so every configured engine can run it. Listing none would read as
+  // "supported nowhere", which is the opposite of what the matrix is saying.
+  if (statuses.every((entry) => entry.status === 'not-applicable')) {
+    return { engines: [...DATABASE_SYSTEMS], engineIndependent: true }
+  }
+
+  return {
+    engines: statuses
+      .filter((entry) => entry.status === 'supported' || entry.status === 'limited')
+      .map((entry) => entry.system),
+    engineIndependent: false,
+  }
+}
+
+/**
+ * The tier a capability is published with.
+ *
+ * A key may carry different tiers per engine. The published risk is the most
+ * severe one among the engines that actually support it, so a caller reading
+ * the catalog before choosing an engine is never told something is cheaper than
+ * it can be.
+ */
+const TIER_SEVERITY: Readonly<Record<SideEffectTier, number>> = Object.freeze({
+  none: 0,
+  readonly: 1,
+  'dry-run': 2,
+  'local-write': 3,
+  interactive: 4,
+  'db-write': 5,
+})
+
+function sideEffectFor(
+  key: CommandCapabilityKey,
+  engines: readonly DatabaseSystem[]
+): SideEffectTier {
+  const considered = engines.length > 0 ? engines : DATABASE_SYSTEMS
+  let worst: SideEffectTier = 'none'
+  for (const system of considered) {
+    const tier = ENGINE_CAPABILITIES[system][key].tier
+    if (TIER_SEVERITY[tier] > TIER_SEVERITY[worst]) worst = tier
+  }
+  return worst
+}
+
+/**
+ * Facts about the command surface that only the CLI layer can answer.
+ *
+ * Passed in rather than imported so this module stays free of Commander and of
+ * the command modules' import graphs: `capabilities` must not drag forty
+ * command modules — or a database adapter — into memory to describe itself. The
+ * contract test supplies the real values from the live tree.
+ */
+export interface CommandSurfaceFacts {
+  readonly jsonCommands: ReadonlySet<string>
+  readonly evidenceCommands: ReadonlySet<string>
+}
+
+/**
+ * Which command paths expose a JSON output option, and which emit an evidence
+ * receipt. Static, and asserted against the live Commander tree and the real
+ * import graph by `tests/contract/capability-command-parity.test.ts`.
+ */
+export const COMMAND_SURFACE: CommandSurfaceFacts = Object.freeze({
+  jsonCommands: Object.freeze(
+    // Exactly the paths whose own Commander node offers `--format json` or
+    // `--json`. `blacklist`, `migrate` and `queries` are absent on purpose:
+    // JSON lives on their subcommands, and a capability may only claim what
+    // the path it names actually offers. The contract test derives this same
+    // set from the live tree and fails on any disagreement.
+    new Set([
+      'use',
+      'status',
+      'doctor',
+      'list',
+      'schema',
+      'diff',
+      'query',
+      'lint',
+      'q',
+      'insert',
+      'update',
+      'delete',
+      'export',
+      'check',
+      'inspect',
+      'report',
+      'guide',
+      'recover',
+      'audit tail',
+      'audit show',
+      'audit health',
+    ])
+  ) as ReadonlySet<string>,
+  evidenceCommands: Object.freeze(new Set<string>()) as ReadonlySet<string>,
+})
+
+function build(declaration: CapabilityDeclaration, surface: CommandSurfaceFacts): Capability {
+  const { engines, engineIndependent } = enginesFor(declaration.key)
+  const sideEffect = sideEffectFor(declaration.key, engines)
+
+  return Object.freeze({
+    id: declaration.id,
+    description: declaration.description,
+    command: declaration.command,
+    risk: riskForSideEffect(sideEffect),
+    sideEffect,
+    engines: Object.freeze([...engines]),
+    engineIndependent,
+    minimumPermission: declaration.minimumPermission,
+    requiresConnection: declaration.requiresConnection,
+    supportsJson: surface.jsonCommands.has(declaration.command),
+    supportsEvidence: surface.evidenceCommands.has(declaration.command),
+  })
+}
+
+/**
+ * Every capability, sorted by id.
+ *
+ * Sorting is the whole determinism guarantee: two builds of the same version
+ * emit byte-identical catalogs regardless of declaration order, so a consumer
+ * can diff two outputs and see only real changes.
+ */
+export const CAPABILITIES: readonly Capability[] = Object.freeze(
+  DECLARATIONS.map((declaration) => build(declaration, COMMAND_SURFACE)).sort((left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0
+  )
+)
+
+const BY_ID: ReadonlyMap<string, Capability> = new Map(
+  CAPABILITIES.map((capability) => [capability.id, capability])
+)
+
+export function findCapability(id: string): Capability | undefined {
+  return BY_ID.get(id)
+}
+
+export function listCapabilityIds(): readonly string[] {
+  return CAPABILITIES.map((capability) => capability.id)
+}
+
+/** The catalog as an external consumer receives it. */
+export function buildCapabilityCatalog(): {
+  schemaVersion: typeof CAPABILITY_CONTRACT_SCHEMA_VERSION
+  capabilities: readonly Capability[]
+} {
+  return { schemaVersion: CAPABILITY_CONTRACT_SCHEMA_VERSION, capabilities: CAPABILITIES }
+}
+
+/** The declaration table, exposed so contract tests can check key coverage. */
+export const CAPABILITY_DECLARATIONS = DECLARATIONS
+export const DECLARED_CAPABILITY_KEYS: readonly CommandCapabilityKey[] =
+  Object.freeze(COMMAND_CAPABILITY_KEYS)

--- a/src/core/capabilities/schema.ts
+++ b/src/core/capabilities/schema.ts
@@ -1,0 +1,113 @@
+/**
+ * Strict runtime schemas for the capability contract.
+ *
+ * These exist for the *consumer's* benefit: an external Skill that pins
+ * `schemaVersion: 1` can validate what it received rather than trusting a shape
+ * it was handed. `.strict()` throughout is the point — an unknown field means
+ * the producer is speaking a dialect this reader does not know, and accepting
+ * it silently is how a contract stops being one.
+ */
+
+import { z } from 'zod'
+import { DATABASE_SYSTEMS } from '@/adapters/types'
+import { CAPABILITY_CONTRACT_SCHEMA_VERSION } from './types'
+import type { CapabilityCatalog, CapabilityCheckReport } from './types'
+
+export class CapabilityContractError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CapabilityContractError'
+    Object.setPrototypeOf(this, CapabilityContractError.prototype)
+  }
+}
+
+const PermissionSchema = z.enum(['query-only', 'read-write', 'data-admin', 'admin'])
+const EngineSchema = z.enum(DATABASE_SYSTEMS)
+const RiskSchema = z.enum(['readonly', 'dry-run', 'write', 'unknown'])
+const SideEffectSchema = z.enum([
+  'readonly',
+  'dry-run',
+  'local-write',
+  'db-write',
+  'interactive',
+  'none',
+])
+
+/** Dotted lower-case segments, e.g. `schema.read-object`. */
+const CapabilityIdSchema = z.string().regex(/^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/, {
+  message: 'capability id must be dotted lower-case segments, e.g. schema.read',
+})
+
+export const CapabilitySchema = z
+  .object({
+    id: CapabilityIdSchema,
+    description: z.string().min(1),
+    command: z.string().min(1),
+    risk: RiskSchema,
+    sideEffect: SideEffectSchema,
+    engines: z.array(EngineSchema),
+    engineIndependent: z.boolean(),
+    minimumPermission: PermissionSchema,
+    requiresConnection: z.boolean(),
+    supportsJson: z.boolean(),
+    supportsEvidence: z.boolean(),
+  })
+  .strict()
+
+export const CapabilityCatalogSchema = z
+  .object({
+    schemaVersion: z.literal(CAPABILITY_CONTRACT_SCHEMA_VERSION),
+    capabilities: z.array(CapabilitySchema),
+  })
+  .strict()
+
+const CheckContextSchema = z
+  .object({
+    engine: EngineSchema,
+    permission: PermissionSchema,
+    connectionName: z.string().nullable(),
+  })
+  .strict()
+
+const CheckResultSchema = z
+  .object({
+    id: z.string().min(1),
+    status: z.enum(['available', 'unavailable', 'unknown']),
+    reason: z
+      .enum(['unknown-capability', 'context-unavailable', 'engine', 'permission'])
+      .nullable(),
+  })
+  .strict()
+
+export const CapabilityCheckReportSchema = z
+  .object({
+    schemaVersion: z.literal(CAPABILITY_CONTRACT_SCHEMA_VERSION),
+    ok: z.boolean(),
+    required: z.array(z.string().min(1)),
+    context: CheckContextSchema.nullable(),
+    results: z.array(CheckResultSchema),
+    warnings: z.array(z.string()),
+  })
+  .strict()
+
+function parse<T>(schema: z.ZodType<T>, value: unknown, what: string): T {
+  const result = schema.safeParse(value)
+  if (result.success) return result.data
+  throw new CapabilityContractError(
+    `${what} does not match capability contract v${CAPABILITY_CONTRACT_SCHEMA_VERSION}: ${result.error.issues
+      .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ')}`
+  )
+}
+
+export function parseCapabilityCatalog(value: unknown): CapabilityCatalog {
+  return parse(CapabilityCatalogSchema, value, 'capability catalog') as CapabilityCatalog
+}
+
+export function parseCapabilityCheckReport(value: unknown): CapabilityCheckReport {
+  return parse(
+    CapabilityCheckReportSchema,
+    value,
+    'capability check report'
+  ) as CapabilityCheckReport
+}

--- a/src/core/capabilities/schema.ts
+++ b/src/core/capabilities/schema.ts
@@ -46,9 +46,11 @@ export const CapabilitySchema = z
     risk: RiskSchema,
     sideEffect: SideEffectSchema,
     engines: z.array(EngineSchema),
+    limitedEngines: z.array(EngineSchema),
     engineIndependent: z.boolean(),
     minimumPermission: PermissionSchema,
     requiresConnection: z.boolean(),
+    mutatesConfiguration: z.boolean(),
     supportsJson: z.boolean(),
     supportsEvidence: z.boolean(),
   })
@@ -65,7 +67,12 @@ const CheckContextSchema = z
   .object({
     engine: EngineSchema,
     permission: PermissionSchema,
-    connectionName: z.string().nullable(),
+    // Bounded because it is the one field carrying a user-supplied string
+    // straight back out. The value is a connection label the user chose, so it
+    // is not untrusted in the usual sense, but an unbounded echo is still an
+    // echo.
+    connectionName: z.string().max(200).nullable(),
+    agentMode: z.boolean(),
   })
   .strict()
 
@@ -74,7 +81,14 @@ const CheckResultSchema = z
     id: z.string().min(1),
     status: z.enum(['available', 'unavailable', 'unknown']),
     reason: z
-      .enum(['unknown-capability', 'context-unavailable', 'engine', 'permission'])
+      .enum([
+        'unknown-capability',
+        'context-unavailable',
+        'context-unresolvable',
+        'engine',
+        'agent-mode',
+        'permission',
+      ])
       .nullable(),
   })
   .strict()

--- a/src/core/capabilities/types.ts
+++ b/src/core/capabilities/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Agent-facing Capability Contract — types.
+ *
+ * A capability names an *atomic tool ability* dbcli has ("read visible schema
+ * metadata"), never a job or a method ("review this migration as a DBA"). Role
+ * and method knowledge belongs in the Skills that compose dbcli, not in dbcli.
+ *
+ * `CAPABILITY_CONTRACT_SCHEMA_VERSION` is the contract's own version and is
+ * deliberately independent of the npm package version, matching ADR 0013 for
+ * the verification artifact. A consumer pins this number, not `7.x`.
+ */
+
+import type { DatabaseSystem } from '@/adapters/types'
+import type { SideEffectTier } from '@/adapters/capabilities'
+import type { Permission } from '@/types'
+
+export const CAPABILITY_CONTRACT_SCHEMA_VERSION = 1 as const
+
+/**
+ * Risk vocabulary, reused verbatim from the Agent Task Pack contract
+ * (`AgentTaskRisk`) so a pack's step risk and a capability's risk are the same
+ * four words. `sideEffect` carries the finer existing `SideEffectTier` beside
+ * it, because collapsing `local-write` and `db-write` into `write` would hide
+ * the one distinction a caller most needs.
+ */
+export type CapabilityRisk = 'readonly' | 'dry-run' | 'write' | 'unknown'
+
+export interface Capability {
+  /** Stable dotted id, e.g. `schema.read`. The value external Skills pin. */
+  readonly id: string
+  readonly description: string
+  /** Space-separated live CLI command path, e.g. `audit tail`. */
+  readonly command: string
+  readonly risk: CapabilityRisk
+  /** The precise pre-existing side-effect tier this risk was derived from. */
+  readonly sideEffect: SideEffectTier
+  /** Engines on which the capability is supported or limited, sorted. */
+  readonly engines: readonly DatabaseSystem[]
+  /** True when the capability works irrespective of the configured engine. */
+  readonly engineIndependent: boolean
+  readonly minimumPermission: Permission
+  readonly requiresConnection: boolean
+  readonly supportsJson: boolean
+  readonly supportsEvidence: boolean
+}
+
+export interface CapabilityCatalog {
+  readonly schemaVersion: typeof CAPABILITY_CONTRACT_SCHEMA_VERSION
+  readonly capabilities: readonly Capability[]
+}
+
+// ── capabilities check ───────────────────────────────────
+
+export type CapabilityCheckStatus = 'available' | 'unavailable' | 'unknown'
+
+/**
+ * Why a capability is not available. `null` only ever accompanies `available`.
+ *
+ * `context-unavailable` is distinct from `engine`/`permission` on purpose: with
+ * no local config there is nothing to evaluate against, and reporting that as
+ * an engine mismatch would invent a fact. It is still not `available` — absence
+ * of context never reads as permission to act.
+ */
+export type CapabilityUnavailableReason =
+  | 'unknown-capability'
+  | 'context-unavailable'
+  | 'engine'
+  | 'permission'
+
+export interface CapabilityCheckContext {
+  readonly engine: DatabaseSystem
+  readonly permission: Permission
+  /** Named v2 connection in effect, or null for a v1/single-connection config. */
+  readonly connectionName: string | null
+}
+
+export interface CapabilityCheckResultEntry {
+  readonly id: string
+  readonly status: CapabilityCheckStatus
+  readonly reason: CapabilityUnavailableReason | null
+}
+
+export interface CapabilityCheckReport {
+  readonly schemaVersion: typeof CAPABILITY_CONTRACT_SCHEMA_VERSION
+  readonly ok: boolean
+  /** The de-duplicated requirement list, in first-seen order. */
+  readonly required: readonly string[]
+  readonly context: CapabilityCheckContext | null
+  readonly results: readonly CapabilityCheckResultEntry[]
+  readonly warnings: readonly string[]
+}

--- a/src/core/capabilities/types.ts
+++ b/src/core/capabilities/types.ts
@@ -36,10 +36,24 @@ export interface Capability {
   readonly sideEffect: SideEffectTier
   /** Engines on which the capability is supported or limited, sorted. */
   readonly engines: readonly DatabaseSystem[]
+  /**
+   * The subset of `engines` the matrix marks `limited` rather than `supported`.
+   *
+   * Carried separately because folding it into `engines` would discard
+   * information the matrix already holds: `data.delete` works on Redis, but not
+   * the way it works on PostgreSQL, and a caller choosing an engine deserves to
+   * know which before it commits.
+   */
+  readonly limitedEngines: readonly DatabaseSystem[]
   /** True when the capability works irrespective of the configured engine. */
   readonly engineIndependent: boolean
   readonly minimumPermission: Permission
   readonly requiresConnection: boolean
+  /**
+   * True when the capability changes connection identity, permission or
+   * credentials — the class of change `DBCLI_AGENT_MODE=1` refuses outright.
+   */
+  readonly mutatesConfiguration: boolean
   readonly supportsJson: boolean
   readonly supportsEvidence: boolean
 }
@@ -60,11 +74,28 @@ export type CapabilityCheckStatus = 'available' | 'unavailable' | 'unknown'
  * no local config there is nothing to evaluate against, and reporting that as
  * an engine mismatch would invent a fact. It is still not `available` — absence
  * of context never reads as permission to act.
+ *
+ * `context-unresolvable` is a *different* fact from `context-unavailable`, and
+ * conflating them was a real defect: a config whose `{"$env": "..."}` password
+ * reference points at an unset variable is present and perfectly readable, and
+ * reporting "no configuration was readable" there states something false. This
+ * command needs no credential, but the one config reader resolves them before
+ * it will answer, so the honest report is "a config exists and could not be
+ * turned into an evaluable context" — never "there is no config".
+ *
+ * `agent-mode` is an environment gate, not an execution-time one. Under
+ * `DBCLI_AGENT_MODE=1` every configuration, permission and credential change is
+ * refused unconditionally, and that is fully knowable without connecting. The
+ * "available is not approval" disclaimer does not cover it: blacklist and human
+ * consent are decided at execution time, whereas this is decided here, and the
+ * contract's primary consumer is exactly the agent the flag describes.
  */
 export type CapabilityUnavailableReason =
   | 'unknown-capability'
   | 'context-unavailable'
+  | 'context-unresolvable'
   | 'engine'
+  | 'agent-mode'
   | 'permission'
 
 export interface CapabilityCheckContext {
@@ -72,7 +103,18 @@ export interface CapabilityCheckContext {
   readonly permission: Permission
   /** Named v2 connection in effect, or null for a v1/single-connection config. */
   readonly connectionName: string | null
+  /** `DBCLI_AGENT_MODE=1`: configuration changes are refused unconditionally. */
+  readonly agentMode: boolean
 }
+
+/**
+ * Why there is no context, when there is none.
+ *
+ * `absent` means nothing is configured here. `unresolvable` means something is,
+ * and it could not be turned into an engine and a permission. Only the first
+ * justifies telling a caller there is no configuration.
+ */
+export type CapabilityContextFailure = 'absent' | 'unresolvable'
 
 export interface CapabilityCheckResultEntry {
   readonly id: string

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -473,14 +473,11 @@ export function enforcePermission(
   return result.classification
 }
 
-/** Permission ordering helper. Higher rank = more powerful tier. */
-const PERMISSION_RANK: Record<Permission, number> = {
-  'query-only': 1,
-  'read-write': 2,
-  'data-admin': 3,
-  admin: 4,
-}
-
-export function permissionAtLeast(actual: Permission, required: Permission): boolean {
-  return PERMISSION_RANK[actual] >= PERMISSION_RANK[required]
-}
+/**
+ * Permission ordering helper. Higher rank = more powerful tier.
+ *
+ * Defined in `@/core/permission/rank` so callers needing only the ladder do not
+ * pull this module's i18n and SQL-analysis graph in with it; re-exported here
+ * because this is where every existing caller imports it from.
+ */
+export { PERMISSION_RANK, permissionAtLeast } from '@/core/permission/rank'

--- a/src/core/permission-guard.ts
+++ b/src/core/permission-guard.ts
@@ -479,5 +479,9 @@ export function enforcePermission(
  * Defined in `@/core/permission/rank` so callers needing only the ladder do not
  * pull this module's i18n and SQL-analysis graph in with it; re-exported here
  * because this is where every existing caller imports it from.
+ *
+ * `PERMISSION_RANK` itself is deliberately not re-exported: it was module-private
+ * before the extraction and nothing outside the ladder reads it, so forwarding it
+ * would widen this module's surface as a side effect of moving a function.
  */
-export { PERMISSION_RANK, permissionAtLeast } from '@/core/permission/rank'
+export { permissionAtLeast } from '@/core/permission/rank'

--- a/src/core/permission/rank.ts
+++ b/src/core/permission/rank.ts
@@ -1,0 +1,25 @@
+/**
+ * The permission ladder, on its own.
+ *
+ * `permissionAtLeast` lived in `permission-guard.ts`, which pulls in the i18n
+ * catalogue and the SQL analyser. Anything wanting only "is this level at least
+ * that one?" — the capability contract, for instance — had the choice of
+ * dragging that graph in or re-declaring the ranks, and a re-declared ladder is
+ * a second authority that drifts the first time a tier is added.
+ *
+ * `permission-guard.ts` re-exports these, so its callers are unaffected.
+ */
+
+import type { Permission } from '@/types'
+
+/** Higher rank = more powerful tier. */
+export const PERMISSION_RANK: Readonly<Record<Permission, number>> = Object.freeze({
+  'query-only': 1,
+  'read-write': 2,
+  'data-admin': 3,
+  admin: 4,
+})
+
+export function permissionAtLeast(actual: Permission, required: Permission): boolean {
+  return PERMISSION_RANK[actual] >= PERMISSION_RANK[required]
+}

--- a/src/core/public.ts
+++ b/src/core/public.ts
@@ -88,6 +88,7 @@ export type {
   CapabilityCatalog,
   CapabilityRisk,
   CapabilityCheckContext,
+  CapabilityContextFailure,
   CapabilityCheckReport,
   CapabilityCheckResultEntry,
   CapabilityCheckStatus,

--- a/src/core/public.ts
+++ b/src/core/public.ts
@@ -66,6 +66,34 @@ export {
 } from '@/core/config-binding'
 export type { DbcliConfigV2 } from '@/utils/validation'
 
+// ── Capability contract (agent-facing discovery) ─────────
+// Pure data and pure functions: no adapter, no filesystem, no environment.
+// It lives here rather than in `agent-core` because the catalog names engines
+// and `check-agent-core-purity.ts` forbids that word there — see ADR-0022.
+export {
+  CAPABILITY_CONTRACT_SCHEMA_VERSION,
+  CAPABILITIES,
+  buildCapabilityCatalog,
+  findCapability,
+  listCapabilityIds,
+  checkCapabilities,
+  parseRequirements,
+  parseCapabilityCatalog,
+  parseCapabilityCheckReport,
+  CapabilityRequirementError,
+  CapabilityContractError,
+} from '@/core/capabilities'
+export type {
+  Capability,
+  CapabilityCatalog,
+  CapabilityRisk,
+  CapabilityCheckContext,
+  CapabilityCheckReport,
+  CapabilityCheckResultEntry,
+  CapabilityCheckStatus,
+  CapabilityUnavailableReason,
+} from '@/core/capabilities'
+
 // ── Safety ───────────────────────────────────────────────
 export { BlacklistManager } from '@/core/blacklist-manager'
 export { BlacklistValidator, BlacklistError } from '@/core/blacklist-validator'

--- a/src/program-lazy.ts
+++ b/src/program-lazy.ts
@@ -277,6 +277,12 @@ export const COMMAND_LOADERS: Record<string, () => Promise<(program: Command) =>
       program.addCommand(impactCommand)
     }
   },
+  capabilities: async () => {
+    const { capabilitiesCommand } = await import('./commands/capabilities')
+    return (program) => {
+      program.addCommand(capabilitiesCommand)
+    }
+  },
 }
 
 export const COMMAND_NAMES: readonly string[] = Object.keys(COMMAND_LOADERS)

--- a/src/program.ts
+++ b/src/program.ts
@@ -43,6 +43,7 @@ import { backfillCommand } from './commands/backfill'
 import { evidenceCommand } from './commands/evidence'
 import { contractCommand } from './commands/contracts'
 import { impactCommand } from './commands/impact'
+import { capabilitiesCommand } from './commands/capabilities'
 import {
   registerQueryCommand,
   registerPlanCommand,
@@ -137,6 +138,7 @@ export function buildProgram(): Command {
   program.addCommand(evidenceCommand)
   program.addCommand(contractCommand)
   program.addCommand(impactCommand)
+  program.addCommand(capabilitiesCommand)
 
   return program
 }

--- a/tests/contract/capability-contract.test.ts
+++ b/tests/contract/capability-contract.test.ts
@@ -18,6 +18,9 @@ import { buildCompletionTree, findCommandPath } from '../../src/core/completion/
 import { CAPABILITIES, COMMAND_SURFACE } from '../../src/core/capabilities'
 import { COMMAND_LOADERS } from '../../src/program-lazy'
 
+/** Forward-slash form of a path, so the `/src/...` filters below hold on Windows too. */
+const toPosix = (file: string): string => file.replaceAll('\\', '/')
+
 const SRC = resolve(import.meta.dir, '../../src')
 const tree = buildCompletionTree(buildProgram())
 
@@ -97,7 +100,7 @@ async function importGraph(entry: string): Promise<Set<string>> {
   const queue = [entry]
 
   while (queue.length > 0) {
-    const file = queue.pop()!
+    const file = toPosix(queue.pop()!)
     if (seen.has(file)) continue
     seen.add(file)
 

--- a/tests/contract/capability-contract.test.ts
+++ b/tests/contract/capability-contract.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Capability contract — structural gates (DBCLI-PLAT-001/002/003).
+ *
+ * ADR-0022 makes three claims that only hold if something checks them:
+ *
+ *   1. the catalog's command paths track the live Commander tree,
+ *   2. capability discovery never reaches a database adapter, and
+ *   3. `supportsJson` / `supportsEvidence` describe the real command surface.
+ *
+ * Each is asserted here against the real tree and the real import graph, not
+ * against a restatement of the declaration table.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { buildProgram } from '../../src/program'
+import { buildCompletionTree, findCommandPath } from '../../src/core/completion/command-tree'
+import { CAPABILITIES, COMMAND_SURFACE } from '../../src/core/capabilities'
+import { COMMAND_LOADERS } from '../../src/program-lazy'
+
+const SRC = resolve(import.meta.dir, '../../src')
+const tree = buildCompletionTree(buildProgram())
+
+/** Every distinct command path the catalog names. */
+const commandPaths = [...new Set(CAPABILITIES.map((capability) => capability.command))].sort()
+
+// ── 1. the catalog cannot drift from the live command tree ───────────────
+
+describe('capability command parity', () => {
+  test.each(commandPaths)('`dbcli %s` is a live command', (path) => {
+    expect(findCommandPath(tree, path.split(' '))).toBeDefined()
+  })
+
+  test('`capabilities` itself is registered on both the eager and lazy paths', () => {
+    expect(findCommandPath(tree, ['capabilities'])).toBeDefined()
+    expect(findCommandPath(tree, ['capabilities', 'check'])).toBeDefined()
+    expect(Object.keys(COMMAND_LOADERS)).toContain('capabilities')
+  })
+
+  test('a command declared to support JSON really offers a JSON output option', () => {
+    for (const path of COMMAND_SURFACE.jsonCommands) {
+      const node = findCommandPath(tree, path.split(' '))
+      expect({ path, found: node !== undefined }).toEqual({ path, found: true })
+
+      const offersJson = node!.options.some(
+        (option) =>
+          option.long === '--json' ||
+          (option.long === '--format' && /json/i.test(option.description))
+      )
+      expect({ path, offersJson }).toEqual({ path, offersJson: true })
+    }
+  })
+
+  test('the declared JSON surface is exactly what the live tree offers', () => {
+    // Both directions. A `--format json` added to `migrate` later must not
+    // leave the catalog quietly saying it has none.
+    const derived = new Set<string>()
+    for (const path of commandPaths) {
+      const node = findCommandPath(tree, path.split(' '))
+      if (!node) continue
+      const offersJson = node.options.some(
+        (option) =>
+          option.long === '--json' ||
+          (option.long === '--format' && /json/i.test(option.description))
+      )
+      if (offersJson) derived.add(path)
+    }
+    const declared = new Set(
+      [...COMMAND_SURFACE.jsonCommands].filter((p) => commandPaths.includes(p))
+    )
+    expect([...declared].sort()).toEqual([...derived].sort())
+  })
+
+  test('supportsJson on a capability matches its command', () => {
+    for (const capability of CAPABILITIES) {
+      expect({ id: capability.id, json: capability.supportsJson }).toEqual({
+        id: capability.id,
+        json: COMMAND_SURFACE.jsonCommands.has(capability.command),
+      })
+    }
+  })
+})
+
+// ── 2. discovery never reaches a database adapter ────────────────────────
+
+/**
+ * Walk the static import graph from an entry module, staying inside `src/`.
+ *
+ * Textual, matching the sibling purity gates: a dynamic import built from a
+ * variable is invisible here. That is accepted for the same reason it is
+ * accepted there — this guards against drift by ordinary edits, not against
+ * deliberate circumvention — and the capability modules contain no dynamic
+ * imports at all, which this test also asserts.
+ */
+async function importGraph(entry: string): Promise<Set<string>> {
+  const seen = new Set<string>()
+  const queue = [entry]
+
+  while (queue.length > 0) {
+    const file = queue.pop()!
+    if (seen.has(file)) continue
+    seen.add(file)
+
+    let source: string
+    try {
+      source = await readFile(file, 'utf8')
+    } catch {
+      continue
+    }
+
+    const specifiers = [
+      ...source.matchAll(
+        /\b(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?['"]([^'"]+)['"]/g
+      ),
+      ...source.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g),
+    ].map((match) => match[1]!)
+
+    for (const specifier of specifiers) {
+      // Never traverse the registration roots. `completion` imports the whole
+      // command tree by design, so following that edge would report every
+      // command as depending on every other one — a fact about registration,
+      // not about what this command does.
+      if (/^(@\/)?\.{0,2}\/?program(-lazy|-root)?$/.test(specifier)) continue
+
+      let target: string | undefined
+      if (specifier.startsWith('@/')) target = join(SRC, specifier.slice(2))
+      else if (specifier.startsWith('.')) target = resolve(dirname(file), specifier)
+      if (!target) continue
+
+      for (const candidate of [`${target}.ts`, join(target, 'index.ts'), target]) {
+        if (await Bun.file(candidate).exists()) {
+          queue.push(candidate)
+          break
+        }
+      }
+    }
+  }
+  return seen
+}
+
+const ADAPTER_MODULES = /\/src\/adapters\/(?!types\.ts$|capabilities\.ts$)/
+
+describe('capability discovery stays offline', () => {
+  test('the capability core loads no database adapter', async () => {
+    const graph = await importGraph(join(SRC, 'core/capabilities/index.ts'))
+    const adapters = [...graph].filter((file) => ADAPTER_MODULES.test(file))
+    expect(adapters).toEqual([])
+  })
+
+  test('the capability core imports only the two type-level adapter modules', async () => {
+    const graph = await importGraph(join(SRC, 'core/capabilities/index.ts'))
+    const fromAdapters = [...graph]
+      .filter((file) => file.includes('/src/adapters/'))
+      .map((file) => file.slice(file.indexOf('/src/adapters/')))
+      .sort()
+    expect(fromAdapters).toEqual(['/src/adapters/capabilities.ts', '/src/adapters/types.ts'])
+  })
+
+  test('the capability core does not read the filesystem, env or process', async () => {
+    const graph = await importGraph(join(SRC, 'core/capabilities/index.ts'))
+    for (const file of graph) {
+      if (!file.includes('/src/core/capabilities/')) continue
+      const source = await readFile(file, 'utf8')
+      expect({ file, hit: /\bprocess\s*\.\s*env\b/.test(source) }).toEqual({ file, hit: false })
+      expect({ file, hit: /\bBun\s*\.\s*file\s*\(/.test(source) }).toEqual({ file, hit: false })
+      expect({ file, hit: /from ['"]node:fs/.test(source) }).toEqual({ file, hit: false })
+      expect({ file, hit: /\bimport\s*\(/.test(source) }).toEqual({ file, hit: false })
+    }
+  })
+
+  test('a capability claiming no connection has a command that loads no adapter', async () => {
+    // Only this direction is checked. A false `requiresConnection` would tell a
+    // Skill it can run offline when it cannot, which is the failure that costs
+    // something; a conservative `true` merely under-promises.
+    for (const capability of CAPABILITIES) {
+      if (capability.requiresConnection) continue
+      const entry = join(SRC, `commands/${capability.command.split(' ')[0]}.ts`)
+      if (!(await Bun.file(entry).exists())) continue
+
+      const graph = await importGraph(entry)
+      const adapters = [...graph]
+        .filter((file) => ADAPTER_MODULES.test(file))
+        .map((file) => file.slice(file.indexOf('/src/adapters/')))
+      expect({ id: capability.id, adapters }).toEqual({ id: capability.id, adapters: [] })
+    }
+  })
+
+  test('the capabilities command never constructs a database connection', async () => {
+    const graph = await importGraph(join(SRC, 'commands/capabilities.ts'))
+    const connectionFactories = [...graph].filter((file) =>
+      /\/src\/adapters\/(index|factory|postgresql|mysql|mongo|redis|elasticsearch)/.test(file)
+    )
+    expect(connectionFactories).toEqual([])
+  })
+})
+
+// ── 3. evidence claims track the real evidence subsystem ─────────────────
+
+describe('capability evidence parity', () => {
+  test('no v1 capability claims evidence support', () => {
+    // The evidence receipt is emitted by `assert`, `verify` and `evidence`,
+    // none of which the v1 catalog covers (ADR-0022). A `true` here without a
+    // corresponding receipt would be a promise nothing keeps.
+    expect(COMMAND_SURFACE.evidenceCommands.size).toBe(0)
+    expect(CAPABILITIES.every((capability) => !capability.supportsEvidence)).toBe(true)
+  })
+
+  test('no catalogued command reaches the evidence receipt subsystem', async () => {
+    for (const path of commandPaths) {
+      const entry = join(SRC, `commands/${path.split(' ')[0]}.ts`)
+      if (!(await Bun.file(entry).exists())) continue
+      const graph = await importGraph(entry)
+      const emitsReceipt = [...graph].some((file) => file.includes('/src/core/evidence-receipt/'))
+      expect({ path, emitsReceipt }).toEqual({ path, emitsReceipt: false })
+    }
+  })
+})

--- a/tests/contract/capability-contract.test.ts
+++ b/tests/contract/capability-contract.test.ts
@@ -194,6 +194,103 @@ describe('capability discovery stays offline', () => {
   })
 })
 
+/**
+ * The config-writing entry points, every one of which sits behind
+ * `assertConfigMutationApproved()`.
+ *
+ * Detected as calls in the command layer rather than as graph reachability:
+ * `src/core/config.ts` holds both `read` and `write`, so *reaching* the guard
+ * says only that a command reads configuration — `audit clear` reaches it and
+ * mutates nothing.
+ */
+const CONFIG_MUTATORS = [
+  'configModule.write',
+  'writeV2Config',
+  'setConnectionPassword',
+  'writeProjectBinding',
+  'patchConnectionSchema',
+]
+
+/**
+ * Commands that write configuration incidentally rather than as their purpose.
+ *
+ * `schema` persists the discovered schema into `config.json` after reading it
+ * (`src/commands/schema.ts:479,532,642,746`). That write is behind the same
+ * agent-mode guard, so under `DBCLI_AGENT_MODE=1` the persistence step is
+ * refused — but the read itself is the capability, and marking `schema.read`
+ * `unavailable` would overstate the refusal far worse than staying silent
+ * understates it. The trade-off is disclosed in the spec, and DBCLI-PLAT-012
+ * covers moving cache persistence out from behind the identity guard.
+ *
+ * Listing them here rather than skipping them silently means adding a
+ * capability on such a command forces the decision back into view.
+ */
+const INCIDENTAL_CONFIG_WRITERS = new Set(['schema'])
+
+async function commandWritesConfig(commandPath: string): Promise<boolean> {
+  const entry = join(SRC, `commands/${commandPath.split(' ')[0]}.ts`)
+  if (!(await Bun.file(entry).exists())) return false
+
+  const graph = [...(await importGraph(entry))].filter((file) => file.includes('/src/commands/'))
+  for (const file of graph) {
+    const source = await readFile(file, 'utf8')
+    if (CONFIG_MUTATORS.some((call) => source.includes(`${call}(`))) return true
+  }
+  return false
+}
+
+describe('capability configuration-mutation parity', () => {
+  test('a capability claiming to mutate configuration really does write it', async () => {
+    // The direction that matters. A fabricated `true` would make
+    // `capabilities check` refuse something that would in fact have worked.
+    for (const capability of CAPABILITIES) {
+      if (!capability.mutatesConfiguration) continue
+      const writes = await commandWritesConfig(capability.command)
+      expect({ id: capability.id, writes }).toEqual({ id: capability.id, writes: true })
+    }
+  })
+
+  test('a capability on a command that writes no configuration never claims it does', async () => {
+    for (const capability of CAPABILITIES) {
+      if (INCIDENTAL_CONFIG_WRITERS.has(capability.command)) continue
+      if (await commandWritesConfig(capability.command)) continue
+      expect({ id: capability.id, mutates: capability.mutatesConfiguration }).toEqual({
+        id: capability.id,
+        mutates: false,
+      })
+    }
+  })
+
+  test('the incidental-writer list names only commands that really write', async () => {
+    // Stops the escape hatch above from silently covering a command that no
+    // longer writes at all, which would turn it into an unchecked exemption.
+    for (const command of INCIDENTAL_CONFIG_WRITERS) {
+      expect({ command, writes: await commandWritesConfig(command) }).toEqual({
+        command,
+        writes: true,
+      })
+    }
+  })
+
+  test('every listed mutator really is behind the agent-mode guard', async () => {
+    // Stops the mutator list going stale: an entry that stopped enforcing the
+    // boundary would make the tests above assert the wrong thing while staying
+    // green.
+    for (const relative of [
+      'core/config.ts',
+      'core/config-v2.ts',
+      'core/connection-credential.ts',
+      'core/config-binding.ts',
+    ]) {
+      const source = await readFile(join(SRC, relative), 'utf8')
+      expect({ relative, guarded: source.includes('assertConfigMutationApproved') }).toEqual({
+        relative,
+        guarded: true,
+      })
+    }
+  })
+})
+
 // ── 3. evidence claims track the real evidence subsystem ─────────────────
 
 describe('capability evidence parity', () => {

--- a/tests/integration/capabilities-command.test.ts
+++ b/tests/integration/capabilities-command.test.ts
@@ -1,0 +1,467 @@
+/**
+ * `dbcli capabilities` / `dbcli capabilities check` — integration tests
+ * (DBCLI-PLAT-002 / DBCLI-PLAT-003).
+ *
+ * Every case runs the real CLI in a temporary directory with no database
+ * reachable, which is what makes "discovery never connects" observable rather
+ * than merely asserted: if any path opened a socket these would hang or fail.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const CLI = resolve(import.meta.dir, '../../src/cli.ts')
+const workDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(workDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+function sanitizeEnv(): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^DBCLI_/i.test(key)) continue
+    if (key === 'DATABASE_URL') continue
+    out[key] = value
+  }
+  out.NODE_ENV = 'test'
+  out.DBCLI_NO_UPDATE_CHECK = '1'
+  return out
+}
+
+function run(
+  args: string[],
+  workDir: string
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((res) => {
+    const child = spawn('bun', ['run', CLI, ...args], { cwd: workDir, env: sanitizeEnv() })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (buffer) => (stdout += buffer.toString()))
+    child.stderr.on('data', (buffer) => (stderr += buffer.toString()))
+    child.on('close', (code) => res({ stdout, stderr, code: code ?? 0 }))
+  })
+}
+
+async function emptyDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'dbcli-capabilities-'))
+  workDirs.push(dir)
+  return dir
+}
+
+/**
+ * A v1 single-file config. Written with an unreachable host on purpose: every
+ * assertion below must hold without anything listening on it.
+ */
+async function dirWithConfig(
+  system: string,
+  permission: string
+): Promise<{ dir: string; configPath: string }> {
+  const dir = await emptyDir()
+  const configPath = join(dir, 'dbcli.json')
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      connection: {
+        system,
+        host: '203.0.113.1',
+        port: 5432,
+        user: 'nobody',
+        password: 'unused-secret-value',
+        database: 'nothing',
+      },
+      permission,
+      metadata: { createdAt: '2026-09-03T00:00:00.000Z', version: '1.0' },
+    })
+  )
+  return { dir, configPath }
+}
+
+describe('dbcli capabilities', () => {
+  test('--format json emits a parseable, versioned catalog', async () => {
+    const dir = await emptyDir()
+    const { stdout, code } = await run(['capabilities', '--format', 'json'], dir)
+
+    expect(code).toBe(0)
+    const catalog = JSON.parse(stdout)
+    expect(catalog.schemaVersion).toBe(1)
+    expect(Array.isArray(catalog.capabilities)).toBe(true)
+    expect(catalog.capabilities.length).toBeGreaterThan(0)
+    expect(catalog.capabilities.map((c: { id: string }) => c.id)).toContain('schema.read')
+  })
+
+  test('the JSON catalog is byte-identical across invocations', async () => {
+    const dir = await emptyDir()
+    const first = await run(['capabilities', '--format', 'json'], dir)
+    const second = await run(['capabilities', '--format', 'json'], dir)
+    expect(first.stdout).toBe(second.stdout)
+  })
+
+  test('--format markdown emits a table', async () => {
+    const dir = await emptyDir()
+    const { stdout, code } = await run(['capabilities', '--format', 'markdown'], dir)
+    expect(code).toBe(0)
+    expect(stdout).toContain('| id | risk | command | permission | connection | engines |')
+    expect(stdout).toContain('`schema.read`')
+  })
+
+  test('the default output is human-readable, not JSON', async () => {
+    const dir = await emptyDir()
+    const { stdout, code } = await run(['capabilities'], dir)
+    expect(code).toBe(0)
+    expect(stdout).toContain('dbcli capability contract v1')
+    expect(stdout).toContain('not permission to run it')
+    expect(() => JSON.parse(stdout)).toThrow()
+  })
+
+  test('an unknown format is refused', async () => {
+    const dir = await emptyDir()
+    const { code, stderr } = await run(['capabilities', '--format', 'yaml'], dir)
+    expect(code).toBe(2)
+    expect(stderr).toContain('Error:')
+  })
+
+  test('listing touches nothing on disk', async () => {
+    const dir = await emptyDir()
+    await run(['capabilities', '--format', 'json'], dir)
+    expect(await readdir(dir)).toEqual([])
+  })
+
+  test('the catalog exposes no credential, host or endpoint', async () => {
+    const dir = await emptyDir()
+    const { stdout } = await run(['capabilities', '--format', 'json'], dir)
+    expect(stdout).not.toMatch(/localhost|127\.0\.0\.1|:\/\/|"host"|"port"|password/i)
+  })
+})
+
+describe('dbcli capabilities check', () => {
+  test('reports available for a supported engine and sufficient permission', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'query-only')
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read,query.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(0)
+    const report = JSON.parse(stdout)
+    expect(report.ok).toBe(true)
+    expect(report.schemaVersion).toBe(1)
+    expect(report.context.engine).toBe('postgresql')
+    expect(report.context.permission).toBe('query-only')
+    expect(report.results.every((r: { status: string }) => r.status === 'available')).toBe(true)
+  })
+
+  test('an unsupported engine is unavailable with a non-zero exit', async () => {
+    const { dir, configPath } = await dirWithConfig('redis', 'admin')
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'data.health-check',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.ok).toBe(false)
+    expect(report.results[0].status).toBe('unavailable')
+    expect(report.results[0].reason).toBe('engine')
+  })
+
+  test('an insufficient permission is unavailable, never available', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'query-only')
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'data.delete',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.results[0].status).toBe('unavailable')
+    expect(report.results[0].reason).toBe('permission')
+  })
+
+  test('an unknown capability fails closed', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'admin')
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.reed',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.results[0].status).toBe('unknown')
+    expect(report.results[0].reason).toBe('unknown-capability')
+  })
+
+  test('a missing config reports context unavailable rather than assuming a default', async () => {
+    const dir = await emptyDir()
+    const { stdout, code } = await run(
+      ['capabilities', 'check', '--require', 'schema.read', '--format', 'json'],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.context).toBeNull()
+    expect(report.results[0].status).toBe('unavailable')
+    expect(report.results[0].reason).toBe('context-unavailable')
+    // The default config is a localhost PostgreSQL at query-only. Reporting it
+    // would say a database nobody configured supports this.
+    expect(stdout).not.toContain('postgresql')
+  })
+
+  test('an empty --require is refused with the input exit code', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'admin')
+    const { code, stderr } = await run(
+      ['--config', configPath, 'capabilities', 'check', '--require', '', '--format', 'json'],
+      dir
+    )
+    expect(code).toBe(2)
+    expect(stderr).toContain('Error:')
+  })
+
+  test('a duplicate id is de-duplicated and reported as a warning', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'admin')
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read,schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(0)
+    const report = JSON.parse(stdout)
+    expect(report.required).toEqual(['schema.read'])
+    expect(report.results).toHaveLength(1)
+    expect(report.warnings.join(' ')).toContain('Duplicate')
+  })
+
+  test('the root --use selector is honoured and named in the report', async () => {
+    const dir = await emptyDir()
+    const configDir = join(dir, 'store')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        version: 2,
+        default: 'primary',
+        connections: {
+          primary: {
+            system: 'postgresql',
+            host: '203.0.113.1',
+            port: 5432,
+            user: 'u',
+            password: 'p',
+            database: 'd',
+            permission: 'query-only',
+          },
+          cache: {
+            system: 'redis',
+            host: '203.0.113.2',
+            port: 6379,
+            user: '',
+            password: '',
+            database: '0',
+            permission: 'query-only',
+          },
+        },
+        schema: {},
+        schemas: {},
+        metadata: { version: '1.0', createdAt: '2026-09-03T00:00:00.000Z' },
+        blacklist: { tables: [], columns: {} },
+        audit: {
+          enabled: true,
+          strict: false,
+          rotation: { max_bytes: 10_485_760, max_entries: 1000 },
+        },
+      })
+    )
+
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configDir,
+        '--use',
+        'cache',
+        'capabilities',
+        'check',
+        '--require',
+        'data.health-check',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.context.engine).toBe('redis')
+    expect(report.context.connectionName).toBe('cache')
+    expect(report.results[0].reason).toBe('engine')
+  })
+
+  test('a v2 default connection is named even with no --use', async () => {
+    // The verdict must be attributable to the connection that produced it. With
+    // a v2 config and no selector, a named connection *is* in effect.
+    const dir = await emptyDir()
+    const configDir = join(dir, 'store')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        version: 2,
+        default: 'primary',
+        connections: {
+          primary: {
+            system: 'postgresql',
+            host: '203.0.113.1',
+            port: 5432,
+            user: 'u',
+            password: 'p',
+            database: 'd',
+            permission: 'query-only',
+          },
+        },
+        schema: {},
+        schemas: {},
+        metadata: { version: '1.0', createdAt: '2026-09-04T00:00:00.000Z' },
+        blacklist: { tables: [], columns: {} },
+        audit: {
+          enabled: true,
+          strict: false,
+          rotation: { max_bytes: 10_485_760, max_entries: 1000 },
+        },
+      })
+    )
+
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configDir,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(0)
+    expect(JSON.parse(stdout).context.connectionName).toBe('primary')
+  })
+
+  test('a v1 single-connection config reports no connection name', async () => {
+    const { dir, configPath } = await dirWithConfig('mysql', 'read-write')
+    const { stdout } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+    const report = JSON.parse(stdout)
+    expect(report.context.engine).toBe('mysql')
+    expect(report.context.connectionName).toBeNull()
+  })
+
+  test('checking mutates nothing on disk', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'query-only')
+    const before = await readdir(dir)
+    await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+    expect(await readdir(dir)).toEqual(before)
+  })
+
+  test('the report never echoes the configured credential or endpoint', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'admin')
+    const { stdout } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+    expect(stdout).not.toContain('unused-secret-value')
+    expect(stdout).not.toContain('203.0.113.1')
+    expect(stdout).not.toContain('nobody')
+  })
+
+  test('the default output is human-readable and still exits non-zero on failure', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'query-only')
+    const { stdout, code } = await run(
+      ['--config', configPath, 'capabilities', 'check', '--require', 'data.delete'],
+      dir
+    )
+    expect(code).toBe(1)
+    expect(stdout).toContain('unavailable')
+    expect(stdout).toContain('Some requirements are not met.')
+  })
+})

--- a/tests/integration/capabilities-command.test.ts
+++ b/tests/integration/capabilities-command.test.ts
@@ -11,6 +11,7 @@ import { spawn } from 'node:child_process'
 import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { writeV2Config } from '@/core/config-v2'
 
 const CLI = resolve(import.meta.dir, '../../src/cli.ts')
 const workDirs: string[] = []
@@ -43,6 +44,17 @@ function run(
     child.stderr.on('data', (buffer) => (stderr += buffer.toString()))
     child.on('close', (code) => res({ stdout, stderr, code: code ?? 0 }))
   })
+}
+
+/**
+ * Every path under `dir`, recursively.
+ *
+ * A non-recursive `readdir` would let a write into `.dbcli/` pass a test named
+ * "mutates nothing on disk" — precisely the write this command must not make.
+ */
+async function treeOf(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true })
+  return entries.map((entry) => join(entry.parentPath, entry.name)).sort()
 }
 
 async function emptyDir(): Promise<string> {
@@ -126,7 +138,7 @@ describe('dbcli capabilities', () => {
   test('listing touches nothing on disk', async () => {
     const dir = await emptyDir()
     await run(['capabilities', '--format', 'json'], dir)
-    expect(await readdir(dir)).toEqual([])
+    expect(await treeOf(dir)).toEqual([])
   })
 
   test('the catalog exposes no credential, host or endpoint', async () => {
@@ -413,6 +425,163 @@ describe('dbcli capabilities check', () => {
     const report = JSON.parse(stdout)
     expect(report.context.engine).toBe('mysql')
     expect(report.context.connectionName).toBeNull()
+  })
+
+  test('an unresolvable env-ref says the config exists, not that it is missing', async () => {
+    // The config is present and fine; only its `{"$env":...}` password points at
+    // an unset variable — a credential this command never needs. Reporting "no
+    // configuration was found" here was the contract stating a falsehood.
+    const dir = await emptyDir()
+    const configPath = join(dir, 'envref.json')
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        connection: {
+          system: 'postgresql',
+          host: '203.0.113.1',
+          port: 5432,
+          user: 'u',
+          password: { $env: 'DBCLI_TEST_NEVER_SET_PASSWORD' },
+          database: 'd',
+        },
+        permission: 'read-write',
+        metadata: { createdAt: '2026-09-04T00:00:00.000Z', version: '1.0' },
+      })
+    )
+
+    const { stdout, code } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.results[0].reason).toBe('context-unresolvable')
+    expect(report.warnings.join(' ')).toContain('could not be resolved')
+    expect(report.warnings.join(' ')).not.toContain('No dbcli configuration was found')
+  })
+
+  test('an unresolvable config leaks no filesystem path', async () => {
+    const dir = await emptyDir()
+    const configPath = join(dir, 'broken.json')
+    await writeFile(configPath, '{ this is not json')
+
+    const { stdout } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'schema.read',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+    expect(stdout).not.toContain(dir)
+    expect(stdout).not.toContain('broken.json')
+    expect(JSON.parse(stdout).results[0].reason).toBe('context-unresolvable')
+  })
+
+  test('agent mode refuses a configuration-changing capability regardless of permission', async () => {
+    // DBCLI_AGENT_MODE=1 blocks every config write unconditionally, so
+    // reporting `available` for `connection.select` at admin would be a promise
+    // the very next command breaks.
+    //
+    // The config is written through `writeV2Config` rather than `writeFile` so
+    // it carries a real integrity record: agent mode both requires one and
+    // refuses legacy single-file configs, so a hand-written v1 fixture never
+    // reaches the code under test.
+    const dir = await emptyDir()
+    const configDir = join(dir, 'store')
+    await mkdir(configDir, { recursive: true })
+    await writeV2Config(configDir, {
+      version: 2,
+      default: 'primary',
+      connections: {
+        primary: {
+          system: 'postgresql',
+          host: '203.0.113.1',
+          port: 5432,
+          user: 'u',
+          password: 'p',
+          database: 'd',
+          permission: 'admin',
+        },
+      },
+      schema: {},
+      schemas: {},
+      metadata: { version: '1.0', createdAt: '2026-09-04T00:00:00.000Z' },
+      blacklist: { tables: [], columns: {} },
+      audit: {
+        enabled: true,
+        strict: false,
+        rotation: { max_bytes: 10_485_760, max_entries: 1000 },
+      },
+    } as never)
+
+    const child = spawn(
+      'bun',
+      [
+        'run',
+        CLI,
+        '--config',
+        configDir,
+        'capabilities',
+        'check',
+        '--require',
+        'connection.select,schema.read',
+        '--format',
+        'json',
+      ],
+      { cwd: dir, env: { ...sanitizeEnv(), DBCLI_AGENT_MODE: '1' } }
+    )
+    let stdout = ''
+    child.stdout.on('data', (buffer) => (stdout += buffer.toString()))
+    const code: number = await new Promise((res) => child.on('close', (c) => res(c ?? 0)))
+
+    expect(code).toBe(1)
+    const report = JSON.parse(stdout)
+    expect(report.context.agentMode).toBe(true)
+    const byId = Object.fromEntries(
+      report.results.map((r: { id: string; status: string; reason: string | null }) => [
+        r.id,
+        [r.status, r.reason],
+      ])
+    )
+    expect(byId['connection.select']).toEqual(['unavailable', 'agent-mode'])
+    expect(byId['schema.read']).toEqual(['available', null])
+    expect(report.warnings.join(' ')).toContain('DBCLI_AGENT_MODE=1')
+  })
+
+  test('agent mode is reported as false when the flag is unset', async () => {
+    const { dir, configPath } = await dirWithConfig('postgresql', 'admin')
+    const { stdout } = await run(
+      [
+        '--config',
+        configPath,
+        'capabilities',
+        'check',
+        '--require',
+        'connection.select',
+        '--format',
+        'json',
+      ],
+      dir
+    )
+    const report = JSON.parse(stdout)
+    expect(report.context.agentMode).toBe(false)
+    expect(report.results[0].status).toBe('available')
   })
 
   test('checking mutates nothing on disk', async () => {

--- a/tests/unit/adapters/database-systems-roster.test.ts
+++ b/tests/unit/adapters/database-systems-roster.test.ts
@@ -1,0 +1,28 @@
+/**
+ * `DATABASE_SYSTEMS` is the runtime roster of engines. `satisfies` and the
+ * `AssertNever` alias in `src/adapters/types.ts` tie it to the `DatabaseSystem`
+ * union at compile time, but nothing tied it to `ENGINE_CAPABILITIES`, whose
+ * keys are the roster everything engine-facing actually iterates. A comment
+ * claimed this test existed before it did.
+ */
+import { describe, expect, test } from 'bun:test'
+import { DATABASE_SYSTEMS } from '@/adapters/types'
+import { ENGINE_CAPABILITIES } from '@/adapters/capabilities'
+
+describe('DATABASE_SYSTEMS roster', () => {
+  test('holds exactly the keys of ENGINE_CAPABILITIES', () => {
+    // Compared as plain strings so the assertion needs no cast: the point is
+    // that the two rosters hold the same names, not that they share a type.
+    expect([...DATABASE_SYSTEMS].map(String).sort()).toEqual(
+      Object.keys(ENGINE_CAPABILITIES).sort()
+    )
+  })
+
+  test('has no duplicates', () => {
+    expect(new Set(DATABASE_SYSTEMS).size).toBe(DATABASE_SYSTEMS.length)
+  })
+
+  test('is frozen, so a caller cannot reorder the published engine order', () => {
+    expect(Object.isFrozen(DATABASE_SYSTEMS)).toBe(true)
+  })
+})

--- a/tests/unit/core-public.test.ts
+++ b/tests/unit/core-public.test.ts
@@ -93,6 +93,7 @@ test('capability contract 在 public 表面上是可往返驗證的', () => {
     engine: 'postgresql',
     permission: 'query-only',
     connectionName: null,
+    agentMode: false,
   })
   expect(report.ok).toBe(true)
   expect(core.parseCapabilityCheckReport(JSON.parse(JSON.stringify(report)))).toBeDefined()

--- a/tests/unit/core-public.test.ts
+++ b/tests/unit/core-public.test.ts
@@ -64,3 +64,36 @@ test('readConfig 對空目錄回傳預設 config（含 connection + permission�
 test('public API 不暴露未經 gate 的 adapter 工廠', () => {
   expect('AdapterFactory' in core).toBe(false)
 })
+
+/**
+ * Capability contract on the published `./core` surface (DBCLI-PLAT-001).
+ *
+ * External Skills pin these names. Exporting them is the deliverable; the
+ * point of the test is that a refactor cannot quietly drop one.
+ */
+test('public API 暴露 capability contract', () => {
+  expect(core.CAPABILITY_CONTRACT_SCHEMA_VERSION).toBe(1)
+  expect(typeof core.buildCapabilityCatalog).toBe('function')
+  expect(typeof core.findCapability).toBe('function')
+  expect(typeof core.listCapabilityIds).toBe('function')
+  expect(typeof core.checkCapabilities).toBe('function')
+  expect(typeof core.parseRequirements).toBe('function')
+  expect(typeof core.parseCapabilityCatalog).toBe('function')
+  expect(typeof core.parseCapabilityCheckReport).toBe('function')
+  expect(core.CapabilityRequirementError).toBeDefined()
+  expect(core.CapabilityContractError).toBeDefined()
+  expect(Array.isArray(core.CAPABILITIES)).toBe(true)
+})
+
+test('capability contract 在 public 表面上是可往返驗證的', () => {
+  const catalog = core.buildCapabilityCatalog()
+  expect(core.parseCapabilityCatalog(JSON.parse(JSON.stringify(catalog)))).toBeDefined()
+
+  const report = core.checkCapabilities(['schema.read'], {
+    engine: 'postgresql',
+    permission: 'query-only',
+    connectionName: null,
+  })
+  expect(report.ok).toBe(true)
+  expect(core.parseCapabilityCheckReport(JSON.parse(JSON.stringify(report)))).toBeDefined()
+})

--- a/tests/unit/core/capabilities/check.test.ts
+++ b/tests/unit/core/capabilities/check.test.ts
@@ -18,12 +18,14 @@ const PG_QUERY_ONLY: CapabilityCheckContext = {
   engine: 'postgresql',
   permission: 'query-only',
   connectionName: null,
+  agentMode: false,
 }
 
 const REDIS_ADMIN: CapabilityCheckContext = {
   engine: 'redis',
   permission: 'admin',
   connectionName: 'cache',
+  agentMode: false,
 }
 
 describe('parseRequirements', () => {
@@ -88,6 +90,7 @@ describe('checkCapabilities', () => {
       engine: 'postgresql',
       permission: 'admin',
       connectionName: null,
+      agentMode: false,
     })
     expect(report.results[0]!.status).toBe('available')
   })
@@ -100,21 +103,78 @@ describe('checkCapabilities', () => {
       engine: 'redis',
       permission: 'query-only',
       connectionName: null,
+      agentMode: false,
     })
     expect(report.results[0]!.reason).toBe('engine')
   })
 
-  test('missing context is unavailable with context-unavailable, never available', () => {
-    const report = checkCapabilities(['schema.read', 'query.read'], null)
+  test('an absent config is unavailable with context-unavailable, never available', () => {
+    const report = checkCapabilities(['schema.read', 'query.read'], null, [], 'absent')
     expect(report.ok).toBe(false)
     for (const result of report.results) {
       expect(result.status).toBe('unavailable')
       expect(result.reason).toBe('context-unavailable')
     }
-    expect(report.warnings.join(' ')).toContain('configuration')
+    expect(report.warnings.join(' ')).toContain('No dbcli configuration was found')
   })
 
-  test('missing context still distinguishes an unknown id from a known one', () => {
+  test('a config that exists but will not resolve says so, not "no config"', () => {
+    // The distinction is the whole point: an unset `{"$env":...}` password
+    // leaves a perfectly present config unresolvable, and reporting "there is no
+    // configuration" there would be the contract stating a falsehood.
+    const report = checkCapabilities(['schema.read'], null, [], 'unresolvable')
+    expect(report.results[0]!.reason).toBe('context-unresolvable')
+    expect(report.warnings.join(' ')).toContain('could not be resolved')
+    expect(report.warnings.join(' ')).not.toContain('No dbcli configuration was found')
+  })
+
+  test('agent mode makes a configuration-mutating capability unavailable', () => {
+    // DBCLI_AGENT_MODE=1 refuses every config change unconditionally, and that
+    // is knowable without connecting. Reporting `available` here would be the
+    // one promise this contract makes that its primary consumer would act on
+    // and find false.
+    const agent: CapabilityCheckContext = { ...PG_QUERY_ONLY, permission: 'admin', agentMode: true }
+    for (const id of ['connection.select', 'connection.init', 'blacklist.manage']) {
+      const report = checkCapabilities([id], agent)
+      expect({ id, status: report.results[0]!.status, reason: report.results[0]!.reason }).toEqual({
+        id,
+        status: 'unavailable',
+        reason: 'agent-mode',
+      })
+    }
+  })
+
+  test('agent mode leaves capabilities that change no configuration alone', () => {
+    const agent: CapabilityCheckContext = { ...PG_QUERY_ONLY, agentMode: true }
+    for (const id of ['schema.read', 'query.read', 'snippet.manage', 'audit.tail']) {
+      const report = checkCapabilities([id], agent)
+      expect({ id, status: report.results[0]!.status }).toEqual({ id, status: 'available' })
+    }
+  })
+
+  test('agent mode is reported in warnings so the refusal is explicable', () => {
+    const report = checkCapabilities(['schema.read'], { ...PG_QUERY_ONLY, agentMode: true })
+    expect(report.warnings.join(' ')).toContain('DBCLI_AGENT_MODE=1')
+  })
+
+  test('engine outranks agent mode, which outranks permission', () => {
+    // Least-fixable first, so the reason names the blocker actually in the way.
+    const onRedisUnderAgentMode: CapabilityCheckContext = {
+      engine: 'redis',
+      permission: 'query-only',
+      connectionName: null,
+      agentMode: true,
+    }
+    expect(checkCapabilities(['schema.migrate'], onRedisUnderAgentMode).results[0]!.reason).toBe(
+      'engine'
+    )
+    expect(
+      checkCapabilities(['blacklist.manage'], { ...onRedisUnderAgentMode, engine: 'postgresql' })
+        .results[0]!.reason
+    ).toBe('agent-mode')
+  })
+
+  test('an absent context still distinguishes an unknown id from a known one', () => {
     const report = checkCapabilities(['schema.read', 'not.a.capability'], null)
     expect(report.results[0]!.reason).toBe('context-unavailable')
     expect(report.results[1]!.status).toBe('unknown')
@@ -126,6 +186,7 @@ describe('checkCapabilities', () => {
         engine,
         permission: 'query-only',
         connectionName: null,
+        agentMode: false,
       })
       expect(report.results[0]!.status).toBe('available')
     }

--- a/tests/unit/core/capabilities/check.test.ts
+++ b/tests/unit/core/capabilities/check.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `capabilities check` evaluation — unit tests (DBCLI-PLAT-003).
+ *
+ * The property under test throughout is fail-closed: nothing the caller can
+ * type, and no state of the local environment, produces `available` for a
+ * capability whose engine or permission does not actually allow it.
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+  CapabilityRequirementError,
+  checkCapabilities,
+  parseRequirements,
+  type CapabilityCheckContext,
+} from '@/core/capabilities'
+import { parseCapabilityCheckReport } from '@/core/capabilities/schema'
+
+const PG_QUERY_ONLY: CapabilityCheckContext = {
+  engine: 'postgresql',
+  permission: 'query-only',
+  connectionName: null,
+}
+
+const REDIS_ADMIN: CapabilityCheckContext = {
+  engine: 'redis',
+  permission: 'admin',
+  connectionName: 'cache',
+}
+
+describe('parseRequirements', () => {
+  test('splits and trims a comma-separated list', () => {
+    expect(parseRequirements(' schema.read , query.read ').ids).toEqual([
+      'schema.read',
+      'query.read',
+    ])
+  })
+
+  test('de-duplicates in first-seen order and warns', () => {
+    const parsed = parseRequirements('query.read,schema.read,query.read')
+    expect(parsed.ids).toEqual(['query.read', 'schema.read'])
+    expect(parsed.warnings).toHaveLength(1)
+    expect(parsed.warnings[0]).toContain('query.read')
+  })
+
+  test('refuses an empty requirement list rather than reporting ok', () => {
+    expect(() => parseRequirements('')).toThrow(CapabilityRequirementError)
+    expect(() => parseRequirements('   ')).toThrow(CapabilityRequirementError)
+  })
+
+  test('refuses an empty element inside the list', () => {
+    expect(() => parseRequirements('schema.read,,query.read')).toThrow(CapabilityRequirementError)
+    expect(() => parseRequirements('schema.read,')).toThrow(CapabilityRequirementError)
+  })
+})
+
+describe('checkCapabilities', () => {
+  test('reports available when engine and permission both allow it', () => {
+    const report = checkCapabilities(['schema.read', 'query.read'], PG_QUERY_ONLY)
+    expect(report.ok).toBe(true)
+    expect(report.results.map((result) => result.status)).toEqual(['available', 'available'])
+    expect(report.results.every((result) => result.reason === null)).toBe(true)
+  })
+
+  test('an unknown id is unknown, never available, and never guessed at', () => {
+    const report = checkCapabilities(['schema.reed'], PG_QUERY_ONLY)
+    expect(report.ok).toBe(false)
+    expect(report.results[0]).toEqual({
+      id: 'schema.reed',
+      status: 'unknown',
+      reason: 'unknown-capability',
+    })
+  })
+
+  test('an unsupported engine is unavailable, not available', () => {
+    // `data.health-check` is SQL-only in ENGINE_CAPABILITIES.
+    const report = checkCapabilities(['data.health-check'], REDIS_ADMIN)
+    expect(report.results[0]!.status).toBe('unavailable')
+    expect(report.results[0]!.reason).toBe('engine')
+  })
+
+  test('an insufficient permission is unavailable, not available', () => {
+    const report = checkCapabilities(['data.delete'], PG_QUERY_ONLY)
+    expect(report.results[0]!.status).toBe('unavailable')
+    expect(report.results[0]!.reason).toBe('permission')
+  })
+
+  test('a higher permission than required still passes', () => {
+    const report = checkCapabilities(['query.read'], {
+      engine: 'postgresql',
+      permission: 'admin',
+      connectionName: null,
+    })
+    expect(report.results[0]!.status).toBe('available')
+  })
+
+  test('engine is checked before permission, so the reason names the real blocker', () => {
+    // `schema.migrate` needs admin and is SQL-only; on Redis with query-only
+    // both would fail, and the engine is the one that cannot be fixed by
+    // raising a level.
+    const report = checkCapabilities(['schema.migrate'], {
+      engine: 'redis',
+      permission: 'query-only',
+      connectionName: null,
+    })
+    expect(report.results[0]!.reason).toBe('engine')
+  })
+
+  test('missing context is unavailable with context-unavailable, never available', () => {
+    const report = checkCapabilities(['schema.read', 'query.read'], null)
+    expect(report.ok).toBe(false)
+    for (const result of report.results) {
+      expect(result.status).toBe('unavailable')
+      expect(result.reason).toBe('context-unavailable')
+    }
+    expect(report.warnings.join(' ')).toContain('configuration')
+  })
+
+  test('missing context still distinguishes an unknown id from a known one', () => {
+    const report = checkCapabilities(['schema.read', 'not.a.capability'], null)
+    expect(report.results[0]!.reason).toBe('context-unavailable')
+    expect(report.results[1]!.status).toBe('unknown')
+  })
+
+  test('an engine-independent capability is available on any engine', () => {
+    for (const engine of ['postgresql', 'redis', 'elasticsearch'] as const) {
+      const report = checkCapabilities(['shell-completion.generate'], {
+        engine,
+        permission: 'query-only',
+        connectionName: null,
+      })
+      expect(report.results[0]!.status).toBe('available')
+    }
+  })
+
+  test('input order is preserved and does not change the verdict', () => {
+    const forward = checkCapabilities(['schema.read', 'data.delete'], PG_QUERY_ONLY)
+    const reverse = checkCapabilities(['data.delete', 'schema.read'], PG_QUERY_ONLY)
+
+    expect(forward.ok).toBe(reverse.ok)
+    expect(forward.results.map((r) => r.id)).toEqual(['schema.read', 'data.delete'])
+    expect(reverse.results.map((r) => r.id)).toEqual(['data.delete', 'schema.read'])
+
+    const byId = (report: typeof forward) =>
+      Object.fromEntries(report.results.map((r) => [r.id, r.status]))
+    expect(byId(forward)).toEqual(byId(reverse))
+  })
+
+  test('the report satisfies the strict schema', () => {
+    for (const context of [PG_QUERY_ONLY, REDIS_ADMIN, null]) {
+      const report = checkCapabilities(['schema.read', 'nope.nope'], context)
+      expect(() => parseCapabilityCheckReport(report)).not.toThrow()
+    }
+  })
+
+  test('the report never carries a host, port or credential', () => {
+    const serialized = JSON.stringify(checkCapabilities(['schema.read'], REDIS_ADMIN))
+    expect(serialized).not.toMatch(/localhost|127\.0\.0\.1|:\/\/|password|"port"|"host"/i)
+    // The connection *name* is a label the user chose, and is what makes the
+    // report attributable; the endpoint behind it never appears.
+    expect(serialized).toContain('cache')
+  })
+})

--- a/tests/unit/core/capabilities/registry.test.ts
+++ b/tests/unit/core/capabilities/registry.test.ts
@@ -18,6 +18,7 @@ import {
 import { CapabilitySchema, CapabilityCatalogSchema } from '@/core/capabilities/schema'
 import { COMMAND_CAPABILITY_KEYS, ENGINE_CAPABILITIES } from '@/adapters/capabilities'
 import { DATABASE_SYSTEMS } from '@/adapters/types'
+import { minimumPermissionFor } from '@/core/permission-guard'
 
 describe('capability catalog', () => {
   test('is sorted by id and therefore deterministic across builds', () => {
@@ -113,12 +114,48 @@ describe('capability catalog', () => {
     }
   })
 
-  test('permissions match the SQL permission ladder where one applies', () => {
-    expect(findCapability('query.read')!.minimumPermission).toBe('query-only')
-    expect(findCapability('data.insert')!.minimumPermission).toBe('read-write')
-    expect(findCapability('data.update')!.minimumPermission).toBe('read-write')
-    expect(findCapability('data.delete')!.minimumPermission).toBe('data-admin')
-    expect(findCapability('schema.migrate')!.minimumPermission).toBe('admin')
+  test('permissions come from the runtime permission ladder, not a copy of it', () => {
+    // Compared against `minimumPermissionFor` rather than against a literal:
+    // asserting `data.delete` is `data-admin` only restates the declaration and
+    // stays green when TIER_GRANTS changes underneath it.
+    expect(findCapability('query.read')!.minimumPermission).toBe(minimumPermissionFor('SELECT'))
+    expect(findCapability('data.insert')!.minimumPermission).toBe(minimumPermissionFor('INSERT'))
+    expect(findCapability('data.update')!.minimumPermission).toBe(minimumPermissionFor('UPDATE'))
+    expect(findCapability('data.delete')!.minimumPermission).toBe(minimumPermissionFor('DELETE'))
+    expect(findCapability('schema.migrate')!.minimumPermission).toBe(minimumPermissionFor('ALTER'))
+  })
+
+  test('limitedEngines is the matrix `limited` subset of engines', () => {
+    for (const declaration of CAPABILITY_DECLARATIONS) {
+      const capability = findCapability(declaration.id)!
+      if (capability.engineIndependent) {
+        expect(capability.limitedEngines).toEqual([])
+        continue
+      }
+
+      const expected = DATABASE_SYSTEMS.filter(
+        (system) => ENGINE_CAPABILITIES[system][declaration.key].status === 'limited'
+      )
+      expect({ id: capability.id, limited: [...capability.limitedEngines] }).toEqual({
+        id: capability.id,
+        limited: [...expected],
+      })
+      for (const engine of capability.limitedEngines) {
+        expect(capability.engines).toContain(engine)
+      }
+    }
+  })
+
+  test('at least one capability really is limited somewhere, so the field is load-bearing', () => {
+    // Guards the assertion above from passing vacuously.
+    expect(CAPABILITIES.some((capability) => capability.limitedEngines.length > 0)).toBe(true)
+  })
+
+  test('mutatesConfiguration marks the capabilities agent mode refuses', () => {
+    const marked = CAPABILITIES.filter((capability) => capability.mutatesConfiguration).map(
+      (capability) => capability.id
+    )
+    expect(marked).toEqual(['blacklist.manage', 'connection.init', 'connection.select'])
   })
 
   test('ids name tool abilities, never job titles or methods', () => {
@@ -136,7 +173,9 @@ describe('capability catalog', () => {
       'engineIndependent',
       'engines',
       'id',
+      'limitedEngines',
       'minimumPermission',
+      'mutatesConfiguration',
       'requiresConnection',
       'risk',
       'sideEffect',

--- a/tests/unit/core/capabilities/registry.test.ts
+++ b/tests/unit/core/capabilities/registry.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Capability catalog — unit tests (DBCLI-PLAT-001).
+ *
+ * The catalog is a published contract, so these assert the properties an
+ * external consumer relies on: stable ordering, unique ids, no invented engine
+ * or risk claims, and nothing resembling a credential in the payload.
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+  CAPABILITIES,
+  CAPABILITY_CONTRACT_SCHEMA_VERSION,
+  CAPABILITY_DECLARATIONS,
+  buildCapabilityCatalog,
+  findCapability,
+  listCapabilityIds,
+  riskForSideEffect,
+} from '@/core/capabilities'
+import { CapabilitySchema, CapabilityCatalogSchema } from '@/core/capabilities/schema'
+import { COMMAND_CAPABILITY_KEYS, ENGINE_CAPABILITIES } from '@/adapters/capabilities'
+import { DATABASE_SYSTEMS } from '@/adapters/types'
+
+describe('capability catalog', () => {
+  test('is sorted by id and therefore deterministic across builds', () => {
+    const ids = CAPABILITIES.map((capability) => capability.id)
+    expect(ids).toEqual([...ids].sort())
+  })
+
+  test('emits byte-identical JSON on repeated calls', () => {
+    expect(JSON.stringify(buildCapabilityCatalog())).toBe(JSON.stringify(buildCapabilityCatalog()))
+  })
+
+  test('ids are unique', () => {
+    const ids = listCapabilityIds()
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('carries the contract schema version, not the package version', () => {
+    const catalog = buildCapabilityCatalog()
+    expect(catalog.schemaVersion).toBe(CAPABILITY_CONTRACT_SCHEMA_VERSION)
+    expect(catalog.schemaVersion).toBe(1)
+  })
+
+  test('every capability satisfies the strict schema', () => {
+    for (const capability of CAPABILITIES) {
+      expect(() => CapabilitySchema.parse(capability)).not.toThrow()
+    }
+    expect(() => CapabilityCatalogSchema.parse(buildCapabilityCatalog())).not.toThrow()
+  })
+
+  test('the strict schema rejects an unknown field', () => {
+    const [first] = CAPABILITIES
+    expect(() => CapabilitySchema.parse({ ...first, extra: true })).toThrow()
+  })
+
+  test('the strict schema rejects an unknown schemaVersion', () => {
+    expect(() =>
+      CapabilityCatalogSchema.parse({ ...buildCapabilityCatalog(), schemaVersion: 2 })
+    ).toThrow()
+  })
+
+  test('engines are drawn only from the supported roster', () => {
+    for (const capability of CAPABILITIES) {
+      for (const engine of capability.engines) {
+        expect(DATABASE_SYSTEMS).toContain(engine)
+      }
+    }
+  })
+
+  test('engine lists match ENGINE_CAPABILITIES rather than a second table', () => {
+    for (const declaration of CAPABILITY_DECLARATIONS) {
+      const capability = findCapability(declaration.id)!
+      if (capability.engineIndependent) continue
+
+      const expected = DATABASE_SYSTEMS.filter((system) => {
+        const status = ENGINE_CAPABILITIES[system][declaration.key].status
+        return status === 'supported' || status === 'limited'
+      })
+      expect(capability.engines).toEqual(expected)
+    }
+  })
+
+  test('an engine-independent capability lists every engine', () => {
+    for (const capability of CAPABILITIES) {
+      if (!capability.engineIndependent) continue
+      expect(capability.engines).toEqual([...DATABASE_SYSTEMS])
+    }
+  })
+
+  test('risk is derived from the published side-effect tier', () => {
+    for (const capability of CAPABILITIES) {
+      expect(capability.risk).toBe(riskForSideEffect(capability.sideEffect))
+    }
+  })
+
+  test('every declaration names a real engine matrix key', () => {
+    for (const declaration of CAPABILITY_DECLARATIONS) {
+      expect(COMMAND_CAPABILITY_KEYS).toContain(declaration.key)
+    }
+  })
+
+  test('every engine matrix key is represented by at least one capability', () => {
+    const covered = new Set(CAPABILITY_DECLARATIONS.map((declaration) => declaration.key))
+    for (const key of COMMAND_CAPABILITY_KEYS) {
+      expect(covered.has(key)).toBe(true)
+    }
+  })
+
+  test('a write capability never claims readonly risk', () => {
+    for (const capability of CAPABILITIES) {
+      if (capability.sideEffect === 'db-write' || capability.sideEffect === 'local-write') {
+        expect(capability.risk).toBe('write')
+      }
+    }
+  })
+
+  test('permissions match the SQL permission ladder where one applies', () => {
+    expect(findCapability('query.read')!.minimumPermission).toBe('query-only')
+    expect(findCapability('data.insert')!.minimumPermission).toBe('read-write')
+    expect(findCapability('data.update')!.minimumPermission).toBe('read-write')
+    expect(findCapability('data.delete')!.minimumPermission).toBe('data-admin')
+    expect(findCapability('schema.migrate')!.minimumPermission).toBe('admin')
+  })
+
+  test('ids name tool abilities, never job titles or methods', () => {
+    const forbidden = ['dba', 'crud', 'cqrs', 'developer', 'engineer', 'operator', 'review']
+    for (const capability of CAPABILITIES) {
+      const domain = capability.id.split('.')[0]!
+      expect(forbidden).not.toContain(domain)
+    }
+  })
+
+  test('exposes exactly the contract fields and nothing else', () => {
+    const expected = [
+      'command',
+      'description',
+      'engineIndependent',
+      'engines',
+      'id',
+      'minimumPermission',
+      'requiresConnection',
+      'risk',
+      'sideEffect',
+      'supportsEvidence',
+      'supportsJson',
+    ]
+    for (const capability of CAPABILITIES) {
+      expect(Object.keys(capability).sort()).toEqual(expected)
+    }
+  })
+
+  test('no capability value looks like a host, port, credential or connection string', () => {
+    // Checked value by value rather than over the whole JSON blob: a substring
+    // scan flags "report" for containing "port" and proves nothing.
+    const suspicious =
+      /(:\/\/)|(\b\d{2,5}\b)|(localhost)|(127\.0\.0\.1)|(password)|(secret)|(token)/i
+    for (const capability of CAPABILITIES) {
+      for (const [field, value] of Object.entries(capability)) {
+        if (typeof value !== 'string') continue
+        expect({ id: capability.id, field, value: suspicious.test(value) }).toEqual({
+          id: capability.id,
+          field,
+          value: false,
+        })
+      }
+    }
+  })
+
+  test('uses the DatabaseSystem engine vocabulary, never the task-pack fork', () => {
+    const serialized = JSON.stringify(buildCapabilityCatalog())
+    expect(serialized).toContain('postgresql')
+    expect(serialized).not.toMatch(/"postgres"/)
+  })
+
+  test('findCapability fails closed on an unknown id', () => {
+    expect(findCapability('schema.reed')).toBeUndefined()
+    expect(findCapability('')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
外部 Skill 現在問得到 dbcli 能做什麼。新增 `dbcli capabilities`（靜態、有版本的
capability catalog）與 `dbcli capabilities check --require <ids>`（依本機設定檢查
engine / agent mode / permission）。兩者都不建立資料庫連線、不動檔案系統。

Story: `specs/stories/DBCLI-PLAT-001-capability-contract/`
設計記錄: `docs/specs/2026-09-04-agent-integration-contract-v1.md`
決定: [ADR-0022](docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md)

## 這個 PR 真正的設計決定：不新增第二張表

`src/adapters/capabilities.ts` 早就有六個引擎 × 三十四個 command key 的支援矩陣，
被 `doctor` 與引擎支援文件讀著。再寫一份 per-capability 的引擎清單，會在某個引擎
第一次獲得支援時無聲地與它分歧——沒有東西會去比對兩者。

所以 registry 只宣告矩陣不知道的事（id、描述、command path、`requiresConnection`），
`engines` / `limitedEngines` / `risk` / `sideEffect` 一律推導，`minimumPermission`
在有 SQL statement type 可對應時由 `minimumPermissionFor` 導出（也就是 runtime 拒絕
時查的同一張表）。Contract test 雙向檢查覆蓋率、實際 Commander tree、以及實際
import graph。

`available` 不等於已核准：blacklist、write gate、確認與 audit 在執行時全部照跑。
設定檔裡的 `admin` 是權限等級，不是 DBA 的簽核。

## v1 的邊界是刻意的

矩陣涵蓋 34 個 command key，dbcli 有 50 個 top-level 指令。其餘 16 個
（`explain`、`plan`、`impact`、`assert`、`verify`、`evidence` …）**不在 catalog 裡**，
問它們回 `unknown`，fail closed。

替它們寫引擎支援度等於憑讀碼捏造未經稽核的宣稱，而一份帶著未稽核宣稱的 discovery
契約比一份承認邊界的更糟。擴充矩陣是 DBCLI-PLAT-011。

## 契約說謊了六次，沒有一次是讀碼看出來的

這是這個 PR 最值得看的部分。每一次都不會讓任何既有測試變紅，只會讓一份對外契約
長期說錯話：

1. 空目錄裡回報 `engine: postgresql, permission: query-only`——`configModule.read`
   在沒有設定時回傳 `DEFAULT_CONFIG`。等於用 JSON 宣稱一個沒人設定過的資料庫支援
   該能力。
2. 手寫的 `supportsJson` 四個指令是錯的（`queries` / `migrate` / `blacklist` 的
   JSON 在子指令上，`use` 則相反）。
3. v2 預設連線在沒給 `--use` 時 `connectionName` 回 `null`，判決無法歸屬。
4. **agent mode 下對 `connection.select` 回 `available`。** `DBCLI_AGENT_MODE=1`
   無條件拒絕所有設定變更，下一個 `dbcli use` 直接被擋。
5. 一個裸 catch 把五種狀況壓成「找不到可讀的設定」——包括未設定的 `{"$env":...}`
   密碼（設定完整可讀，而這個指令根本不需要密碼）與 agent mode 的完整性稽核失敗。
6. 抽出權限階梯時順手把 module-private 的 `PERMISSION_RANK` 變成公開 export。

1–3 是測試與探測抓到的，4–6 是 code review 抓到的。

第 4 點最值得記住。原本的辯護是「available 不是核准」，但那條免責聲明蓋不住它——
差別在**拒絕是何時決定的**：blacklist 與人類同意在執行當下決定，契約無從代言；
agent mode 在這裡就決定了，而且不連線就完全可知。對著這份契約的主要客群（agent）
宣稱一件下一個指令就會推翻的事，是它唯一會被真正依賴的假承諾。

## 已知的過度宣稱（刻意保留）

`dbcli schema` 會把讀到的 schema 持久化進 `config.json`，那個寫入也在 agent mode
的閘門後，所以 `schema.read` 在 agent mode 下回 `available` 但實際跑會在持久化那步
失敗。標成 unavailable 會讓 agent 以為完全讀不到 schema，反方向的錯更大。

已寫進 ADR 與 acceptance 的 known deviation，測試裡以具名豁免清單擋住它變成無聲
破口。真正的修法是 schema *快取*的寫入本來就不該擋在「連線身分」的閘門後：
DBCLI-PLAT-012。

## 不在這個 PR 裡

沒有改動任何既有 `--format json` 輸出。沒有 Operation Envelope、correlation id 或
evidence 擴充。Task Pack 仍是 `plan-only`，`safety.requires` 沒有動。沒有 CRUD /
CQRS / DBA 行為進 core，沒有第二條資料庫執行路徑，沒有弱化任何安全控制。
後續 DBCLI-PLAT-004 到 012 只寫進 spec。

契約住在 `src/core` 而非 `src/agent-core`：purity gate 禁止那裡出現 `postgresql`
這個字，而一份列出引擎的 catalog 無法滿足它。Gate 保持原樣嚴格。

## Test plan

**已通過**：`bun test` 6509 pass / 27 skip / 0 fail（557 檔）· `typecheck` ·
`typecheck:tests` · `lint` · `format:check` · `contract:check` · `agent-core:check` ·
`core-stdout:check` · `docs:check` · `skill:check` · `platform:check` ·
`plugin:check` · `plan:check` · `manifest:check` · `forgeflow:check` · `build` ·
`build:determinism`

**跳過**：27 個 skip 是 Elasticsearch、live-DB 與 MySQL 整合套件，本機沒有服務。
這個 Story 沒有任何判斷需要可連線的資料庫——這正是重點。

**未跑完**：`release:check` 卡在 1/9 步的 `bun audit` 網路逾時，早於任何 repository
檢查執行。環境問題，早於本分支，不當成通過回報。

新增測試涵蓋：catalog 決定性與唯一性、strict schema 拒絕未知欄位、engine/risk/
permission 全部對著真正的權威比對（不是覆述宣告表）、command path 與 JSON 表面對著
實際 Commander tree 雙向比對、discovery 不載入任何 adapter、`requiresConnection:
false` 的指令 import graph 不含 adapter、`mutatesConfiguration` 對著實際設定寫入
呼叫推導、unknown / engine / agent-mode / permission / 缺設定 / 解不開的設定全部
fail closed、exit code、遞迴確認零檔案寫入、以及對 env-ref MongoDB 設定的憑證外洩
探測。

https://claude.ai/code/session_01Cz5NRvBNmqSE7GHFHkFtvT
