### PR TITLE
fix: [ ci ] audit 只在真的有 advisory 時才紅

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,4 +194,7 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - name: Dependency audit
-        run: bun audit
+        # Via `bun run audit` rather than `bun audit` directly: the wrapper
+        # retries a registry that is merely unreachable, so red keeps meaning
+        # "a dependency has an advisory". `release:check` runs the same script.
+        run: bun run audit

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 verify:
 	bun run services:check
-	bun audit
+	bun run audit
 	bun run format:check
 	bun run agent-core:check
 	bun run core-stdout:check

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "build": "bun run scripts/build.ts",
     "build:determinism": "bun run scripts/check-build-determinism.ts",
     "prepublishOnly": "bun run build",
+    "audit": "bun run scripts/audit.ts",
     "release:check": "bash scripts/release-check.sh",
     "plugin:sync": "bun run scripts/sync-plugin-assets.ts --write",
     "plugin:check": "bun run scripts/sync-plugin-assets.ts",

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,0 +1,92 @@
+/**
+ * `bun audit`, with the registry's bad days told apart from this repository's.
+ *
+ * The audit job blocks every push on purpose: an advisory that lands mid-cycle
+ * should turn the branch red while the change that pulled it in is still on
+ * screen. That only works if red means "a dependency has an advisory". On
+ * 2026-09-04 `main` went red because the npm advisory endpoint answered 503 —
+ * a fact about npm, not about this repository, and exactly the kind of noise
+ * that teaches people to re-run a gate without reading it.
+ *
+ * `bun audit` reports both with exit code 1, so the two are separated by what
+ * it printed: transport-level failures are retried with a short backoff,
+ * everything else fails immediately. Exhausting the retries still fails —
+ * an audit that never reached the registry has not cleared anything.
+ */
+
+/**
+ * Transport-level failures, which say nothing about the dependency tree.
+ *
+ * Deliberately narrow: a 5xx or 429 on an `error:` line, and the connection
+ * errors Bun's fetch surfaces. A 4xx other than 429 is a real, stable answer
+ * and is not retried.
+ */
+const TRANSIENT = [
+  /^\s*error:.* - (?:5\d\d|429)\s*$/m,
+  /\bConnection(?:Refused|Closed|Reset)\b/,
+  /\bfetch failed\b/,
+  /\b(?:ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN)\b/,
+  /\bsocket connection was closed\b/i,
+]
+
+/** True when the failure is the registry being unreachable rather than an advisory. */
+export function isTransientAuditFailure(output: string): boolean {
+  return TRANSIENT.some((pattern) => pattern.test(output))
+}
+
+export interface AuditAttempt {
+  exitCode: number
+  output: string
+}
+
+export interface RetryOptions {
+  run: () => Promise<AuditAttempt>
+  attempts: number
+  wait: (ms: number) => Promise<void>
+}
+
+/** Run the audit, retrying only transport failures. Returns the exit code to exit with. */
+export async function runAuditWithRetry({ run, attempts, wait }: RetryOptions): Promise<number> {
+  let last: AuditAttempt = { exitCode: 1, output: '' }
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    last = await run()
+    if (last.exitCode === 0) return 0
+    if (!isTransientAuditFailure(last.output)) return last.exitCode
+
+    if (attempt < attempts) {
+      const delay = 2000 * attempt
+      console.error(
+        `bun audit: registry unreachable (attempt ${attempt}/${attempts}), retrying in ${delay}ms`
+      )
+      await wait(delay)
+    }
+  }
+
+  console.error(
+    `bun audit: registry still unreachable after ${attempts} attempts — failing rather than reporting an audit that never ran`
+  )
+  return last.exitCode
+}
+
+async function spawnAudit(): Promise<AuditAttempt> {
+  const proc = Bun.spawn(['bun', 'audit'], { stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  process.stdout.write(stdout)
+  process.stderr.write(stderr)
+  return { exitCode, output: `${stdout}\n${stderr}` }
+}
+
+if (import.meta.main) {
+  process.exit(
+    await runAuditWithRetry({
+      run: spawnAudit,
+      attempts: 3,
+      wait: (ms) => Bun.sleep(ms),
+    })
+  )
+}

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -6,7 +6,8 @@ cd "$(dirname "$0")/.."
 step() { printf '\n\033[1;34m▶ %s\033[0m\n' "$*"; }
 
 step '1/9 bun audit'
-bun audit
+# Same wrapper CI's `audit` job runs, so the two cannot drift.
+bun run audit
 
 # Via `bun run` so the glob lives in one place (package.json) and CI's `format`
 # job checks exactly what this checks — the two drifting apart is how unformatted

--- a/tests/unit/scripts/audit.test.ts
+++ b/tests/unit/scripts/audit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The audit gate must separate two failures that `bun audit` reports the same
+ * way — exit code 1.
+ *
+ * A published advisory is the signal the job exists for and must stay red on
+ * the first attempt. A 503 from the npm advisory endpoint is the registry
+ * being unavailable, says nothing about this repository's dependencies, and
+ * turned `main` red on 2026-09-04 while nothing had changed. Only the second
+ * is retried, and exhausting the retries still fails: an audit that could not
+ * run is not an audit that passed.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { isTransientAuditFailure, runAuditWithRetry } from '../../../scripts/audit'
+
+describe('isTransientAuditFailure', () => {
+  test('a 5xx from the advisory endpoint is transient', () => {
+    const output = 'error: POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk - 503'
+    expect(isTransientAuditFailure(output)).toBe(true)
+  })
+
+  test('a rate-limited request is transient', () => {
+    expect(isTransientAuditFailure('error: POST https://registry.npmjs.org/-/npm/v1/x - 429')).toBe(
+      true
+    )
+  })
+
+  test('a connection-level error is transient', () => {
+    expect(isTransientAuditFailure('error: ConnectionRefused: Unable to connect')).toBe(true)
+    expect(isTransientAuditFailure('error: fetch failed')).toBe(true)
+  })
+
+  test('a real advisory is not transient', () => {
+    // The failure the job exists for. Retrying it would only delay the report.
+    const output = [
+      'bun audit v1.4.0',
+      '',
+      'lodash  <4.17.21',
+      'Prototype Pollution - https://github.com/advisories/GHSA-1234',
+      '',
+      '1 vulnerability (1 high)',
+    ].join('\n')
+    expect(isTransientAuditFailure(output)).toBe(false)
+  })
+
+  test('a 4xx that is not rate limiting is not transient', () => {
+    expect(isTransientAuditFailure('error: POST https://registry.npmjs.org/-/npm/v1/x - 404')).toBe(
+      false
+    )
+  })
+})
+
+/** A scripted `bun audit` that hands back one canned result per attempt. */
+function scripted(results: Array<{ exitCode: number; output: string }>) {
+  const attempts: number[] = []
+  return {
+    attempts,
+    run: async () => {
+      attempts.push(attempts.length + 1)
+      return results[attempts.length - 1] ?? results[results.length - 1]!
+    },
+  }
+}
+
+const noWait = async () => {}
+
+describe('runAuditWithRetry', () => {
+  test('a clean audit runs once', async () => {
+    const audit = scripted([{ exitCode: 0, output: 'no vulnerabilities found' }])
+    expect(await runAuditWithRetry({ run: audit.run, attempts: 3, wait: noWait })).toBe(0)
+    expect(audit.attempts.length).toBe(1)
+  })
+
+  test('an advisory fails on the first attempt without retrying', async () => {
+    const audit = scripted([{ exitCode: 1, output: '1 vulnerability (1 high)' }])
+    expect(await runAuditWithRetry({ run: audit.run, attempts: 3, wait: noWait })).toBe(1)
+    expect(audit.attempts.length).toBe(1)
+  })
+
+  test('a registry outage is retried and the later success is the result', async () => {
+    const audit = scripted([
+      { exitCode: 1, output: 'error: POST https://registry.npmjs.org/x - 503' },
+      { exitCode: 0, output: 'no vulnerabilities found' },
+    ])
+    expect(await runAuditWithRetry({ run: audit.run, attempts: 3, wait: noWait })).toBe(0)
+    expect(audit.attempts.length).toBe(2)
+  })
+
+  test('an outage that outlasts the retries still fails', async () => {
+    // Fail closed. Reporting green for an audit that never reached the registry
+    // would make the job say something it does not know.
+    const audit = scripted([
+      { exitCode: 1, output: 'error: POST https://registry.npmjs.org/x - 503' },
+    ])
+    expect(await runAuditWithRetry({ run: audit.run, attempts: 3, wait: noWait })).toBe(1)
+    expect(audit.attempts.length).toBe(3)
+  })
+
+  test('an advisory found after a retry is reported, not swallowed', async () => {
+    const audit = scripted([
+      { exitCode: 1, output: 'error: POST https://registry.npmjs.org/x - 503' },
+      { exitCode: 1, output: '2 vulnerabilities (1 high, 1 low)' },
+    ])
+    expect(await runAuditWithRetry({ run: audit.run, attempts: 3, wait: noWait })).toBe(1)
+    expect(audit.attempts.length).toBe(2)
+  })
+})


### PR DESCRIPTION
## 背景

audit job 刻意每次 push 都擋，前提是「紅」等於「相依套件有 advisory」。

2026-09-04 `main`（merge commit `9719eb49`）變紅，原因是：

```
bun audit
error: POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk - 503
##[error]Process completed with exit code 1.
```

npm 的 advisory 端點回 503。那是 npm 的事實，不是這個 repo 的——而這種雜訊正好會訓練大家不看內容就直接重跑 gate，長期會侵蝕這個 job 存在的意義。

## 修正

`bun audit` 兩種失敗都是 exit 1，所以改用**輸出**區分：

- 傳輸層失敗（`error: ... - 5xx/429`、`ConnectionRefused/Closed/Reset`、`fetch failed`、`ETIMEDOUT` 等）→ 退避重試，最多 3 次（2s、4s）
- 其餘一律第一次就失敗，不拖延真正的 advisory 回報
- **重試用盡仍然失敗**——沒連到 registry 的稽核不算通過，不 fail-open

刻意收窄：429 以外的 4xx 是穩定且真實的回答，不重試。

包成 `scripts/audit.ts`，`Makefile`、`.github/workflows/ci.yml`、`scripts/release-check.sh` 三個呼叫點統一改走 `bun run audit`，避免其中一個漏改後又各自漂移。

## Test plan

- `tests/unit/scripts/audit.test.ts` 新增 10 個測試（先 RED 後 GREEN）：503 重試、429 重試、連線錯誤重試、真 advisory 不重試、404 不重試、重試後才出現的 advisory 仍要回報、重試用盡仍失敗
- 對真實 registry 跑 `bun run audit` → `No vulnerabilities found`，exit 0
- `make verify` 本地全過
- branch CI 已在 `1e10b8d0` 全綠（22 checks）

https://claude.ai/code/session_01Cz5NRvBNmqSE7GHFHkFtvT