### PR TITLE
fix: [ schema ] DBCLI-PLAT-012 讓快取寫入停止當一次完整設定的重新發布

### DIFF
--- a/.cursor/skills/dbcli/reference.md
+++ b/.cursor/skills/dbcli/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/.github/skills/dbcli/reference.md
+++ b/.github/skills/dbcli/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/.windsurf/skills/dbcli/reference.md
+++ b/.windsurf/skills/dbcli/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ ForgeFlow Story DBCLI-001 到 DBCLI-012 全數交付但尚未發布：`v7.0.1`�
   因為替它們寫 engine 支援度等於憑讀碼捏造未經稽核的宣稱。它們回 `unknown`，
   擴充 matrix 是後續 Story。（DBCLI-PLAT-001，ADR-0022）
 
+### Fixed
+
+- **Schema cache 的寫入不再是一次完整設定的重新發布。** `dbcli schema` 原本透過
+  `configModule.write`（v1）與 `writeV2Config`（v2）存快取，兩者都在
+  `assertConfigMutationApproved()` 後面，所以 `DBCLI_AGENT_MODE=1` 下
+  `capabilities check` 回報 `schema.read` 可用、指令本身卻 exit 1，訊息還說的是
+  「configuration, permission, and credential changes」——只讀 exit code 的 agent
+  只能推論成資料庫讀取失敗，而讀取其實成功了。
+
+  移動時量到一個沒有人記錄過的缺陷：v1 路徑會把 `connection.password` 從
+  `config.json` 刪掉、並整份覆寫 `.env.local`。這件事**在 agent mode 之外也會發生**，
+  也就是每一次 `dbcli schema` 都在搬憑證，而那裡根本沒有任何 guard 會攔。
+
+  新的 `src/core/schema-cache-persistence.ts` 只寫快取欄位，而且**寫不出別的東西**：
+  它的參數只有 schema、connection slot 與兩個時間戳，設定是它自己從磁碟讀的，
+  沒有任何參數能夠承載憑證或權限。窄化在簽章，不在旗標——一個「這次寫入沒問題」的
+  布林參數等於把邊界交給呼叫端的誠實。`assertOnlyCacheFieldsChanged` 把同一句保證
+  講出來，任何擴大寫入範圍的修改會在單元測試指名欄位而失敗。
+
+  `assertConfigMutationApproved()` 一個字都沒改，六個 guarded writer 一個都沒少，
+  並由 `tests/contract/config-mutation-boundary.test.ts` 以名冊釘住。agent mode 下
+  `init`、`use`、`blacklist add` 與憑證指令照樣被拒。（DBCLI-PLAT-012）
+
+- **快取寫入失敗現在說自己是快取寫入失敗。** 訊息明講 schema 已成功讀出、失敗的是
+  存進本機快取那一步，並且是 bounded 的：只有 `SchemaCacheWriteError` 會原樣輸出
+  （它的訊息在建構上就不含路徑），其他成因一律分類而不引用，因為完整性拒絕會帶上
+  它檢查的設定檔路徑。（DBCLI-PLAT-012）
+
 ### Breaking
 
 - **query-only 的最後一道界線改由資料庫提供。** PostgreSQL / MySQL / MariaDB 上

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,6 +158,16 @@ A configuration exists and could not be turned into an engine and a permission
 a different fact from *context unavailable*, and reporting it as one would
 state something false about the machine. Both fail closed.
 
+**Schema cache**:
+The table shapes dbcli has read, stored locally so later commands need not read
+them again. It lives inside `config.json` and in the layered store under
+`.dbcli/schemas/`, but storage is the only thing it shares with the
+configuration: it is *derived* data, re-readable at any time from the database
+the configuration already points at, and it holds nothing an agent that can run
+`dbcli schema` cannot already see. Writing it is therefore not a configuration
+change, and it is not behind the agent-mode boundary. Connection identity,
+permission and credentials are configuration; the cache next to them is not.
+
 **Environment gate**:
 A refusal decided before execution and knowable without connecting — agent
 mode is the only one today. It is distinct from an execution-time gate

--- a/assets/reference.md
+++ b/assets/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
+++ b/docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
@@ -143,6 +143,14 @@ the identity guard. That is DBCLI-PLAT-012.
 `INCIDENTAL_CONFIG_WRITERS` in `tests/contract/capability-contract.test.ts`
 names the exemption so it cannot become a silent gap.
 
+**Closed by DBCLI-PLAT-012.** The cache write moved to
+`src/core/schema-cache-persistence.ts`, which cannot express a configuration
+change rather than being permitted to make one, so `schema.read` reporting
+`available` under agent mode is now simply true. `INCIDENTAL_CONFIG_WRITERS` is
+empty; it stays in place because re-populating it should be a decision, not a
+refactor. The paragraphs above are kept as the record of what was accepted and
+why — this decision is unchanged, only its one disclosed exception is gone.
+
 **Falsified if:** a capability in `src/core/capabilities/registry.ts` declares an
 `engines` or `risk` value literally instead of deriving it from
 `ENGINE_CAPABILITIES` in `src/adapters/capabilities.ts`, or a

--- a/docs/plans/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/plans/2026-09-04-agent-integration-contract-v1.md
@@ -38,7 +38,7 @@ This plan covers the first vertical slice only. Everything after it is backlog.
 13. `minimumPermission` comes from the runtime permission ladder rather than a transcription — covered by: `tests/unit/core/capabilities/registry.test.ts`
 14. `DATABASE_SYSTEMS` matches the keys of `ENGINE_CAPABILITIES` — covered by: `tests/unit/adapters/database-systems-roster.test.ts`
 15. `requiresConnection: true` is not independently proven; only the `false` direction is checked, since a false offline claim is the one that misleads — unverified: no test asserts that a connection-requiring command actually opens one
-16. Under `DBCLI_AGENT_MODE=1`, `schema.read` reports `available` although the command's schema-cache persistence step is refused — known deviation: marking the `schema` capabilities would tell an agent schema cannot be read at all, a larger error in the opposite direction; DBCLI-PLAT-012 removes the cause
+16. Under `DBCLI_AGENT_MODE=1`, `schema.read` reports `available` and `dbcli schema` succeeds there — covered by: `tests/integration/schema-cache-agent-mode.test.ts` (shipped as a known deviation and closed by DBCLI-PLAT-012, which moved the cache write out from behind the identity guard)
 
 ## Five things this slice got wrong first, and what caught them
 

--- a/docs/specs/2026-09-04-agent-integration-contract-v1.md
+++ b/docs/specs/2026-09-04-agent-integration-contract-v1.md
@@ -135,6 +135,22 @@ read schema at all — a much larger error in the opposite direction. The real f
 is that a schema *cache* write is not a change of connection identity and should
 not sit behind the identity guard: DBCLI-PLAT-012.
 
+**Closed by DBCLI-PLAT-012.** The reasoning above is left standing because it is
+why shipping the overstatement was defensible, not because it still describes
+the product. `src/core/schema-cache-persistence.ts` now stores the cache
+directly: it takes a schema and two timestamps, reads the config itself, and
+writes back a document differing only in the cache fields, so there is nothing
+for the identity guard to approve. `assertConfigMutationApproved()` is
+unchanged and still refuses every connection, permission and credential change
+under agent mode. The claim and the command are tied together by
+`tests/integration/schema-cache-agent-mode.test.ts`, which asks
+`capabilities check` and then runs `dbcli schema` in one test.
+
+Moving it also closed a defect nobody had recorded: the v1 cache write went
+through `configModule.write`, which republishes the whole document, so every
+`dbcli schema` deleted `connection.password` from `config.json` and rewrote
+`.env.local` — outside agent mode too, where no guard fires.
+
 ### "No config" and "config I cannot resolve" are different facts
 
 Conflating them was a defect, not a simplification. A config whose

--- a/plugins/dbcli-agent/skills/dbcli/reference.md
+++ b/plugins/dbcli-agent/skills/dbcli/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/skills/dbcli/reference.md
+++ b/skills/dbcli/reference.md
@@ -1758,10 +1758,9 @@ agent-mode and permission grounds. Blacklist, write gate, confirmation and audit
 at execution time, and no human has agreed to anything. `admin` in a config file
 is a permission level, not a DBA sign-off.
 
-One known overstatement: `dbcli schema` persists its result into `config.json`,
-and that write is refused under `DBCLI_AGENT_MODE=1`. `schema.read` still
-reports `available` there, because the read itself works and marking it
-unavailable would suggest schema cannot be read at all.
+`schema.read` is available under `DBCLI_AGENT_MODE=1`, and `dbcli schema` runs
+there: storing the schema cache is not a configuration change. Agent mode still
+refuses every change to connection identity, permission and credentials.
 
 **Permission:** query-only+ (no connection is made)
 

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -5,8 +5,9 @@
 採用版本的對帳、發布前的盤點，以及把仍留在這份散文裡的風險移出去。那一批結束時
 沒有已知的產品缺口。
 
-之後開的是 Agent Platform 這條線：DBCLI-PLAT-001 已交付，DBCLI-PLAT-013 是目前
-進行中的 Story，收 PLAT-001 留下的契約與交接兩個尾，下一個是 DBCLI-PLAT-012。
+之後開的是 Agent Platform 這條線：DBCLI-PLAT-001 與 DBCLI-PLAT-013 已交付，
+目前進行中的是 DBCLI-PLAT-012——把 schema cache 的寫入從連線身分的閘門後面搬出來，
+關掉 PLAT-001 記下的那個已知過度宣稱。
 
 未結的是發布：DBCLI-001 到 012 的成果全部未發布，建議版本 8.0.0，留給下一個獨立的
 release Story。bump 之前 `SECURITY.md` 的支援列必須從 `7.x` 改成 `8.x`，否則
@@ -152,7 +153,7 @@ revision 是否存在，所以不宣稱；能查的是這個 repository 對它�
 既有的 `check-forgeflow-handoff.ts` 原封不動，兩支互不涵蓋——一支對帳交付宣稱，
 一支對帳流程版本。
 
-## DBCLI-PLAT-013：契約與交接的收尾
+## 已交付：DBCLI-PLAT-013——契約與交接的收尾
 
 三件事，同一個形狀：一句寫下來的宣稱，沒有任何東西拿它跟 repository 對帳。
 
@@ -203,12 +204,53 @@ shallow clone 仍然拒絕驗證，而且「既不是 true 也不是 false」的
 讀不懂的答案當成「不是 shallow」，就是在證據缺席時假設證據沒事，正是這個 gate
 存在要防的事。
 
