### PR TITLE
docs: 收掉 DBCLI-014／015 的 lifecycle，並把 R3 換成真實 runner 量測

### DIFF
--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -428,11 +428,28 @@ DBCLI-014 這次一併進 `completed_stories`。它交付、驗證、Human Revie
 留在清單外只會讓紀錄同時說不出它是進行中還是完成——`status` 仍是 `review`，因為
 ForgeFlow 的 DONE 還要求 merge policy，而這條分支尚未合併。
 
+## 收尾：PR #172 合併，以及 R3 的真實 runner 數字
+
+PR #172 於 `dbf2c5d7` 合併進 main，CI 十一個 job 全綠（三個 OS × 兩個 Bun 版本，
+外加 format、audit、integration、build-determinism、docs-parity）。DBCLI-014 與
+DBCLI-015 進 `completed_stories`，`status` 推到 `done`——ForgeFlow 的 DONE 這下
+merge policy 也滿足了。
+
+順帶補掉審查留下的最後一個缺口。DBCLI-015 的 R3 要求預算「在它會跑的那台 runner
+上量」，而合併前那些常數旁邊寫的是「這台機器 0.14ms，乘三倍推估 runner」——推估
+不是量測。現在 CI 真的跑過了，數字直接抄回註解：100-table 預算在 ubuntu 0.08ms、
+macos 0.07ms、windows 0.27ms，最慢的一台離 2ms 還有 7.4 倍；1000-table 是
+0.10 / 0.07 / 0.20ms，跟 100-table 分不出來，這正是 set 查表該有的樣子。
+
+比值那對測試也拿到了跨平台的數字：set 查表 1.03–1.15，線性掃描 8.33–9.49，門檻 3
+在兩者中間，兩側都有餘裕。三個 OS 的絕對速度差了快四倍，比值卻幾乎不動——這就是
+當初選比值而不選毫秒數的理由，現在有量測撐著，不只是論證。
+
 ## Lifecycle
 
 ```yaml
 workflow:
-  current_story: DBCLI-015
+  current_story: pending
   next_story: pending
   completed_stories:
     - DBCLI-001
@@ -457,13 +474,14 @@ workflow:
     - DBCLI-PLAT-013
     - DBCLI-PLAT-007
     - DBCLI-014
-  status: review
+    - DBCLI-015
+  status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 64f2831eb708b3687ca990151aba8ba982f23545
-  dirty_worktree: true
+  commit: dbf2c5d74cac2d834b417d9212a5284a8dfb1280
+  dirty_worktree: false
   story_owned_paths:
     - specs/handoff.md
     - specs/stories/DBCLI-015-deterministic-blacklist-lookup-budget/task.md

--- a/tests/perf/blacklist-performance.bench.ts
+++ b/tests/perf/blacklist-performance.bench.ts
@@ -93,12 +93,12 @@ describe('Blacklist Performance Benchmarks', () => {
       return hits
     })
 
-    // 0.14ms on this machine across five runs. Scaled the same way as the rest of
-    // this file — a CI runner costs about 3x here — that is ~0.42ms, so 2ms keeps
-    // a 4.7x margin. This case does not guard the linear-scan regression on its
-    // own: at 100 tables that shape measures 0.98ms here, under any budget loose
-    // enough not to be a coin flip. The 1000-table case below is what fails on it,
-    // which is why both scales are kept.
+    // Measured on the runners this actually runs on (workflow run 34177694446,
+    // the merge of DBCLI-015): 0.08ms ubuntu, 0.07ms macos, 0.27ms windows. The
+    // slowest of the three leaves 2ms a 7.4x margin. This case does not guard the
+    // linear-scan regression on its own — at 100 tables that shape is fast enough
+    // to pass any budget loose enough not to be a coin flip. The scaling pair
+    // below is what rejects it, which is why both scales are kept.
     report('Table lookup (100 tables, typical)', elapsed, 2)
     expect(elapsed).toBeLessThan(2)
   })
@@ -115,11 +115,12 @@ describe('Blacklist Performance Benchmarks', () => {
     })
 
     // Budget tightened from 10ms to 2ms by DBCLI-015. The lookup is set-backed, so
-    // it does not care that the blacklist is ten times larger: 0.099ms here,
-    // ~0.3ms on a runner at this file's 3x scaling. The old 10ms was 100x the
-    // measurement. This budget is a cost ceiling only; the linear-scan regression
-    // is rejected by the scaling pair below, which does not depend on how fast
-    // the machine reading it happens to be.
+    // it does not care that the blacklist is ten times larger: same run as above,
+    // 0.10ms ubuntu, 0.07ms macos, 0.20ms windows — indistinguishable from the
+    // 100-table case, which is the point. The old 10ms was 100x the measurement.
+    // This budget is a cost ceiling only; the linear-scan regression is rejected
+    // by the scaling pair below, which does not depend on how fast the machine
+    // reading it happens to be.
     report('Table lookup (1000 tables)', elapsed, 2)
     expect(elapsed).toBeLessThan(2)
   })
@@ -136,7 +137,12 @@ describe('Blacklist Performance Benchmarks', () => {
 
   /** Probes must be spread across the whole blacklist. */
   const LOOKUPS_PER_SAMPLE = 2000
-  /** Set-backed measures 0.83–1.04 here; a linear scan measures 7.3–9.6. */
+  /**
+   * Set-backed measures 1.03–1.15 across ubuntu, macos and windows runners; a
+   * linear scan measures 8.33–9.49 on the same three (workflow run 34177694446).
+   * The threshold sits between them with margin on both sides, and because a
+   * ratio has no unit, a slow runner slows both halves.
+   */
   const MAX_SIZE_SCALING = 3
 
   const probeAllOf = (size: number, lookup: (name: string) => boolean) => () => {


### PR DESCRIPTION
PR #172 合併後的收尾。兩件事：把 ForgeFlow lifecycle 推到終態，以及補掉審查留下的最後一個缺口。

## Lifecycle 收尾

`dbf2c5d7` 進 main，CI 十一個 job 全綠（三個 OS × 兩個 Bun 版本，外加 format、audit、integration、build-determinism、docs-parity），ForgeFlow 的 DONE 所要求的 merge policy 這下滿足了。

- DBCLI-014、DBCLI-015 進 `completed_stories`（共 23 個）
- `current_story` 回到 `pending`，`status` 推到 `done`
- baseline 換成合併點 `dbf2c5d7`，`dirty_worktree: false`

## R3：推估換成量測

DBCLI-015 的 R3 要求預算「在它會跑的那台 runner 上量」，合併前那些常數旁邊寫的卻是「這台機器 0.14ms，乘三倍推估 runner」。推估不是量測，這正是這個 repo 反覆在修的形狀。現在 CI 真的跑過 `test:perf`，數字直接抄回註解（workflow run 34177694446）：

| | ubuntu | macos | windows | 預算／門檻 |
|---|---|---|---|---|
| 100-table 查表 | 0.08ms | 0.07ms | 0.27ms | 2ms |
| 1000-table 查表 | 0.10ms | 0.07ms | 0.20ms | 2ms |
| set 查表比值 | 1.04 | 1.03 | 1.15 | < 3 |
| 線性掃描比值 | 8.60 | 8.33 | 9.49 | > 3 |

1000-table 與 100-table 在三個平台上都分不出來，這正是 set 查表該有的樣子。最慢的一台（windows 0.27ms）離 2ms 還有 7.4 倍。

三個 OS 的絕對速度差了快四倍，比值卻幾乎不動——當初選比值而不選毫秒數的理由，現在有量測撐著，不只是論證。

## Test plan

- `make verify` PASS（exit 0），本地完整一輪含六個整合服務容器。
- `bun run test:perf` 24 pass / 0 fail；本輪比值 set 0.84、線性掃描 9.81。
- `bun run forgeflow:check` 通過，23 completed Stories（22 by commit trailer, 1 by recorded delivering commit）。

只動註解、handoff 與 lifecycle，沒有行為改動。

https://claude.ai/code/session_016ergjTN99kDPMngzfquBBw