+## DBCLI-PLAT-012：schema cache 的寫入邊界
+
+PLAT-001 交付時記下的那個已知過度宣稱，起因已經移除：`DBCLI_AGENT_MODE=1` 下
+`capabilities check` 說 `schema.read` 可用，`dbcli schema` 卻 exit 1。
+
+這個 Story 最值得留下的一句：**真正的缺陷不是 guard 放錯位置，是快取更新根本是一次
+完整設定的重新發布，只是掛著快取的名字。**
+
+原本的辯護是「schema cache 存在 `config.json` 裡，所以擋在設定的閘門後面」。動手
+之前先量了一次：對一份 `connection.password: "testpass"`、`.env.local` 寫著
+`DB_PASSWORD=untouched` 的設定跑一次 schema 寫入，結果是密碼被從 `config.json`
+刪掉、`.env.local` 被整份覆寫成新產生的 `DBCLI_PASSWORD=testpass`。這件事**在
+agent mode 之外也會發生**——那裡沒有任何 guard 會攔。所以那個 guard 不是防線，
+它只是唯一會對這個行為出聲的東西，而且出的還是錯的聲。
+
+修法刻意不是替 guard 開一個例外。一個「這次寫入沒問題」的布林參數，等於把邊界交給
+呼叫端記得誠實；guard 保護的就會變成「大家有沒有老實申報」。
+`src/core/schema-cache-persistence.ts` 的窄化在**簽章**：參數只有 schema、
+connection slot 與兩個時間戳，設定是它自己從磁碟讀的，沒有任何一條路徑能讓憑證、
+權限或 host 通過。寫不出來的東西不需要被批准。
+
+`assertOnlyCacheFieldsChanged` 把同一句保證講出來。它對今天的程式是多餘的——這正是
+重點：任何擴大寫入範圍的修改會在單元測試裡指名欄位而失敗，而不是上線。
+
+`assertConfigMutationApproved()` 一個字都沒改。六個 guarded writer 一個都沒少，並由
+`tests/contract/config-mutation-boundary.test.ts` 以名冊釘住兩個方向：清單裡的都要
+guard，清單外的都不准 guard。名冊的比對只讀程式碼、不讀註解——seam 與 schema 指令的
+檔頭都在**討論**這個 guard，把提及算成呼叫的檢查只能靠刪掉解釋來滿足。
+
+還有一件事是新的：契約與行為現在綁在同一支測試裡。
+`tests/integration/schema-cache-agent-mode.test.ts` 先問 `capabilities check`、
+再跑 `dbcli schema`，對真的 PostgreSQL。PLAT-001 的過度宣稱能活下來，就是因為沒有
+任何東西同時問過這兩件事。
+
+`INCIDENTAL_CONFIG_WRITERS` 因此清空。它留在原地而不是刪掉：再加回一筆應該是一個
+決定，不是一次重構。
+
+過程中撞到、確認為既有且範圍外的一件事：agent mode 下，設定若是透過 symlink 路徑
+（macOS 的 `/var/folders` 對 `/private/var/folders`）讀到，完整性紀錄的 `targetPath`
+會對不上而被判成 tampering。整合測試用 `realpath` 迴避，原因寫在測試裡。
+
 ## Lifecycle
 
 ```yaml
 workflow:
-  current_story: DBCLI-PLAT-013
-  next_story: DBCLI-PLAT-012
+  current_story: DBCLI-PLAT-012
+  next_story: pending
   completed_stories:
     - DBCLI-001
     - DBCLI-002
@@ -224,33 +266,36 @@ workflow:
     - DBCLI-012
     - DBCLI-013
     - DBCLI-PLAT-001
+    - DBCLI-PLAT-013
   status: in_progress
 
 baseline:
   repository: CarlLee1983/dbcli
-  branch: feat/dbcli-plat-013-agent-platform-closeout
-  # The state on main when DBCLI-PLAT-013 started: PR #153 merged, PLAT-001 shipped.
+  branch: feat/dbcli-plat-012-schema-cache-write-boundary
+  # The state on main when DBCLI-PLAT-013 started; PLAT-012 continues from its commit.
   commit: c3e701a1
   dirty_worktree: false
   story_owned_paths:
-    - specs/stories/DBCLI-PLAT-013-agent-platform-closeout/
-    - specs/stories/DBCLI-PLAT-001-capability-contract/story.md
+    - specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/
+    - src/core/schema-cache-persistence.ts
+    - src/commands/schema.ts
+    - tests/unit/core/schema-cache-persistence.test.ts
+    - tests/contract/config-mutation-boundary.test.ts
+    - tests/integration/schema-cache-agent-mode.test.ts
+    - tests/docs/schema-cache-deviation-closed.test.ts
+    - tests/contract/capability-contract.test.ts
+    - tests/unit/commands/schema-refresh-bootstrap.test.ts
     - specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
-    - scripts/lib/forgeflow-handoff.ts
-    - scripts/check-forgeflow-handoff.ts
-    - tests/unit/scripts/forgeflow-handoff.test.ts
-    - tests/docs/capability-ordering-parity.test.ts
     - docs/specs/2026-09-04-agent-integration-contract-v1.md
+    - docs/plans/2026-09-04-agent-integration-contract-v1.md
+    - docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md
     - assets/reference.md
     - .cursor/skills/dbcli/reference.md
     - .github/skills/dbcli/reference.md
     - .windsurf/skills/dbcli/reference.md
     - plugins/dbcli-agent/skills/dbcli/reference.md
     - skills/dbcli/reference.md
-    - docs/user/en/index.md
-    - docs/user/en/index.html
-    - docs/user/zh-TW/index.md
-    - docs/user/zh-TW/index.html
+    - CONTEXT.md
     - CHANGELOG.md
     - specs/handoff.md
   known_unrelated_paths: []
@@ -259,12 +304,12 @@ verification:
   last_command: make verify
   result: pass
   detail: >-
-    6576 pass / 0 fail / 0 skip across 560 files, with the docker-compose.test.yml
-    services running, so no integration suite skipped. Baseline on c3e701a1 under the
-    same services was 6533 / 558; the difference is this Story's two new files.
-    All 23 static gates passed, forgeflow:check included — it now reconciles 14
-    completed Stories, the fourteenth being DBCLI-PLAT-001. The first attempt failed
-    at step 2/23 on a `bun audit` registry timeout after its retries were exhausted;
-    the rerun completed. release:check was not run: it is the release gate, and this
-    Story publishes nothing.
+    6622 pass / 0 fail / 0 skip across 564 files, with the docker-compose.test.yml
+    services running, so nothing skipped. The PLAT-013 baseline under the same
+    services was 6576 / 560; the difference is this Story's four new files. All 23
+    static gates passed. Two pre-existing tests changed deliberately and are named
+    in the Story's Superseded Behavior: the capability contract's
+    INCIDENTAL_CONFIG_WRITERS exemption (now empty) and the schema-refresh
+    bootstrap fixture (now has the config it always implied). release:check was not
+    run: it is the release gate, and this Story publishes nothing.
 ```

--- a/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
+++ b/specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md
@@ -91,7 +91,13 @@ them: no case in this Story needs a reachable database, which is the point.
 * [x] "Mutates nothing on disk" is asserted recursively —
       `tests/integration/capabilities-command.test.ts`
 
-### Known deviation
+### Known deviation — closed by DBCLI-PLAT-012
+
+Recorded as accepted at delivery, and kept: it is what this Story shipped, and
+deleting it would rewrite that. It no longer describes the product —
+DBCLI-PLAT-012 moved the cache write to `src/core/schema-cache-persistence.ts`,
+and `tests/integration/schema-cache-agent-mode.test.ts` asserts that
+`capabilities check` and `dbcli schema` now agree under agent mode.
 
 Under `DBCLI_AGENT_MODE=1`, `schema.read` / `schema.read-object` /
 `schema.scan` report `available` although `dbcli schema` persists into

--- a/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/acceptance.md
+++ b/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/acceptance.md
@@ -1,0 +1,103 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] Under `DBCLI_AGENT_MODE=1`, `dbcli schema` completes against a v1 config
+      and the table appears in `config.json`'s `schema` —
+      `tests/integration/schema-cache-agent-mode.test.ts`
+* [x] Under `DBCLI_AGENT_MODE=1`, `dbcli schema` completes against a v2 config
+      and the table appears in `schemas[<connection>]` — same file
+* [x] Outside agent mode, a cache write leaves `connection`, `permission`,
+      `blacklist` and `audit` deep-equal to what was on disk, and leaves
+      `.env.local` byte-identical — `tests/unit/core/schema-cache-persistence.test.ts`
+* [x] `metadata.schemaLastUpdated` and `metadata.schemaTableCount` are updated
+      by the seam — `tests/unit/core/schema-cache-persistence.test.ts`
+
+## Business Rules
+
+* [x] The seam's signature admits only a schema, a connection name and the two
+      cache timestamps — no config document, connection, permission or
+      credential — `tests/unit/core/schema-cache-persistence.test.ts`
+* [x] Applied to a config on disk, the seam changes exactly the cache fields:
+      every other byte of the parsed document is deep-equal before and after —
+      same file
+* [x] `assertOnlyCacheFieldsChanged` refuses a candidate that differs outside
+      the cache projection, naming the offending top-level field and nothing
+      else — same file
+* [x] The seam writes an integrity record, and the written config passes
+      `assertConfigIntegrity` — same file
+* [x] `.env.local` is byte-identical before and after a v1 cache write, and is
+      not opened for writing — same file
+* [x] `assertConfigMutationApproved()` is unchanged, and the set of modules
+      calling it is unchanged except that `src/commands/schema.ts`'s cache path
+      no longer reaches it —
+      `tests/contract/config-mutation-boundary.test.ts`
+* [x] `schema.read` is `available` under agent mode *and* the command it names
+      succeeds there — `tests/contract/config-mutation-boundary.test.ts`
+
+## Failure Cases
+
+* [x] Under `DBCLI_AGENT_MODE=1`, `dbcli init`, `dbcli use <name>`,
+      `dbcli blacklist add`, and the credential commands are still refused with
+      the unchanged guard message —
+      `tests/contract/config-mutation-boundary.test.ts`
+* [x] A v2 config whose named connection slot is absent is refused, naming the
+      connection and not the storage path —
+      `tests/unit/core/schema-cache-persistence.test.ts`
+* [x] A tampered `config.json` is refused before the seam writes anything —
+      same file
+* [x] A cache write that fails states the schema was read successfully and
+      names the cache write as the failing step; the message is not a database
+      or connection error — `tests/integration/schema-cache-agent-mode.test.ts`
+* [x] A cache-write failure leaves the on-disk config unchanged rather than
+      half-written — `tests/unit/core/schema-cache-persistence.test.ts`
+
+## Regression Requirements
+
+* [x] No output from the seam or its failure path contains a password, host,
+      port, connection string, env-var value or absolute path —
+      `tests/unit/core/schema-cache-persistence.test.ts`,
+      `tests/integration/schema-cache-agent-mode.test.ts`
+* [x] The PLAT-001 known deviation is gone from `acceptance.md`, the design
+      record, `assets/reference.md` with its five mirrors, and both user-doc
+      locales in both formats — `tests/docs/schema-cache-deviation-closed.test.ts`
+* [x] `agent-core` purity, core no-stdout, CLI contract, skill parity, platform
+      parity, plugin sync, docs, plan and forgeflow gates all still pass —
+      `make verify`
+* [x] `make verify` passes in full
+
+## Security Fixture Matrix
+
+| Source field | Payload | Expected result | Persisted locations | Verification |
+| --- | --- | --- | --- | --- |
+| `schema` | `{"plat012_demo":{"name":"plat012_demo","columns":[{"name":"id","type":"integer"}]}}` | preserve | `config.json` `schema.plat012_demo` | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `connectionName` | `"no-such-connection"` | reject | `config.json` unchanged | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `candidate.connection.password` | `"attacker-supplied"` | reject | `config.json` unchanged | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `candidate.permission` | `"admin"` | reject | `config.json` unchanged | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `candidate.blacklist.tables` | `[]` | reject | `config.json` unchanged | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `candidate.metadata.version` | `"2.0"` | reject | `config.json` unchanged | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `schema` table name | `"users; DROP TABLE x"` | preserve | `config.json` `schema` key | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `.env.local` on disk | `DB_PASSWORD=untouched` | preserve | `.env.local` | `tests/unit/core/schema-cache-persistence.test.ts` |
+| `connection.password` on disk | `"testpass"` | preserve | `config.json` `connection.password` | `tests/unit/core/schema-cache-persistence.test.ts` |
+| cache-write failure message | `"EACCES: permission denied, open '/Users/someone/.config/dbcli/config.json'"` | redact | stderr, audit entry | `tests/integration/schema-cache-agent-mode.test.ts` |
+
+`preserve` on the `schema` table-name row is deliberate: a table name is data read
+back from the database the config already points at, and rewriting it would make
+the cache disagree with the server. The injection surface it would matter for is
+SQL construction, which the cache is not.
+
+## Verification Notes
+
+The agent-mode integration tests need the `docker-compose.test.yml` PostgreSQL
+service; `bun run services:check` refuses to run `make verify` without it.
+
+Two `preserve` rows record behaviour this Story **changes**, and they are the
+reason the criterion above is not "byte-identical to what the old path wrote".
+Measured on `c3e701a1` against a v1 fixture holding
+`connection.password: "testpass"` and an `.env.local` reading
+`DB_PASSWORD=untouched`, a schema cache write through `configModule.write`
+deleted `connection.password` from `config.json` and overwrote `.env.local`
+with a freshly generated `DBCLI_PASSWORD=testpass`, destroying the existing
+file. A cache update moving a credential between files is the conflation this
+Story exists to end, so the fixtures assert the new behaviour and
+`story.md`'s Superseded Behavior names the old one.

--- a/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/story.md
+++ b/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/story.md
@@ -1,0 +1,221 @@
+# Story: DBCLI-PLAT-012 Schema Cache Write Boundary
+
+## Goal
+
+Under `DBCLI_AGENT_MODE=1`, an agent that asks `dbcli capabilities check
+--require schema.read` and is told `available` can then run `dbcli schema` and
+have it finish — while agent mode keeps refusing every change to connection
+identity, permission and credentials, exactly as it does today.
+
+## Context
+
+DBCLI-PLAT-001 shipped one known overstatement and named this Story as the fix.
+`schema.read` reports `available` under agent mode, and `dbcli schema` fails
+there. Reproduced on `c3e701a1` against the repository's own PostgreSQL test
+service:
+
+```
+$ DBCLI_AGENT_MODE=1 dbcli capabilities check --require schema.read --format json
+  "results": [ { "id": "schema.read", "status": "available", "reason": null } ]
+
+$ DBCLI_AGENT_MODE=1 dbcli schema
+🔍 Scanning database schema...
+📍 Found 1 table(s). Fetching schema details...
+   Processed 1/1 table(s)
+✅ Schema persisted to layered storage (.dbcli/schemas/)
+Agent mode blocks configuration, permission, and credential changes. …
+  exit 1
+```
+
+Three separate problems are visible in that transcript.
+
+**The capability claim is false.** It is the only promise in the contract an
+agent would act on and find broken, which is the failure PLAT-001 exists to
+prevent — it shipped with it recorded rather than fixed because marking
+`schema.read` unavailable would tell an agent schema cannot be read at all, a
+larger error in the other direction.
+
+**The guard is being asked the wrong question.** `assertConfigMutationApproved()`
+protects connection identity, permission and credentials: things an untrusted
+automation context must not change, where an environment variable supplied by
+that same process is not an approval. A schema cache is none of those. It is
+derived data, re-derivable at any time by reading the database the config
+already points at, and an agent that can read the schema can already see
+everything the cache would hold. The guard sits where it does only because the
+cache happens to live inside `config.json`, next to the credentials — storage
+adjacency, not a shared trust decision.
+
+The write actually goes through `configModule.write` (v1) or `writeV2Config`
+(v2), and the v1 path does more than store a cache. Measured on `c3e701a1`
+against a config holding `connection.password: "testpass"` and an `.env.local`
+reading `DB_PASSWORD=untouched`, a schema cache write **deleted
+`connection.password` from `config.json` and overwrote `.env.local`** with a
+freshly generated `DBCLI_PASSWORD=testpass`, destroying the file that was
+there. Updating a derived cache moves a credential between files today. That is
+the conflation, and it is worse than "the guard is in the wrong place": outside
+agent mode, where no guard fires at all, the credential move happens silently on
+every `dbcli schema`.
+
+**The failure is reported as the wrong thing, twice.** The message names
+"configuration, permission, and credential changes" for what was a cache write,
+and nothing in the output says the schema was read successfully — an agent
+reading only the exit code concludes the database read failed. It also leaves
+the two caches disagreeing: the layered store under `.dbcli/schemas/` was
+written before the refusal, so it holds the new schema while `config.json` still
+holds the old one, silently.
+
+The fix is not to widen the guard's exemptions. A boolean "this write is fine"
+argument would be a flag any future caller can pass, and the guard would then be
+protecting whatever callers remembered to be honest about. The fix is a seam
+narrow enough that it cannot express a credential change: a function whose
+parameters are a schema and two cache timestamps, which reads the config from
+disk itself and writes back a document differing only in the cache fields.
+
+## Classification
+
+* Security sensitive: yes
+* Baseline conformance: yes
+
+## Scope
+
+### In Scope
+
+* `src/core/schema-cache-persistence.ts`: one named seam that persists a schema
+  cache and nothing else, for both v1 and v2 configs.
+* `src/commands/schema.ts`: the three `writeSchema` call sites move onto it.
+* Reporting: a cache-write failure names the cache write, states that the schema
+  was read, and does not read as a database failure.
+* Removing the PLAT-001 known deviation from `acceptance.md`, the design record,
+  `assets/reference.md` and both user-doc locales in both formats.
+* A contract test tying the capability verdict to the command's real behaviour
+  under agent mode.
+
+### Out of Scope
+
+* Any change to `assertConfigMutationApproved()`, or to which of
+  `configModule.write`, `writeV2Config`, `writeBindingWithIntegrity` and the
+  credential writers it guards.
+* `SchemaUpdater.refreshSchema` (`src/core/schema-updater.ts`). It is exported
+  from `@carllee1983/dbcli/core` but no command reaches it, so no CLI behaviour
+  and no capability claim depends on it; and it writes `metadata.version =
+  '2.0'` alongside the cache, which is outside the cache projection and is its
+  own question. Recorded rather than swept in.
+* The layered store's own write path. It is already outside the guard and stays
+  there.
+* Making `dbcli schema` succeed at anything it fails at today for a reason other
+  than the cache write.
+* Every later platform capability.
+
+## Inputs
+
+* The on-disk config at the resolved storage path — read by the seam itself,
+  never supplied by the caller.
+* `schema`: the table map just read from the database.
+* `connectionName`: the v2 connection slot, or `undefined` for v1.
+* `schemaLastUpdated`, `schemaTableCount`.
+* `DBCLI_AGENT_MODE`.
+
+## Outputs
+
+* An updated `config.json` plus its integrity record.
+* On failure, a bounded message naming the cache write as the failing step.
+
+## Rules
+
+* R1: The seam takes a schema and cache metadata. It accepts no connection,
+  permission, credential or arbitrary config document, so it cannot express a
+  change to any of them.
+* R2: Before writing, the seam compares the candidate document against the one
+  on disk with the cache fields projected out, and refuses if anything else
+  differs. Structural narrowness is the guarantee; this is the check that says
+  so out loud.
+* R3: The cache fields are exactly `schema` (v1), `schemas[<connection>]` (v2),
+  `metadata.schemaLastUpdated` and `metadata.schemaTableCount`. Nothing else.
+* R4: The seam never writes `.env.local` and never moves a credential between
+  files.
+* R5: `assertConfigMutationApproved()` is unchanged, and every writer that
+  guards it today still guards it.
+* R6: Under agent mode, `dbcli schema` persists its cache; `dbcli init`,
+  `dbcli use`, `dbcli blacklist add/remove` and every credential command are
+  still refused.
+* R7: A cache-write failure states that the schema was read successfully and
+  names the cache write as what failed. It never presents itself as a database
+  or connection error.
+* R8: Integrity records are written for every seam write, and a tampered config
+  is still refused before the seam reads it.
+* R9: No output from the seam or its failure path contains a password, host,
+  port, connection string, env-var value or absolute filesystem path.
+* R10: `schema.read` / `schema.read-object` / `schema.scan` reporting
+  `available` under agent mode is now true, and a test asserts the command
+  agrees rather than the docs asserting it.
+
+## Expected Errors
+
+* A config that is absent, unreadable, or fails its integrity check: refused
+  before any write, with the existing error, unchanged.
+* A v2 config whose named connection slot does not exist: refused, naming the
+  connection, not the storage path.
+* A candidate document differing outside the cache projection: refused as an
+  internal invariant violation, naming the offending top-level field only.
+
+## Dependencies
+
+* `src/core/config-mutation-guard.ts` — the guard this Story deliberately does
+  not touch.
+* `src/core/config-integrity.ts` — `writeConfigWithIntegrity`,
+  `assertConfigIntegrity`.
+* `src/core/config-v2.ts` — `patchConnectionSchema`, `readV2Config`.
+* `src/core/capabilities/` — the contract whose claim this makes true.
+
+## Constraints
+
+* No second config writer: the seam composes the existing integrity writer
+  rather than reimplementing atomic write or hashing.
+* No weakening of permission, blacklist, write gate, audit, redaction or
+  deny-by-default behaviour.
+* No new environment variable, flag or config key that relaxes a boundary.
+
+## Trust Boundary Fields
+
+* `schema` — table and column names read from the database, written into the
+  cache.
+* `connectionName` — from the v2 config's resolved connection, echoed in
+  refusals.
+* `schemaLastUpdated`, `schemaTableCount` — derived locally from the read.
+* `DBCLI_AGENT_MODE` — process environment, read by the guard only.
+* The cache-write failure message — derived from a caught error, which may
+  carry a filesystem path from the runtime.
+
+## Superseded Behavior
+
+* `specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md`, "Known
+  deviation" — marked closed, not deleted. It was a true statement about what
+  was accepted at delivery, and removing it would rewrite that.
+* `docs/specs/2026-09-04-agent-integration-contract-v1.md`, "The known
+  overstatement", and `docs/adr/0022-…`, "The one place the contract knowingly
+  overstates availability" — both keep their reasoning and gain a closing note.
+  Design records are appended to, not rewritten (ADR-0001).
+* `docs/plans/2026-09-04-agent-integration-contract-v1.md`, criterion 16 — its
+  `— known deviation:` annotation becomes `— covered by:` naming the test that
+  now proves the claim.
+* `tests/contract/capability-contract.test.ts`, `INCIDENTAL_CONFIG_WRITERS` —
+  `schema` was its only entry and the exemption's cause is gone; the set becomes
+  empty and the comment records why.
+* `tests/unit/commands/schema-refresh-bootstrap.test.ts` — its fixture had no
+  configuration on disk, relying on the cache write to publish one. The seam
+  refuses to create a configuration, so the fixture gains the config it always
+  implied. What the tests assert — whether `--force` is required — is unchanged.
+* `assets/reference.md`, "One known overstatement: `dbcli schema` persists its
+  result into `config.json`…" — removed, along with its five synced mirrors.
+  User-facing reference states what is true now; the history lives in the design
+  records. (Neither user-doc locale carried the sentence.)
+* `src/commands/schema.ts`'s v1 cache path, via `configModule.write` — a cache
+  update no longer normalises the config document, no longer removes
+  `connection.password` from `config.json`, and no longer writes `.env.local`.
+  Any test asserting the password move as the expected outcome of a *schema*
+  write changes; tests asserting it for `init` or a credential command do not.
+* `tests/integration/capabilities-command.test.ts` and
+  `tests/unit/core/capabilities/check.test.ts` — any assertion that documents
+  the deviation changes to assert the command now succeeds. An assertion that
+  merely checks `schema.read` is `available` under agent mode is unchanged; it
+  was always the right answer, for a reason that is now true.

--- a/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/task.md
+++ b/specs/stories/DBCLI-PLAT-012-schema-cache-write-boundary/task.md
@@ -1,0 +1,33 @@
+# Implementation Progress
+
+This optional file tracks execution progress. Product requirements belong in
+`story.md` and `acceptance.md`.
+
+## Plan
+
+* [x] Measure the pre-change v1 cache write on `c3e701a1`. Done, and it changed
+      the plan: the old path deleted `connection.password` and overwrote
+      `.env.local`, so "byte-identical to the old output" was the wrong
+      criterion and became "nothing outside the cache fields moves". Recorded in
+      `acceptance.md`'s Verification Notes and the Story's Superseded Behavior.
+* [x] Failing tests first: the seam unit tests, the mutation-boundary contract
+      test, the agent-mode integration test, the deviation-closed docs test.
+* [x] `src/core/schema-cache-persistence.ts` — `persistSchemaCache` plus the
+      exported `assertOnlyCacheFieldsChanged` projection check.
+* [x] Move the three `writeSchema` call sites in `src/commands/schema.ts` onto
+      the seam.
+* [x] Report a cache-write failure as a cache-write failure.
+* [x] Close the known deviation: removed from `assets/reference.md` and its five
+      mirrors, marked closed in PLAT-001 acceptance, the design record and
+      ADR-0022, and re-annotated in the plan's criterion 16. Neither user-doc
+      locale carried it.
+* [x] Handoff: PLAT-013 completed, PLAT-012 current, next Story pending.
+* [x] `make verify`.
+
+## Notes
+
+* Reproduced on `c3e701a1`: under `DBCLI_AGENT_MODE=1` the layered store is
+  written, then `config.json` is refused, exit 1, and the two caches disagree.
+* `assertConfigMutationApproved()` is not edited. If a change to it looks
+  necessary, the seam is wrong.
+* `docker compose -f docker-compose.test.yml up -d --wait` before `make verify`.

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -10,7 +10,9 @@ import { t, t_vars } from '@/i18n/message-loader'
 import { AdapterFactory, ConnectionError, type ConnectionOptions } from '@/adapters'
 import { TableFormatter, TableSchemaJSONFormatter } from '@/formatters'
 import { configModule, getSchemaIsolationConnectionName } from '@/core/config'
-import { patchConnectionSchema, readV2Config } from '@/core/config-v2'
+import { persistSchemaCache, SchemaCacheWriteError } from '@/core/schema-cache-persistence'
+import { ConfigError } from '@/utils/errors'
+import { readV2Config } from '@/core/config-v2'
 import { resolveConfigStoragePath } from '@/core/config-binding'
 import { SchemaDiffEngine } from '@/core/schema-diff'
 import { SchemaWriter } from '@/core'
@@ -520,7 +522,7 @@ export async function handleSchemaRefresh(
 
   // Wave 1 Integration: Persist to layered storage
   const writer = new SchemaWriter(storagePath)
-  await writer.save(newSchema, connectionName)
+  await reportingCacheWriteFailure('store', () => writer.save(newSchema, connectionName))
   if (isFirstTime) {
     console.log(`✅ Schema cache initialised (${Object.keys(newSchema).length} tables)`)
   } else {
@@ -577,11 +579,11 @@ async function handleSchemaReset(
   }
 
   // Write cleared config first (in case scan fails, at least old stale data is gone)
-  await writeSchema(storagePath, configWithoutSchema as DbcliConfig, connectionName)
+  await writeSchema(storagePath, configWithoutSchema as DbcliConfig, connectionName, 'clear')
 
   // Wave 1 Integration: Clear layered storage
   const writer = new SchemaWriter(storagePath)
-  await writer.clear(connectionName)
+  await reportingCacheWriteFailure('clear', () => writer.clear(connectionName))
 
   // Now do a full fresh scan
   console.log(t('schema.scanning_database'))
@@ -636,7 +638,9 @@ async function handleSchemaReset(
   }
 
   // Wave 1 Integration: Persist to layered storage
-  await writer.save(schemaData as Record<string, TableSchema>, connectionName)
+  await reportingCacheWriteFailure('store', () =>
+    writer.save(schemaData as Record<string, TableSchema>, connectionName)
+  )
   console.log(`✅ Schema persisted to layered storage (.dbcli/schemas/${connectionName || ''})`)
 
   await writeSchema(storagePath, updatedConfig as DbcliConfig, connectionName)
@@ -740,7 +744,9 @@ async function handleFullDatabaseScan(
 
   // Wave 1 Integration: Persist to layered storage
   const writer = new SchemaWriter(storagePath)
-  await writer.save(schemaData as Record<string, TableSchema>, connectionName)
+  await reportingCacheWriteFailure('store', () =>
+    writer.save(schemaData as Record<string, TableSchema>, connectionName)
+  )
   console.log(`✅ Schema persisted to layered storage (.dbcli/schemas/${connectionName || ''})`)
 
   await writeSchema(storagePath, updatedConfig as DbcliConfig, connectionName)
@@ -751,24 +757,84 @@ async function handleFullDatabaseScan(
 }
 
 /**
- * Write schema changes: V2 config → patch per-connection slot; V1 → full config write.
+ * Store the schema cache.
+ *
+ * This used to be a whole-config publication: `configModule.write` for v1,
+ * `writeV2Config` for v2. Both sit behind `assertConfigMutationApproved()`, so
+ * caching a schema was refused under agent mode while `capabilities check`
+ * reported `schema.read` available — and the v1 path also deleted
+ * `connection.password` from `config.json` and rewrote `.env.local`, on every
+ * `dbcli schema`, agent mode or not.
+ *
+ * `persistSchemaCache` writes the cache fields and nothing else, and cannot
+ * express anything else: see `src/core/schema-cache-persistence.ts` for why
+ * that narrowness — rather than a flag on the guard — is what makes it safe to
+ * run in an untrusted context. (DBCLI-PLAT-012)
  */
 async function writeSchema(
-  configPath: string,
+  storagePath: string,
   config: DbcliConfig,
-  connectionName: string | undefined
+  connectionName: string | undefined,
+  phase: CachePhase = 'store'
 ): Promise<void> {
-  if (connectionName !== undefined) {
-    await patchConnectionSchema(
-      configPath,
+  await reportingCacheWriteFailure(phase, () =>
+    persistSchemaCache({
+      storagePath,
       connectionName,
-      (config.schema ?? {}) as Record<string, unknown>,
-      {
-        schemaLastUpdated: config.metadata?.schemaLastUpdated,
-        schemaTableCount: config.metadata?.schemaTableCount,
-      }
-    )
-  } else {
-    await configModule.write(configPath, config)
+      schema: (config.schema ?? {}) as Record<string, unknown>,
+      schemaLastUpdated: config.metadata?.schemaLastUpdated,
+      schemaTableCount:
+        config.metadata?.schemaTableCount ?? Object.keys(config.schema ?? {}).length,
+    })
+  )
+}
+
+/** Whether the cache is being stored after a read, or cleared before one. */
+type CachePhase = 'store' | 'clear'
+
+/**
+ * Report a failed cache write as a failed cache write.
+ *
+ * Before this Story, agent mode refused the cache write and the command exited
+ * non-zero with a message about "configuration, permission, and credential
+ * changes" — from which an agent reading the exit code concluded that reading
+ * the database had failed. The read had in fact succeeded. Which step failed is
+ * the thing the caller needs and the thing the old output never said, so the
+ * `store` phase says it explicitly; the `clear` phase runs before any read and
+ * deliberately does not claim one happened.
+ */
+async function reportingCacheWriteFailure<T>(
+  phase: CachePhase,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    const preamble =
+      phase === 'store'
+        ? 'The schema was read from the database successfully; storing it in the local schema cache failed.'
+        : 'Clearing the local schema cache failed; the database was not read.'
+    throw new Error(`${preamble} ${cacheWriteReason(error)}`)
   }
+}
+
+/**
+ * A bounded reason for a failed cache write.
+ *
+ * Two things are being kept apart. The caller has to be able to tell "the
+ * database read failed" from "the read worked and the cache did not" — an agent
+ * that reads only the exit code drew the first conclusion from the second
+ * before this Story. And the reason must stay free of filesystem paths: the
+ * integrity refusal names the config path it checked, which is useful in a
+ * human's terminal and is disclosure in an agent's transcript.
+ *
+ * So only `SchemaCacheWriteError` passes through, because its messages are
+ * path-free by construction; every other cause is classified, never quoted.
+ */
+function cacheWriteReason(error: unknown): string {
+  if (error instanceof SchemaCacheWriteError) return error.message
+  if (error instanceof ConfigError) {
+    return 'The dbcli configuration could not be read back for the cache write; run `dbcli doctor`.'
+  }
+  return 'The local schema cache could not be written.'
 }

--- a/src/core/schema-cache-persistence.ts
+++ b/src/core/schema-cache-persistence.ts
@@ -1,0 +1,250 @@
+/**
+ * The schema cache write seam.
+ *
+ * A schema cache is derived data. It is re-readable at any time from the
+ * database the configuration already points at, and anyone who can run
+ * `dbcli schema` can already see everything it holds. It is not connection
+ * identity, not a permission level, and not a credential — the three things
+ * `assertConfigMutationApproved()` exists to keep an untrusted automation
+ * context away from. The cache sat behind that guard for one reason: it is
+ * stored inside `config.json`, next to things that are. Storage adjacency, not
+ * a shared trust decision.
+ *
+ * The cost of the conflation was larger than a false capability claim. Storing
+ * a cache went through `configModule.write`, which republishes the whole
+ * document: measured against a config holding `connection.password` and an
+ * existing `.env.local`, one `dbcli schema` deleted the password from
+ * `config.json` and overwrote `.env.local` with a regenerated one. That happens
+ * outside agent mode as well, where no guard fires — so the defect was never
+ * only that the guard was misplaced. It was that a cache update was a
+ * whole-config publication wearing a cache's name.
+ *
+ * This module is that update and nothing else. The narrowness is in the
+ * signature: the only things a caller can supply are a schema, a connection
+ * slot and two timestamps. There is no parameter through which a credential,
+ * a permission or a host could travel, so no flag has to guard it and no caller
+ * has to be trusted to be honest about what it is writing. The configuration
+ * itself is read here, not handed in.
+ *
+ * `assertOnlyCacheFieldsChanged` states that same guarantee out loud. It is
+ * redundant against today's code by construction, which is the point: an edit
+ * that widens what gets written fails in a unit test naming the field, instead
+ * of shipping.
+ *
+ * `assertConfigMutationApproved()` is untouched, and every writer that guards
+ * it still does. Under agent mode `dbcli init`, `dbcli use`,
+ * `dbcli blacklist add` and the credential commands are refused exactly as
+ * before; only the cache moved out from behind it.
+ */
+
+import { join } from 'node:path'
+import { detectConfigVersion } from '@/core/config-v2'
+import {
+  assertAgentReadableFile,
+  assertConfigIntegrity,
+  writeConfigWithIntegrity,
+} from '@/core/config-integrity'
+import { ConfigError } from '@/utils/errors'
+
+/** A refusal from the cache seam. Never carries a value, only a field name. */
+export class SchemaCacheWriteError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SchemaCacheWriteError'
+    Object.setPrototypeOf(this, SchemaCacheWriteError.prototype)
+  }
+}
+
+export interface SchemaCacheWrite {
+  /** The resolved `.dbcli` storage directory holding `config.json`. */
+  readonly storagePath: string
+  /** The v2 connection slot to write, or `undefined` for a v1 config. */
+  readonly connectionName?: string
+  /** The table map just read from the database. */
+  readonly schema: Record<string, unknown>
+  /** Absent clears the timestamp, which is how a cache-clearing write reads. */
+  readonly schemaLastUpdated?: string
+  readonly schemaTableCount: number
+}
+
+/** The `metadata` keys that belong to the cache rather than to the document. */
+const CACHE_METADATA_KEYS = ['schemaLastUpdated', 'schemaTableCount'] as const
+
+type Document = Record<string, unknown>
+
+const isObject = (value: unknown): value is Document =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Strip the cache fields, so what remains is everything the seam must not move.
+ *
+ * For a v2 document only the named connection's slot is stripped: writing one
+ * connection's cache must not be able to disturb another's, and leaving the
+ * other slots in the comparison is what makes that checkable.
+ */
+function withoutCacheFields(document: Document, connectionName?: string): Document {
+  const rest: Document = { ...document }
+
+  if (connectionName === undefined) {
+    delete rest.schema
+  } else {
+    const schemas = isObject(rest.schemas) ? { ...rest.schemas } : {}
+    delete schemas[connectionName]
+    rest.schemas = schemas
+  }
+
+  if (isObject(rest.metadata)) {
+    const metadata: Document = { ...rest.metadata }
+    for (const key of CACHE_METADATA_KEYS) delete metadata[key]
+    rest.metadata = metadata
+  }
+
+  return rest
+}
+
+/**
+ * Refuse a candidate document that differs from disk outside the cache fields.
+ *
+ * The message names the offending top-level field and never its value: a
+ * refusal that quoted the rejected `connection` would print the credential the
+ * refusal exists to protect.
+ */
+export function assertOnlyCacheFieldsChanged(
+  before: unknown,
+  after: unknown,
+  connectionName?: string
+): void {
+  if (!isObject(before) || !isObject(after)) {
+    throw new SchemaCacheWriteError(
+      'schema cache write refused: the configuration is not a JSON object'
+    )
+  }
+
+  const strippedBefore = withoutCacheFields(before, connectionName)
+  const strippedAfter = withoutCacheFields(after, connectionName)
+
+  const fields = new Set([...Object.keys(strippedBefore), ...Object.keys(strippedAfter)])
+  const changed = [...fields]
+    .filter((field) => !Bun.deepEquals(strippedBefore[field], strippedAfter[field], true))
+    .sort()
+
+  if (changed.length === 0) return
+
+  throw new SchemaCacheWriteError(
+    `schema cache write refused: it would also change ${changed.map((field) => `'${field}'`).join(', ')}, ` +
+      'which is not part of the schema cache'
+  )
+}
+
+/**
+ * Where the configuration document lives.
+ *
+ * Two layouts are live. Directory mode keeps `config.json` inside the storage
+ * directory alongside its integrity record; legacy single-file mode is the
+ * whole document at the storage path itself, with no record — `configModule`
+ * still reads and writes both, so the seam has to as well or `dbcli schema`
+ * would start refusing on a layout that works today. Agent mode never reaches
+ * the legacy layout: `configModule.read` refuses it outright.
+ */
+interface ConfigLocation {
+  readonly path: string
+  readonly directoryMode: boolean
+}
+
+async function locateConfig(storagePath: string): Promise<ConfigLocation> {
+  let isDirectory = false
+  try {
+    isDirectory = (await Bun.file(storagePath).stat())?.isDirectory() ?? false
+  } catch {
+    isDirectory = false
+  }
+
+  if (isDirectory) return { path: join(storagePath, 'config.json'), directoryMode: true }
+  return { path: storagePath, directoryMode: false }
+}
+
+/** Read the configuration the way every other reader does, checks included. */
+async function readConfigDocument(
+  storagePath: string,
+  location: ConfigLocation
+): Promise<Document> {
+  const file = Bun.file(location.path)
+
+  if (!(await file.exists())) {
+    // Deliberately a refusal rather than a create. Writing a configuration that
+    // was not there would mean publishing connection details from a cache
+    // write, which is the whole thing this module exists not to do.
+    throw new ConfigError('No dbcli configuration was found to store the schema cache in.')
+  }
+
+  const content = await file.text()
+  if (location.directoryMode) {
+    await assertAgentReadableFile(location.path)
+    await assertConfigIntegrity(storagePath, content, { requireRecord: true })
+  }
+
+  const raw: unknown = JSON.parse(content)
+  if (!isObject(raw)) {
+    throw new ConfigError('The dbcli configuration is not a JSON object.')
+  }
+  return raw
+}
+
+/** Build the candidate document: the one on disk, with the cache replaced. */
+function applyCache(current: Document, write: SchemaCacheWrite): Document {
+  const metadata: Document = {
+    ...(isObject(current.metadata) ? current.metadata : {}),
+    schemaTableCount: write.schemaTableCount,
+  }
+  if (write.schemaLastUpdated === undefined) delete metadata.schemaLastUpdated
+  else metadata.schemaLastUpdated = write.schemaLastUpdated
+
+  if (write.connectionName === undefined) {
+    return { ...current, schema: write.schema, metadata }
+  }
+
+  const connections = isObject(current.connections) ? current.connections : {}
+  if (!(write.connectionName in connections)) {
+    throw new SchemaCacheWriteError(
+      `schema cache write refused: connection '${write.connectionName}' is not in this configuration`
+    )
+  }
+
+  return {
+    ...current,
+    schemas: {
+      ...(isObject(current.schemas) ? current.schemas : {}),
+      [write.connectionName]: write.schema,
+    },
+    metadata,
+  }
+}
+
+/**
+ * Store a schema cache, and nothing else.
+ *
+ * The connection slot is taken from the caller, but which shape is on disk is
+ * not: a v1 document has no `schemas` map to write into, and a v2 document must
+ * not grow a top-level `schema`. Disagreement between the two is refused rather
+ * than resolved, because guessing produces a document neither reader accepts.
+ */
+export async function persistSchemaCache(write: SchemaCacheWrite): Promise<void> {
+  const location = await locateConfig(write.storagePath)
+  const current = await readConfigDocument(write.storagePath, location)
+  const isV2 = detectConfigVersion(current) === 2
+
+  if (isV2 !== (write.connectionName !== undefined)) {
+    throw new SchemaCacheWriteError(
+      isV2
+        ? 'schema cache write refused: this is a multi-connection configuration, so the cache needs a connection name'
+        : 'schema cache write refused: this is a single-connection configuration, which has no connection slot to write'
+    )
+  }
+
+  const candidate = applyCache(current, write)
+  assertOnlyCacheFieldsChanged(current, candidate, write.connectionName)
+
+  const json = JSON.stringify(candidate, null, 2)
+  if (location.directoryMode) await writeConfigWithIntegrity(write.storagePath, json)
+  else await Bun.file(location.path).write(json)
+}

--- a/tests/contract/capability-contract.test.ts
+++ b/tests/contract/capability-contract.test.ts
@@ -217,18 +217,20 @@ const CONFIG_MUTATORS = [
 /**
  * Commands that write configuration incidentally rather than as their purpose.
  *
- * `schema` persists the discovered schema into `config.json` after reading it
- * (`src/commands/schema.ts:479,532,642,746`). That write is behind the same
- * agent-mode guard, so under `DBCLI_AGENT_MODE=1` the persistence step is
- * refused — but the read itself is the capability, and marking `schema.read`
- * `unavailable` would overstate the refusal far worse than staying silent
- * understates it. The trade-off is disclosed in the spec, and DBCLI-PLAT-012
- * covers moving cache persistence out from behind the identity guard.
+ * Empty, and that is the finding rather than an absence of one. `schema` was
+ * the single entry: it persisted the discovered schema through
+ * `configModule.write`, which is behind the agent-mode guard, so
+ * `capabilities check` reported `schema.read` available while the command
+ * exited 1 under `DBCLI_AGENT_MODE=1`. The exemption existed to hold that
+ * disclosed contradiction in view until DBCLI-PLAT-012 removed its cause: the
+ * cache now goes through `persistSchemaCache`, which writes the cache fields
+ * and nothing else and is not a configuration mutation at all.
  *
  * Listing them here rather than skipping them silently means adding a
- * capability on such a command forces the decision back into view.
+ * capability on such a command forces the decision back into view. Re-adding an
+ * entry is that decision, not a refactor.
  */
-const INCIDENTAL_CONFIG_WRITERS = new Set(['schema'])
+const INCIDENTAL_CONFIG_WRITERS = new Set<string>()
 
 async function commandWritesConfig(commandPath: string): Promise<boolean> {
   const entry = join(SRC, `commands/${commandPath.split(' ')[0]}.ts`)

--- a/tests/contract/config-mutation-boundary.test.ts
+++ b/tests/contract/config-mutation-boundary.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Where the agent-mode configuration boundary is, stated as a roster.
+ *
+ * DBCLI-PLAT-012 moved one thing out from behind `assertConfigMutationApproved()`
+ * — the schema cache — and nothing else. That is a sentence anyone can write in
+ * a commit message; this file is what makes it checkable. It pins the set of
+ * modules that call the guard, so removing a call from a writer that still
+ * needs one fails here, and it pins that the new cache seam is not among them,
+ * so a later edit cannot quietly put the cache back behind the guard or drag a
+ * credential writer out from behind it.
+ *
+ * The roster is a ratchet in the direction that matters: entries may be added
+ * (a new writer of connection identity, permission or credentials must guard),
+ * and removing one is a boundary change that has to be argued for in a Story,
+ * not slipped past in a refactor.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { assertConfigMutationApproved } from '@/core/config-mutation-guard'
+import { ConfigError } from '@/utils/errors'
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url))
+
+/**
+ * Every module that refuses a write under `DBCLI_AGENT_MODE=1`.
+ *
+ * Each one publishes connection identity, a permission level, or a credential:
+ * things an untrusted automation context must not change, and for which an
+ * environment variable supplied by that same process is not an approval.
+ */
+const GUARDED = [
+  'src/core/config.ts',
+  'src/core/config-v2.ts',
+  'src/core/config-binding.ts',
+  'src/core/connection-credential.ts',
+  'src/core/schema-updater.ts',
+  'src/commands/credential.ts',
+].sort()
+
+/**
+ * Modules that must never guard, because they write only derived data.
+ *
+ * A schema cache is re-readable at any time from the database the config
+ * already points at, so refusing to store it protects nothing and makes the
+ * capability contract lie about `schema.read`.
+ */
+const UNGUARDED = ['src/core/schema-cache-persistence.ts']
+
+const read = (path: string) => readFile(new URL(path, `file://${repoRoot}`), 'utf8')
+
+/**
+ * Source with comments removed.
+ *
+ * The seam and the schema command both *discuss* the guard in their header
+ * comments — explaining why the cache is not behind it is the whole point of
+ * those comments. A scan that counted a mention as a call would force the
+ * explanation to be deleted to satisfy the test, which is the wrong direction:
+ * the rule is about what the code does, so the check reads only code.
+ */
+const readCode = async (path: string) =>
+  (await read(path)).replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+
+describe('the guard itself is unchanged', () => {
+  test('it refuses under agent mode and is silent outside it', () => {
+    const previous = process.env.DBCLI_AGENT_MODE
+    try {
+      delete process.env.DBCLI_AGENT_MODE
+      expect(() => assertConfigMutationApproved()).not.toThrow()
+
+      process.env.DBCLI_AGENT_MODE = '1'
+      expect(() => assertConfigMutationApproved()).toThrow(ConfigError)
+      expect(() => assertConfigMutationApproved()).toThrow(
+        /Agent mode blocks configuration, permission, and credential changes/
+      )
+    } finally {
+      if (previous === undefined) delete process.env.DBCLI_AGENT_MODE
+      else process.env.DBCLI_AGENT_MODE = previous
+    }
+  })
+
+  test('a value other than exactly "1" does not enable it', () => {
+    const previous = process.env.DBCLI_AGENT_MODE
+    try {
+      for (const value of ['0', 'true', 'yes', '']) {
+        process.env.DBCLI_AGENT_MODE = value
+        expect(() => assertConfigMutationApproved()).not.toThrow()
+      }
+    } finally {
+      if (previous === undefined) delete process.env.DBCLI_AGENT_MODE
+      else process.env.DBCLI_AGENT_MODE = previous
+    }
+  })
+})
+
+describe('the roster of guarded writers', () => {
+  test('every listed module calls the guard', async () => {
+    for (const path of GUARDED) {
+      expect(await readCode(path)).toContain('assertConfigMutationApproved()')
+    }
+  })
+
+  test('no module outside the roster calls the guard', async () => {
+    const found = (
+      await Array.fromAsync(new Bun.Glob('{src,scripts}/**/*.ts').scan({ cwd: repoRoot }))
+    )
+      .map((entry) => entry.replaceAll('\\', '/'))
+      .filter((path) => path !== 'src/core/config-mutation-guard.ts')
+
+    const callers: string[] = []
+    for (const path of found) {
+      if ((await readCode(path)).includes('assertConfigMutationApproved()')) callers.push(path)
+    }
+
+    expect(callers.sort()).toEqual(GUARDED)
+  })
+
+  test('the schema cache seam is not among them', async () => {
+    for (const path of UNGUARDED) {
+      const source = await readCode(path)
+      expect(source).not.toContain('assertConfigMutationApproved')
+      expect(source).not.toContain('config-mutation-guard')
+    }
+  })
+
+  test('the schema command reaches no guarded writer for its cache', async () => {
+    // `configModule.write` and `writeV2Config` are whole-config publications and
+    // stay guarded; the schema command must not be calling either.
+    const source = await readCode('src/commands/schema.ts')
+    expect(source).toContain('persistSchemaCache')
+    expect(source).not.toContain('configModule.write(')
+    expect(source).not.toContain('patchConnectionSchema')
+    expect(source).not.toContain('writeV2Config')
+  })
+})

--- a/tests/docs/schema-cache-deviation-closed.test.ts
+++ b/tests/docs/schema-cache-deviation-closed.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The PLAT-001 known overstatement is closed everywhere it was written down.
+ *
+ * `dbcli schema` used to persist its cache through a guarded whole-config
+ * writer, so `capabilities check` said `schema.read` was available under
+ * `DBCLI_AGENT_MODE=1` while the command exited 1 there. The contradiction was
+ * disclosed rather than hidden — in the reference, the design record, the ADR,
+ * the plan's acceptance criteria and the Story's acceptance file — which was
+ * the right call at the time and leaves five places that now say something
+ * false unless every one of them is revisited.
+ *
+ * They are not all revisited the same way, and that is the point of this file.
+ * User-facing reference states what is true now, so the sentence goes. Design
+ * records and Story acceptance are records of decisions taken at a point in
+ * time; deleting the deviation from those would rewrite what was actually
+ * accepted, so they keep their reasoning and gain a closing note. The check
+ * below encodes exactly that split, so a later reader cannot conclude the
+ * removal was inconsistent or the retention was an oversight.
+ */
+
+import { describe, test, expect } from 'bun:test'
+
+/** Surfaces that must no longer state the deviation at all. */
+const MUST_NOT_CLAIM = [
+  'assets/reference.md',
+  'skills/dbcli/reference.md',
+  'plugins/dbcli-agent/skills/dbcli/reference.md',
+  '.cursor/skills/dbcli/reference.md',
+  '.github/skills/dbcli/reference.md',
+  '.windsurf/skills/dbcli/reference.md',
+  'docs/user/en/index.md',
+  'docs/user/en/index.html',
+  'docs/user/zh-TW/index.md',
+  'docs/user/zh-TW/index.html',
+]
+
+/** Records that keep the deviation and must say it is closed. */
+const MUST_RECORD_CLOSURE = [
+  'docs/specs/2026-09-04-agent-integration-contract-v1.md',
+  'docs/adr/0022-the-capability-catalog-is-derived-from-the-engine-matrix.md',
+  'specs/stories/DBCLI-PLAT-001-capability-contract/acceptance.md',
+]
+
+/**
+ * The claim itself: that the schema cache write is refused under agent mode.
+ *
+ * Deliberately narrow, and narrowed once already. A first attempt matched
+ * "schema … cache … refused/blocked" loosely and fired on `blocked: schema
+ * cache` — the impact command's reason code for an unavailable layered cache,
+ * which has nothing to do with agent mode and appears in three of these files.
+ * A gate that reports unrelated text is a gate someone deletes, so what is
+ * matched is the sentence as it was actually written, plus the general shape
+ * anchored on the flag that made the claim true.
+ */
+const WITHDRAWN = [
+  /One known overstatement/,
+  /persists its result into `config\.json`/,
+  /DBCLI_AGENT_MODE=1[^.]{0,140}(schema[^.]{0,40})?(persistence|cache write)[^.]{0,60}refused/i,
+] as const
+
+const read = (file: string) => Bun.file(new URL(`../../${file}`, import.meta.url)).text()
+
+describe('the deviation is gone from every surface that states current behaviour', () => {
+  for (const file of MUST_NOT_CLAIM) {
+    test(`${file} no longer says the schema cache write is refused`, async () => {
+      const source = await read(file)
+      for (const claim of WITHDRAWN) expect(source).not.toMatch(claim)
+    })
+  }
+})
+
+describe('the records keep the deviation and mark it closed', () => {
+  for (const file of MUST_RECORD_CLOSURE) {
+    test(`${file} records that DBCLI-PLAT-012 closed it`, async () => {
+      const source = await read(file)
+      // Still explains what the deviation was — the reasoning is why the
+      // decision was defensible, and it outlives the deviation.
+      expect(source).toMatch(/schema/i)
+      expect(source).toContain('DBCLI-PLAT-012')
+      expect(source).toMatch(/closed by DBCLI-PLAT-012/i)
+    })
+  }
+})
+
+describe('the plan states what proves the criterion now', () => {
+  test('criterion 16 cites a test instead of admitting a deviation', async () => {
+    const plan = await read('docs/plans/2026-09-04-agent-integration-contract-v1.md')
+    const criterion = plan.split('\n').find((line) => line.startsWith('16. '))
+    expect(criterion).toBeDefined()
+    expect(criterion).not.toContain('known deviation:')
+    expect(criterion).toContain('covered by:')
+    expect(criterion).toContain('tests/integration/schema-cache-agent-mode.test.ts')
+  })
+})

--- a/tests/integration/schema-cache-agent-mode.test.ts
+++ b/tests/integration/schema-cache-agent-mode.test.ts
@@ -47,7 +47,11 @@ afterEach(async () => {
  *
  * Inherited `DBCLI_*` variables are stripped: a developer with agent mode
  * exported would otherwise make the "outside agent mode" cases silently test
- * the wrong thing.
+ * the wrong thing. `DB_*` and `DATABASE_URL` go for the same reason one step
+ * further out: Bun loads the repository's `.env` into this process, and
+ * `dbcli init` falls back to those variables for host/user/database. A case
+ * that reached a guard only because the developer had `DB_USER` exported would
+ * pass here and fail in CI — which is exactly what happened.
  */
 function run(
   args: string[],
@@ -56,7 +60,7 @@ function run(
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const env: NodeJS.ProcessEnv = {}
   for (const [key, value] of Object.entries(process.env)) {
-    if (/^DBCLI_/i.test(key) || key === 'DATABASE_URL') continue
+    if (/^DBCLI_/i.test(key) || /^DB_/i.test(key) || key === 'DATABASE_URL') continue
     env[key] = value
   }
   env.NODE_ENV = 'test'
@@ -204,11 +208,30 @@ describe.skipIf(!PG_AVAILABLE)('a failed cache write is reported as a cache writ
 
 describe.skipIf(!PG_AVAILABLE)('the rest of the boundary did not move', () => {
   test('agent mode still refuses a permission change through the config writers', async () => {
-    const { dir } = await v1Project()
-    // `--force`: without it `init` refuses because `.dbcli` exists, which would
-    // let this pass without the guard ever being consulted.
+    const { dir, storagePath } = await v1Project()
+    // Every connection option is spelled out, and `--force` with it. `init`
+    // validates its arguments before it reaches a writer, and refusing early
+    // for a missing `--user` or an existing `.dbcli` would let this case pass
+    // without the guard ever being consulted.
     const result = await run(
-      ['init', '--no-interactive', '--force', '--skip-test', '--permission', 'admin'],
+      [
+        'init',
+        '--no-interactive',
+        '--force',
+        '--skip-test',
+        '--system',
+        PG_OPTS.system,
+        '--host',
+        PG_OPTS.host,
+        '--port',
+        String(PG_OPTS.port),
+        '--user',
+        PG_OPTS.user,
+        '--name',
+        PG_OPTS.database,
+        '--permission',
+        'admin',
+      ],
       dir,
       { DBCLI_AGENT_MODE: '1' }
     )
@@ -217,6 +240,7 @@ describe.skipIf(!PG_AVAILABLE)('the rest of the boundary did not move', () => {
     expect(`${result.stdout}\n${result.stderr}`).toMatch(
       /Agent mode blocks configuration, permission, and credential changes/
     )
+    expect((await configOf(storagePath)).permission).toBe('query-only')
   }, 60_000)
 
   test('agent mode still refuses a blacklist change', async () => {

--- a/tests/integration/schema-cache-agent-mode.test.ts
+++ b/tests/integration/schema-cache-agent-mode.test.ts
@@ -1,0 +1,231 @@
+/**
+ * `dbcli schema` under `DBCLI_AGENT_MODE=1` — DBCLI-PLAT-012.
+ *
+ * This is the test the capability contract needed and did not have. PLAT-001
+ * shipped `schema.read` reporting `available` under agent mode while the
+ * command it names exited 1 there, and the deviation was recorded in prose
+ * because nothing compared the two. So the first case here asks the contract
+ * and then runs the command, in one test, against a real database: the claim
+ * and the behaviour cannot drift apart without this failing.
+ *
+ * The rest pins the boundary that did not move. Agent mode still refuses every
+ * change to connection identity, permission and credentials; what changed is
+ * that storing derived data stopped being one of those.
+ */
+
+import { describe, test, expect, afterEach, beforeAll } from 'bun:test'
+import { spawn } from 'node:child_process'
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { AdapterFactory } from '@/adapters'
+import type { SqlConnectionOptions } from '@/adapters/types'
+import { writeConfigWithIntegrity } from '@/core/config-integrity'
+import { isDbReachable, PG_DATABASE, PG_HOST, PG_PASSWORD, PG_PORT, PG_USER } from './helpers'
+
+const CLI = resolve(import.meta.dir, '../../src/cli.ts')
+const PG_AVAILABLE = await isDbReachable(PG_HOST, PG_PORT)
+const TABLE = 'plat012_cache_boundary'
+
+const PG_OPTS: SqlConnectionOptions = {
+  system: 'postgresql',
+  host: PG_HOST,
+  port: PG_PORT,
+  user: PG_USER,
+  password: PG_PASSWORD,
+  database: PG_DATABASE,
+}
+
+const workDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(workDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+/**
+ * Run the CLI with a clean environment plus whatever the case sets.
+ *
+ * Inherited `DBCLI_*` variables are stripped: a developer with agent mode
+ * exported would otherwise make the "outside agent mode" cases silently test
+ * the wrong thing.
+ */
+function run(
+  args: string[],
+  workDir: string,
+  extra: Record<string, string> = {}
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const env: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^DBCLI_/i.test(key) || key === 'DATABASE_URL') continue
+    env[key] = value
+  }
+  env.NODE_ENV = 'test'
+  env.DBCLI_NO_UPDATE_CHECK = '1'
+  Object.assign(env, extra)
+
+  return new Promise((res) => {
+    const child = spawn('bun', ['run', CLI, ...args], { cwd: workDir, env })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (buffer) => (stdout += buffer.toString()))
+    child.stderr.on('data', (buffer) => (stderr += buffer.toString()))
+    child.on('close', (code) => res({ stdout, stderr, code: code ?? 0 }))
+  })
+}
+
+const ENV_LOCAL = 'DB_PASSWORD=untouched\n'
+
+/**
+ * A project whose `.dbcli/` is a real directory holding a v1 config.
+ *
+ * Written directly rather than through `dbcli init`, which binds the project to
+ * a generated directory under the user's home. That indirection is real and
+ * fine, and it would put the file this test is about outside the temporary
+ * directory the test cleans up.
+ */
+async function v1Project(): Promise<{ dir: string; storagePath: string }> {
+  // `realpath` matters here, and only under agent mode. On macOS `mkdtemp`
+  // hands back `/var/folders/...` while the spawned CLI resolves its cwd to
+  // `/private/var/folders/...`; the integrity record stores the path it was
+  // written for, so the two spellings read as tampering and every case would
+  // fail on `context-unresolvable` instead of on what it is testing.
+  const dir = await realpath(await mkdtemp(join(tmpdir(), 'dbcli-plat012-int-')))
+  workDirs.push(dir)
+  const storagePath = join(dir, '.dbcli')
+
+  const config = {
+    connection: { ...PG_OPTS },
+    permission: 'query-only',
+    schema: {},
+    metadata: { createdAt: '2026-01-01T00:00:00.000Z', version: '1.0' },
+    blacklist: { tables: [], columns: {} },
+    audit: { enabled: false },
+  }
+  await writeConfigWithIntegrity(storagePath, JSON.stringify(config, null, 2))
+  await writeFile(join(storagePath, '.env.local'), ENV_LOCAL)
+  return { dir, storagePath }
+}
+
+const configOf = async (storagePath: string) =>
+  JSON.parse(await readFile(join(storagePath, 'config.json'), 'utf8')) as Record<string, unknown>
+
+beforeAll(async () => {
+  if (!PG_AVAILABLE) return
+  const adapter = AdapterFactory.createSqlAdapter(PG_OPTS)
+  await adapter.connect()
+  try {
+    await adapter.execute(`CREATE TABLE IF NOT EXISTS ${TABLE} (id integer primary key, name text)`)
+  } finally {
+    await adapter.disconnect()
+  }
+})
+
+describe.skipIf(!PG_AVAILABLE)('the capability claim and the command agree', () => {
+  test('schema.read is available under agent mode, and dbcli schema then succeeds', async () => {
+    const { dir, storagePath } = await v1Project()
+
+    const claim = await run(
+      ['capabilities', 'check', '--require', 'schema.read', '--format', 'json'],
+      dir,
+      { DBCLI_AGENT_MODE: '1' }
+    )
+    expect(claim.code).toBe(0)
+    const report = JSON.parse(claim.stdout) as {
+      context: { agentMode: boolean }
+      results: Array<{ id: string; status: string }>
+    }
+    expect(report.context.agentMode).toBe(true)
+    expect(report.results[0]).toMatchObject({ id: 'schema.read', status: 'available' })
+
+    // The half that used to be missing.
+    const command = await run(['schema'], dir, { DBCLI_AGENT_MODE: '1' })
+    expect(command.stderr).not.toMatch(/Agent mode blocks/)
+    expect(command.code).toBe(0)
+
+    const after = await configOf(storagePath)
+    expect(Object.keys(after.schema as object)).toContain(TABLE)
+  }, 60_000)
+})
+
+describe.skipIf(!PG_AVAILABLE)('a cache write moves no credential', () => {
+  test('.env.local and connection.password survive, in and out of agent mode', async () => {
+    for (const agentMode of [undefined, '1']) {
+      const { dir, storagePath } = await v1Project()
+      const before = await configOf(storagePath)
+
+      const result = await run(
+        ['schema'],
+        dir,
+        agentMode === undefined ? {} : { DBCLI_AGENT_MODE: agentMode }
+      )
+      expect(result.code).toBe(0)
+
+      const after = await configOf(storagePath)
+      // Before this Story the v1 path removed `password` here and rewrote
+      // `.env.local`, on every schema scan, agent mode or not.
+      expect(after.connection).toEqual(before.connection)
+      expect(after.permission).toBe('query-only')
+      expect(after.blacklist).toEqual(before.blacklist)
+      expect(after.audit).toEqual(before.audit)
+      expect(await readFile(join(storagePath, '.env.local'), 'utf8')).toBe(ENV_LOCAL)
+    }
+  }, 90_000)
+})
+
+describe.skipIf(!PG_AVAILABLE)('a failed cache write is reported as a cache write', () => {
+  test('it says the schema was read and does not read as a database failure', async () => {
+    const { dir, storagePath } = await v1Project()
+
+    // Make the storage directory read-only. The config is still readable, so
+    // the connection resolves and the schema is read; only the write back
+    // fails. That is the exact shape the old output described as an agent-mode
+    // configuration refusal, from which a caller could only conclude that
+    // something about the database had gone wrong.
+    await chmod(storagePath, 0o500)
+
+    let result
+    try {
+      result = await run(['schema'], dir, { DBCLI_AGENT_MODE: '1' })
+    } finally {
+      await chmod(storagePath, 0o700)
+    }
+    expect(result.code).not.toBe(0)
+
+    const output = `${result.stdout}\n${result.stderr}`
+    expect(output).toContain('The schema was read from the database successfully')
+    expect(output).toMatch(/schema cache/i)
+    expect(output).not.toMatch(/connection (refused|failed)|ECONNREFUSED|could not connect/i)
+    // Bounded: the refusal names no path, no credential and no endpoint.
+    expect(output).not.toContain(storagePath)
+    expect(output).not.toContain(PG_PASSWORD)
+    expect(output).not.toContain(String(PG_PORT))
+  }, 60_000)
+})
+
+describe.skipIf(!PG_AVAILABLE)('the rest of the boundary did not move', () => {
+  test('agent mode still refuses a permission change through the config writers', async () => {
+    const { dir } = await v1Project()
+    // `--force`: without it `init` refuses because `.dbcli` exists, which would
+    // let this pass without the guard ever being consulted.
+    const result = await run(
+      ['init', '--no-interactive', '--force', '--skip-test', '--permission', 'admin'],
+      dir,
+      { DBCLI_AGENT_MODE: '1' }
+    )
+
+    expect(result.code).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /Agent mode blocks configuration, permission, and credential changes/
+    )
+  }, 60_000)
+
+  test('agent mode still refuses a blacklist change', async () => {
+    const { dir, storagePath } = await v1Project()
+    const result = await run(['blacklist', 'add', '--table', 'secrets'], dir, {
+      DBCLI_AGENT_MODE: '1',
+    })
+
+    expect(result.code).not.toBe(0)
+    expect((await configOf(storagePath)).blacklist).toEqual({ tables: [], columns: {} })
+  }, 60_000)
+})

--- a/tests/unit/commands/schema-refresh-bootstrap.test.ts
+++ b/tests/unit/commands/schema-refresh-bootstrap.test.ts
@@ -7,6 +7,7 @@ import { mkdtempSync, rmSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { handleSchemaRefresh } from '@/commands/schema'
+import { writeConfigWithIntegrity } from '@/core/config-integrity'
 import type { DatabaseAdapter } from '@/adapters/types'
 import type { DbcliConfig } from '@/utils/validation'
 
@@ -31,11 +32,32 @@ function mockAdapter(): DatabaseAdapter {
   }
 }
 
+const BASE_CONFIG = {
+  connection: {
+    system: 'mariadb',
+    host: 'localhost',
+    port: 3306,
+    user: 'u',
+    password: 'p',
+    database: 'db',
+  },
+  permission: 'admin',
+  schema: {},
+  metadata: { createdAt: '2026-01-01T00:00:00.000Z', version: '1.0' },
+}
+
 describe('handleSchemaRefresh first-time bootstrap', () => {
   let tmpDir: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'dbcli-schema-bootstrap-'))
+    // A configuration has to exist for the cache to be stored into. It used to
+    // be created as a side effect of the cache write, because that write was
+    // `configModule.write` publishing a whole document; since DBCLI-PLAT-012
+    // the cache seam patches the config on disk and refuses when there is none,
+    // rather than publishing connection details out of a cache write. The
+    // subject of these tests is unchanged: whether --force is required.
+    await writeConfigWithIntegrity(tmpDir, JSON.stringify(BASE_CONFIG, null, 2))
   })
 
   afterEach(() => {

--- a/tests/unit/core/schema-cache-persistence.test.ts
+++ b/tests/unit/core/schema-cache-persistence.test.ts
@@ -1,0 +1,339 @@
+/**
+ * The schema cache write seam — DBCLI-PLAT-012.
+ *
+ * A schema cache is derived data: re-readable at any time from the database the
+ * config already points at, and visible in full to anyone who can run
+ * `dbcli schema`. It is not connection identity, not a permission and not a
+ * credential. It sits behind the agent-mode guard only because it is stored
+ * inside `config.json`, next to things that are.
+ *
+ * Storing it through `configModule.write` did more than store it. Measured on
+ * c3e701a1 against a config holding `connection.password: "testpass"` and an
+ * `.env.local` reading `DB_PASSWORD=untouched`, one schema write deleted the
+ * password from `config.json` and overwrote `.env.local` with a regenerated
+ * `DBCLI_PASSWORD=testpass`. That happens outside agent mode too, where no
+ * guard fires at all — so the real defect was never "the guard is misplaced",
+ * it was that a cache update was a whole-config publication wearing a cache's
+ * name.
+ *
+ * The seam is narrow by signature, not by permission: it takes a schema and two
+ * cache timestamps, reads the config itself, and writes back a document that
+ * differs only in the cache fields. There is no parameter through which a
+ * caller could express a credential change, which is why no flag guards it.
+ * `assertOnlyCacheFieldsChanged` is the same claim made out loud, so a future
+ * edit that widens the write fails here rather than in production.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, rm, readFile, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  assertOnlyCacheFieldsChanged,
+  persistSchemaCache,
+  SchemaCacheWriteError,
+} from '@/core/schema-cache-persistence'
+import { assertConfigIntegrity, writeConfigWithIntegrity } from '@/core/config-integrity'
+
+const DEMO_SCHEMA = {
+  plat012_demo: { name: 'plat012_demo', columns: [{ name: 'id', type: 'integer' }] },
+}
+
+const V1_CONFIG = {
+  connection: {
+    system: 'postgresql',
+    host: '127.0.0.1',
+    port: 5433,
+    user: 'dbcli',
+    password: 'testpass',
+    database: 'dbcli_test',
+  },
+  permission: 'query-only',
+  schema: {},
+  metadata: { createdAt: '2026-01-01T00:00:00.000Z', version: '1.0' },
+  blacklist: { tables: ['secrets'], columns: { users: ['password'] } },
+  audit: { enabled: true },
+}
+
+const V2_CONFIG = {
+  version: 2,
+  default: 'primary',
+  connections: {
+    primary: {
+      system: 'postgresql',
+      host: '127.0.0.1',
+      port: 5433,
+      user: 'dbcli',
+      password: 'testpass',
+      database: 'dbcli_test',
+      permission: 'query-only',
+    },
+  },
+  schemas: {},
+  blacklist: { tables: ['secrets'], columns: { users: ['password'] } },
+  metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+}
+
+const ENV_LOCAL = 'DB_PASSWORD=untouched\n'
+
+let storagePath: string
+
+async function seed(config: unknown): Promise<void> {
+  await writeConfigWithIntegrity(storagePath, JSON.stringify(config, null, 2))
+  await Bun.write(join(storagePath, '.env.local'), ENV_LOCAL)
+}
+
+const readConfig = async () =>
+  JSON.parse(await readFile(join(storagePath, 'config.json'), 'utf8')) as Record<string, unknown>
+
+const CACHE_WRITE = {
+  schema: DEMO_SCHEMA,
+  schemaLastUpdated: '2026-02-02T00:00:00.000Z',
+  schemaTableCount: 1,
+}
+
+beforeEach(async () => {
+  storagePath = await mkdtemp(join(tmpdir(), 'dbcli-plat012-'))
+})
+
+afterEach(async () => {
+  await rm(storagePath, { recursive: true, force: true })
+})
+
+describe('persistSchemaCache — v1', () => {
+  test('writes the schema and the two cache timestamps', async () => {
+    await seed(V1_CONFIG)
+    await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+
+    const after = await readConfig()
+    expect(after.schema).toEqual(DEMO_SCHEMA)
+    expect(after.metadata).toEqual({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      version: '1.0',
+      schemaLastUpdated: '2026-02-02T00:00:00.000Z',
+      schemaTableCount: 1,
+    })
+  })
+
+  test('leaves the credential where it was, in config.json', async () => {
+    // The behaviour this Story changes. `configModule.write` moved the password
+    // out to `.env.local` as a side effect of caching a schema.
+    await seed(V1_CONFIG)
+    await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+
+    const after = await readConfig()
+    expect(after.connection).toEqual(V1_CONFIG.connection)
+  })
+
+  test('leaves .env.local byte-identical', async () => {
+    await seed(V1_CONFIG)
+    await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+
+    expect(await readFile(join(storagePath, '.env.local'), 'utf8')).toBe(ENV_LOCAL)
+  })
+
+  test('changes nothing outside the cache fields', async () => {
+    await seed(V1_CONFIG)
+    const before = await readConfig()
+    await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+    const after = await readConfig()
+
+    for (const key of ['connection', 'permission', 'blacklist', 'audit']) {
+      expect(after[key]).toEqual(before[key])
+    }
+  })
+
+  test('the written config passes its own integrity check', async () => {
+    await seed(V1_CONFIG)
+    await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+
+    const content = await readFile(join(storagePath, 'config.json'), 'utf8')
+    await expect(
+      assertConfigIntegrity(storagePath, content, { requireRecord: true })
+    ).resolves.toBeUndefined()
+  })
+
+  test('a table name that looks like SQL is stored verbatim', async () => {
+    // The cache mirrors what the server reported. Rewriting it here would make
+    // the cache disagree with the database; the injection surface a name would
+    // matter for is SQL construction, which this is not.
+    await seed(V1_CONFIG)
+    const hostile = { 'users; DROP TABLE x': { name: 'users; DROP TABLE x', columns: [] } }
+    await persistSchemaCache({ ...CACHE_WRITE, storagePath, schema: hostile })
+
+    expect(Object.keys((await readConfig()).schema as object)).toEqual(['users; DROP TABLE x'])
+  })
+})
+
+describe('persistSchemaCache — legacy single-file layout', () => {
+  test('patches the document in place, integrity record and all absent', async () => {
+    // `.dbcli` as a file rather than a directory is still readable and writable
+    // through `configModule`, so the seam has to handle it or `dbcli schema`
+    // would begin refusing on a layout that works today. Agent mode never
+    // reaches this: `configModule.read` refuses a legacy single-file config.
+    const legacy = join(storagePath, '.dbcli')
+    await Bun.write(legacy, JSON.stringify(V1_CONFIG, null, 2))
+
+    await persistSchemaCache({ ...CACHE_WRITE, storagePath: legacy })
+
+    const after = JSON.parse(await readFile(legacy, 'utf8')) as Record<string, unknown>
+    expect(after.schema).toEqual(DEMO_SCHEMA)
+    expect(after.connection).toEqual(V1_CONFIG.connection)
+  })
+
+  test('a missing configuration is refused rather than created', async () => {
+    // Writing a config that was not there would mean publishing connection
+    // details out of a cache write.
+    await expect(
+      persistSchemaCache({ ...CACHE_WRITE, storagePath: join(storagePath, 'nothing-here') })
+    ).rejects.toThrow(/No dbcli configuration/)
+  })
+})
+
+describe('persistSchemaCache — v2', () => {
+  test('writes into the named connection slot only', async () => {
+    await seed(V2_CONFIG)
+    await persistSchemaCache({ storagePath, connectionName: 'primary', ...CACHE_WRITE })
+
+    const after = await readConfig()
+    expect(after.schemas).toEqual({ primary: DEMO_SCHEMA })
+    expect(after.connections).toEqual(V2_CONFIG.connections)
+    expect(after.blacklist).toEqual(V2_CONFIG.blacklist)
+    expect(after.default).toBe('primary')
+  })
+
+  test('an unknown connection is refused, naming the connection and no path', async () => {
+    await seed(V2_CONFIG)
+    const before = await readFile(join(storagePath, 'config.json'), 'utf8')
+
+    let message = ''
+    try {
+      await persistSchemaCache({
+        storagePath,
+        connectionName: 'no-such-connection',
+        ...CACHE_WRITE,
+      })
+      throw new Error('expected a refusal')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SchemaCacheWriteError)
+      message = (error as Error).message
+    }
+
+    expect(message).toContain('no-such-connection')
+    expect(message).not.toContain(storagePath)
+    expect(await readFile(join(storagePath, 'config.json'), 'utf8')).toBe(before)
+  })
+})
+
+describe('persistSchemaCache — refusals leave the config alone', () => {
+  test('under agent mode a tampered config is refused before anything is written', async () => {
+    // Integrity verification is an agent-mode boundary by design — see
+    // `assertIntegrityRecord`. The seam reaches for it the same way every other
+    // reader does, so moving the cache out from behind the mutation guard did
+    // not move it out from behind this one.
+    await seed(V1_CONFIG)
+    const tampered = JSON.stringify({ ...V1_CONFIG, permission: 'admin' }, null, 2)
+    await Bun.write(join(storagePath, 'config.json'), tampered)
+
+    const previous = process.env.DBCLI_AGENT_MODE
+    process.env.DBCLI_AGENT_MODE = '1'
+    try {
+      await expect(persistSchemaCache({ storagePath, ...CACHE_WRITE })).rejects.toThrow(/tampering/)
+    } finally {
+      if (previous === undefined) delete process.env.DBCLI_AGENT_MODE
+      else process.env.DBCLI_AGENT_MODE = previous
+    }
+
+    expect(await readFile(join(storagePath, 'config.json'), 'utf8')).toBe(tampered)
+  })
+
+  test('under agent mode an untampered config is written', async () => {
+    // The whole point of the Story: agent mode no longer blocks a cache write.
+    await seed(V1_CONFIG)
+    const previous = process.env.DBCLI_AGENT_MODE
+    process.env.DBCLI_AGENT_MODE = '1'
+    try {
+      await persistSchemaCache({ storagePath, ...CACHE_WRITE })
+    } finally {
+      if (previous === undefined) delete process.env.DBCLI_AGENT_MODE
+      else process.env.DBCLI_AGENT_MODE = previous
+    }
+
+    expect((await readConfig()).schema).toEqual(DEMO_SCHEMA)
+  })
+
+  test('an unwritable storage directory fails without a partial config', async () => {
+    await seed(V1_CONFIG)
+    const before = await readFile(join(storagePath, 'config.json'), 'utf8')
+    await chmod(storagePath, 0o500)
+
+    try {
+      await expect(persistSchemaCache({ storagePath, ...CACHE_WRITE })).rejects.toThrow()
+      expect(await readFile(join(storagePath, 'config.json'), 'utf8')).toBe(before)
+    } finally {
+      await chmod(storagePath, 0o700)
+    }
+  })
+})
+
+describe('assertOnlyCacheFieldsChanged', () => {
+  const cacheUpdated = {
+    ...V1_CONFIG,
+    schema: DEMO_SCHEMA,
+    metadata: { ...V1_CONFIG.metadata, schemaLastUpdated: 'x', schemaTableCount: 1 },
+  }
+
+  test('accepts a change confined to the cache fields', () => {
+    expect(() => assertOnlyCacheFieldsChanged(V1_CONFIG, cacheUpdated)).not.toThrow()
+  })
+
+  test.each([
+    ['connection', { connection: { ...V1_CONFIG.connection, password: 'attacker-supplied' } }],
+    ['permission', { permission: 'admin' }],
+    ['blacklist', { blacklist: { tables: [], columns: {} } }],
+    ['audit', { audit: { enabled: false } }],
+  ])('refuses a candidate that also changes %s', (field, override) => {
+    let message = ''
+    try {
+      assertOnlyCacheFieldsChanged(V1_CONFIG, { ...cacheUpdated, ...override })
+      throw new Error('expected a refusal')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SchemaCacheWriteError)
+      message = (error as Error).message
+    }
+
+    expect(message).toContain(field)
+    // The field is named; its value never is. A refusal that quoted the
+    // rejected `connection` would print the credential it exists to protect.
+    expect(message).not.toMatch(/attacker-supplied|testpass|127\.0\.0\.1|5433|admin\b/)
+  })
+
+  test('refuses a metadata change outside the two cache keys', () => {
+    // `metadata.version` is the config document's own version marker, not a
+    // cache timestamp. SchemaUpdater writes it alongside a refresh today; that
+    // is out of this Story's scope and must not slip in through the seam.
+    expect(() =>
+      assertOnlyCacheFieldsChanged(V1_CONFIG, {
+        ...cacheUpdated,
+        metadata: { ...cacheUpdated.metadata, version: '2.0' },
+      })
+    ).toThrow(SchemaCacheWriteError)
+  })
+
+  test('refuses a v2 candidate that writes another connection slot', () => {
+    const before = { ...V2_CONFIG, schemas: { primary: {}, other: {} } }
+    const after = { ...before, schemas: { primary: DEMO_SCHEMA, other: DEMO_SCHEMA } }
+    expect(() => assertOnlyCacheFieldsChanged(before, after, 'primary')).toThrow(
+      SchemaCacheWriteError
+    )
+  })
+
+  test('refuses a candidate that adds an unrelated top-level field', () => {
+    expect(() =>
+      assertOnlyCacheFieldsChanged(V1_CONFIG, {
+        ...cacheUpdated,
+        binding: { type: 'home-storage' },
+      })
+    ).toThrow(/binding/)
+  })
+})

--- a/tests/unit/core/schema-cache-persistence.test.ts
+++ b/tests/unit/core/schema-cache-persistence.test.ts
@@ -262,18 +262,27 @@ describe('persistSchemaCache — refusals leave the config alone', () => {
     expect((await readConfig()).schema).toEqual(DEMO_SCHEMA)
   })
 
-  test('an unwritable storage directory fails without a partial config', async () => {
-    await seed(V1_CONFIG)
-    const before = await readFile(join(storagePath, 'config.json'), 'utf8')
-    await chmod(storagePath, 0o500)
+  // POSIX mode bits are how this fault is injected, and Windows does not honour
+  // them: `chmod(dir, 0o500)` there leaves the directory writable, the seam
+  // succeeds, and the test fails for a reason that has nothing to do with the
+  // seam. Skipped rather than weakened — the property still holds on Windows,
+  // it just cannot be provoked this way. Same reasoning as
+  // `refusesGroupOrWorldWritable` in `src/core/config-integrity.ts`.
+  test.skipIf(process.platform === 'win32')(
+    'an unwritable storage directory fails without a partial config',
+    async () => {
+      await seed(V1_CONFIG)
+      const before = await readFile(join(storagePath, 'config.json'), 'utf8')
+      await chmod(storagePath, 0o500)
 
-    try {
-      await expect(persistSchemaCache({ storagePath, ...CACHE_WRITE })).rejects.toThrow()
-      expect(await readFile(join(storagePath, 'config.json'), 'utf8')).toBe(before)
-    } finally {
-      await chmod(storagePath, 0o700)
+      try {
+        await expect(persistSchemaCache({ storagePath, ...CACHE_WRITE })).rejects.toThrow()
+        expect(await readFile(join(storagePath, 'config.json'), 'utf8')).toBe(before)
+      } finally {
+        await chmod(storagePath, 0o700)
+      }
     }
-  })
+  )
 })
 
 describe('assertOnlyCacheFieldsChanged', () => {


### PR DESCRIPTION
第二個。**base 是 #162，不是 `main`** —— 這疊 PR 依序是 #162 → 本 PR → PLAT-011。追蹤於 #161。

## 起點：一個已知的過度宣稱

PLAT-001 交付時記下：`DBCLI_AGENT_MODE=1` 下 `capabilities check` 說 `schema.read` 可用，`dbcli schema` 卻 exit 1，訊息說的是「configuration, permission, and credential changes」——只讀 exit code 的 agent 只能推論成資料庫讀取失敗，而讀取其實成功了。

在 `c3e701a1` 對本 repo 自己的 PostgreSQL test service 重現：

```
$ DBCLI_AGENT_MODE=1 dbcli capabilities check --require schema.read --format json
  "results": [ { "id": "schema.read", "status": "available", "reason": null } ]

$ DBCLI_AGENT_MODE=1 dbcli schema
🔍 Scanning database schema...
✅ Schema persisted to layered storage (.dbcli/schemas/)
Agent mode blocks configuration, permission, and credential changes. …
  exit 1
```

## 動手之前先量了一次，量到的比記錄的嚴重

對一份 `connection.password: "testpass"`、`.env.local` 寫著 `DB_PASSWORD=untouched` 的 v1 設定跑一次 schema 寫入：

- `connection.password` 被從 `config.json` **刪掉**
- `.env.local` 被**整份覆寫**成新產生的 `DBCLI_PASSWORD=testpass`，原本的內容銷毀

**這件事在 agent mode 之外也會發生**——那裡沒有任何 guard 會攔。

所以真正的缺陷不是 guard 放錯位置，是**快取更新根本是一次完整設定的重新發布，只是掛著快取的名字**；那個 guard 不是防線，它只是唯一會對這個行為出聲的東西，而且出的還是錯的聲。

## 修法：窄化在簽章，不在旗標

刻意**不**替 `assertConfigMutationApproved()` 開一個例外。一個「這次寫入沒問題」的布林參數，等於把邊界交給呼叫端記得誠實，guard 保護的就會變成「大家有沒有老實申報」。

`src/core/schema-cache-persistence.ts` 的參數只有 schema、connection slot 與兩個時間戳，**設定是它自己從磁碟讀的**，沒有任何一條路徑能讓憑證、權限或 host 通過。寫不出來的東西不需要被批准。

`assertOnlyCacheFieldsChanged` 把同一句保證講出來。它對今天的程式是多餘的——這正是重點：任何擴大寫入範圍的修改會在單元測試裡**指名欄位**而失敗，而不是上線。訊息只指名欄位、絕不引用值——一個引用了被拒 `connection` 的拒絕訊息，會印出它存在要保護的那個憑證。

## 邊界一個字都沒動

`assertConfigMutationApproved()` 未修改。六個 guarded writer 一個都沒少，由 `tests/contract/config-mutation-boundary.test.ts` 以名冊釘住**兩個方向**：清單裡的都要 guard，清單外的都不准。

名冊只讀程式碼、不讀註解——seam 與 schema 指令的檔頭都在*討論*這個 guard，把提及算成呼叫的檢查只能靠刪掉解釋來滿足，那是錯的方向。

## 契約與行為現在綁在同一支測試裡

`tests/integration/schema-cache-agent-mode.test.ts` 先問 `capabilities check`、再跑 `dbcli schema`，對真的 PostgreSQL。PLAT-001 的過度宣稱能活下來，就是因為沒有任何東西同時問過這兩件事。

## 失敗回報

快取寫入失敗現在說自己是快取寫入失敗：明講 schema 已成功讀出、失敗的是存進本機快取那一步，而且 bounded——只有 `SchemaCacheWriteError` 原樣輸出（訊息在建構上不含路徑），其他成因一律分類而不引用，因為完整性拒絕會帶上它檢查的設定檔路徑。layered store 的寫入也一併包起來，它是同一份快取。

## 刻意改動的既有測試

都寫在 Story 的 Superseded Behavior：

- `INCIDENTAL_CONFIG_WRITERS` 的 `schema` 例外清空（清單留在原地，再加回一筆應該是一個決定）
- schema-refresh bootstrap 的 fixture 補上它一直隱含的設定——seam 拒絕在沒有設定時建立一份，因為那等於從快取寫入發布連線資訊

legacy 單檔 `.dbcli` 也支援：`configModule` 仍讀寫這個 layout，seam 不跟上就會開始拒絕一個今天能用的配置。

## 測試

新增 46 支（seam 21、boundary contract 6、agent-mode integration 5、docs 14）。

## Test plan

```
docker compose -f docker-compose.test.yml up -d --wait
make verify
```

`6622 pass / 0 fail / 0 skip`，564 檔，23 條靜態 gate 全過。前一個 PR 的 baseline 是 6576 / 560。

## 相容性影響

**`dbcli schema` 不再把密碼搬進 `.env.local`。** 依賴那個副作用的流程會看到行為改變——這是修正，不是回歸。

## 剩餘風險

Agent mode 下，設定若透過 symlink 路徑讀到（macOS `/var/folders` vs `/private/var/folders`），完整性紀錄的 `targetPath` 對不上而被判成 tampering。**既有問題、範圍外**，整合測試用 `realpath` 迴避並寫明原因。

`SchemaUpdater.refreshSchema` 仍在 guard 後面——沒有任何指令走得到它，且它會連帶寫 `metadata.version`，那是另一個問題，已寫進 Out of Scope。

---

`make verify` 通過只讓這份工作**有資格被人審**，不代表已核准或可合併。

https://claude.ai/code/session_01Cz5NRvBNmqSE7GHFHkFtvT
