### PR TITLE
DBCLI-016: handoff 記交付，不記工作佇列

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,11 +167,17 @@ explicit human instruction.
 The completion report must list changed files, implementation and test changes,
 the exact verification result, assumptions, and remaining risks.
 
-When work changes hands, record the handoff lifecycle block in
-`specs/handoff.md`: exactly one current Story, exactly one next Story or
-`pending`, completed Story IDs, the repository baseline commit and worktree
-state, and the last verification command and result. Never leave the next Story
-to be inferred from list order.
+When work changes hands, `specs/handoff.md` records why: context, decisions,
+findings, remaining risks and assumptions, plus the repository baseline commit
+and worktree state, the completed Story IDs, and the last verification command
+and result.
+
+It does not record what to do next. `forgepilot next` answers that, and
+`forgepilot status` answers what is in progress or blocked. The handoff's
+`current_story` and `next_story` are pinned to the handoff contract's `none` and
+`pending`, and `bun run forgeflow:check` fails if either names a Story — two
+places recording one work queue is what ADR-0025 removed. Never restate
+ForgePilot's queue here, and never infer the next Story from list order either.
 
 ## dbcli Usage Guidelines
 

--- a/docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
+++ b/docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
@@ -1,0 +1,52 @@
+---
+status: proposed
+date: 2026-09-08
+---
+
+# The handoff records delivery, not a work queue
+
+`specs/handoff.md` stops stating which Story is current and which is next.
+ForgePilot is the only component that answers those two questions. The handoff
+keeps what ForgePilot structurally cannot hold: the narrative of why decisions
+were made, the risks and assumptions left for the next reader, the repository
+baseline, and `completed_stories` — the delivery record that
+`bun run forgeflow:check` reconciles against `Story:` commit trailers.
+
+The split is not a preference between two places to write the same thing. It
+follows from where each fact can be true. Actionable-next is a function of
+dependency edges, gates and evidence that change between commits; recorded in a
+committed file it is stale the moment it is written, and it was. Delivery is a
+property of git history; ForgePilot cannot hold it, because `.forgepilot/` is
+gitignored and twenty-one of the twenty-three delivered Stories predate the
+queue entirely.
+
+The duplication had already failed by the time this was written. Measured at
+`141cf4c3`, the handoff recorded `current_story: pending` and
+`next_story: pending`; upstream `handoff-check` rejects that under both the
+adopted 0.3.2 and the current 0.6.0, along with a `verification.detail` key the
+contract does not define. Nothing in `make verify` saw it, because upstream's
+checkers live in a ForgeFlow checkout CI does not have. The half of the block
+that nothing reads is exactly the half that drifted.
+
+Enforcement is a gate rather than a convention. `scripts/lib/forgeflow-handoff.ts`
+refuses a handoff that names a current or next Story, and refuses lifecycle keys
+outside the adopted contract. A convention would have to be re-argued by every
+agent that reads the ForgeFlow handoff template and finds fields to fill in;
+the refusal answers once, with a message naming ForgePilot as where that state
+belongs. The `workflow:`, `baseline:` and `verification:` sections stay, with
+the contract's own sentinels for "no Story is stated" — this repository declares
+it adopted ForgeFlow, and quietly deleting required sections would make that
+declaration false.
+
+The decision costs one thing worth naming: a reader with no ForgePilot installed
+can no longer learn from the repository what is being worked on. That is
+accepted, because the answer they were getting was wrong. Verification is
+unaffected — cloning dbcli and running `make verify` never needed ForgePilot and
+still does not.
+
+**Falsified if:** `bun run forgeflow:check` in `scripts/lib/forgeflow-handoff.ts`
+stops being able to decide the delivery record from git alone — because it needs
+to read ForgePilot state, reach the network, or require a ForgeFlow checkout — or
+if a second component in this repository starts recording which Story is current
+in a file under `specs/`. Either means the boundary in `AGENTS.md` no longer
+describes the system, and the state this decision separated has merged again.

--- a/docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
+++ b/docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-09-08
 ---
 

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -8,6 +8,10 @@
  * against fixtures instead of against a repository whose answers change every
  * time a Story is delivered.
  *
+ * Since DBCLI-016 it also refuses a handoff that names a current or next Story:
+ * ForgePilot owns that state, and a second copy here is what drifted before
+ * anyone noticed nothing was reading it. See `lib/forgeflow-handoff.ts`.
+ *
  * The sibling gate `check-forgeflow-adoption.ts` reconciles the process version
  * those Stories were written against. The two are deliberately disjoint: one
  * checks delivery claims, the other checks which ForgeFlow this repository says
@@ -16,8 +20,11 @@
 
 import { $ } from 'bun'
 import {
+  collectLifecycleViolations,
   collectStoryIds,
   formatFailures,
+  formatViolations,
+  lifecycleBlock,
   parseLifecycle,
   reconcile,
   shallowCloneRefusal,
@@ -84,7 +91,18 @@ if (refusal !== null) {
   process.exit(1)
 }
 
-const lifecycle = parseLifecycle(await Bun.file(handoffPath).text())
+const body = lifecycleBlock(await Bun.file(handoffPath).text())
+
+// The contract first, the claims second. A block making a statement it is not
+// allowed to make is not a block whose delivery list is worth reconciling, and
+// reporting both at once would bury the one the reader has to fix first.
+const violations = collectLifecycleViolations(body)
+if (violations.length > 0) {
+  console.error(formatViolations(violations))
+  process.exit(1)
+}
+
+const lifecycle = parseLifecycle(body)
 
 const failures = await reconcile({
   lifecycle,

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -20,12 +20,11 @@
 
 import { $ } from 'bun'
 import {
-  collectLifecycleViolations,
   collectStoryIds,
   formatFailures,
   formatViolations,
   lifecycleBlock,
-  parseLifecycle,
+  readLifecycle,
   reconcile,
   shallowCloneRefusal,
   type Exemption,
@@ -96,13 +95,11 @@ const body = lifecycleBlock(await Bun.file(handoffPath).text())
 // The contract first, the claims second. A block making a statement it is not
 // allowed to make is not a block whose delivery list is worth reconciling, and
 // reporting both at once would bury the one the reader has to fix first.
-const violations = collectLifecycleViolations(body)
+const { lifecycle, violations } = readLifecycle(body)
 if (violations.length > 0) {
   console.error(formatViolations(violations))
   process.exit(1)
 }
-
-const lifecycle = parseLifecycle(body)
 
 const failures = await reconcile({
   lifecycle,

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -168,6 +168,39 @@ export function lifecycleBlock(handoff: string): string {
   return blocks[0]?.[1] ?? ''
 }
 
+/**
+ * The value a lifecycle line states, with YAML's decoration removed.
+ *
+ * `"none"` and `none # ForgePilot owns this` say what `none` says. Comparing
+ * the raw text told a reader who had quoted or annotated the value that
+ * ForgePilot owns the state they had just deferred to ForgePilot — a refusal
+ * whose message is about the wrong thing is worse than no refusal, because it
+ * sends the reader to change something that was already right.
+ */
+function bareValue(value: string): string {
+  const uncommented = value.replace(/\s+#.*$/, '').trim()
+  return uncommented.replace(/^(['"])([\s\S]*)\1$/, '$2').trim()
+}
+
+/**
+ * Name the place a line the scanner cannot read belongs to.
+ *
+ * Indentation decides, not whichever key happened to be seen last: four spaces
+ * or more continues the key above it, less than that does not, and a line at
+ * the margin belongs to the block rather than to any section. A `---` after the
+ * block's final key used to be reported against that key, which named a
+ * statement the writer never made.
+ */
+function locate(section: string | null, key: string | null, line: string): string {
+  const indent = line.length - line.trimStart().length
+  if (indent >= 4 && section !== null && key !== null) return `${section}.${key}`
+  if (indent >= 1 && section !== null) return section
+  return 'lifecycle block'
+}
+
+const unreadable = (line: string) =>
+  `carries an unsupported lifecycle indentation: ${JSON.stringify(line)}`
+
 /** What one pass over a lifecycle block body found. */
 export interface Reading {
   readonly lifecycle: Lifecycle
@@ -223,9 +256,21 @@ export function readLifecycle(body: string): Reading {
       continue
     }
 
-    if (!known) continue
-
     const keyLine = line.match(KEY_LINE)
+    const listLine = line.match(LIST_LINE)
+
+    // An unrecognised section is reported once, not once per line beneath it;
+    // one mistake deserves one message. Lines that parse as nothing at all are
+    // still reported, because that is a different mistake — a capitalised
+    // `Workflow:` used to be swallowed here and surfaced three rules later as
+    // `workflow.current_story is not stated`, sending the reader to add a key
+    // that was already in front of them.
+    if (!known) {
+      if (keyLine || listLine) continue
+      violations.push({ location: locate(section, key, line), reason: unreadable(line) })
+      continue
+    }
+
     if (keyLine) {
       key = keyLine[1] as string
       const location = `${section}.${key}`
@@ -236,6 +281,10 @@ export function readLifecycle(body: string): Reading {
           location,
           reason: 'is not a key the adopted ForgeFlow handoff contract defines',
         })
+        // The key is not one this gate knows, so nothing below it continues
+        // anything it can name: attributing those lines here would report one
+        // mistake twice under a location that does not exist in the contract.
+        key = null
         continue
       }
 
@@ -259,23 +308,22 @@ export function readLifecycle(body: string): Reading {
       continue
     }
 
-    const listLine = line.match(LIST_LINE)
     if (listLine) {
       if (`${section}.${key}` === COMPLETED) completedStories.push(listLine[1] as string)
       continue
     }
 
-    violations.push({
-      location: key === null ? (section as string) : `${section}.${key}`,
-      reason: `carries an unsupported lifecycle indentation: ${JSON.stringify(line)}`,
-    })
+    violations.push({ location: locate(section, key, line), reason: unreadable(line) })
   }
 
   for (const [field, pinned] of PINNED_WORKFLOW_VALUES) {
     const location = `workflow.${field}`
-    const value = values.get(location)
+    const stated = values.get(location)
+    const value = stated === undefined ? undefined : bareValue(stated)
 
-    if (value === undefined) {
+    // `current_story:` with nothing after it states no Story either. Reporting
+    // it as the wrong value printed an empty pair of backticks at the reader.
+    if (value === undefined || value.length === 0) {
       if (!violations.some((violation) => violation.location === location)) {
         violations.push({
           location,
@@ -289,7 +337,7 @@ export function readLifecycle(body: string): Reading {
       violations.push({
         location,
         reason:
-          `is \`${value}\`, but ForgePilot decides which Story is in progress and which is next — ` +
+          `is \`${stated}\`, but ForgePilot decides which Story is in progress and which is next — ` +
           `record it there and leave this \`${pinned}\``,
       })
     }

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -99,23 +99,22 @@ export interface ReconcileInput {
   readonly commitExists: (commit: string) => Promise<boolean>
 }
 
-const LIFECYCLE_BLOCK = /```yaml\n([\s\S]*?)```/
-const COMPLETED_LIST = /completed_stories:\n((?:[ \t]+-[ \t]+\S+\n)+)/
-const LIST_ITEM = /-\s+(\S+)/g
+const LIFECYCLE_FENCE = /```yaml\n([\s\S]*?)```/g
 const STORY_HEADING = /^#\s*Story:\s*(\S+)/m
 
 const SECTION_LINE = /^([a-z_]+):$/
 const KEY_LINE = /^ {2}([a-z_]+):(?:[ \t]+(.*))?$/
-const LIST_LINE = /^\s{3,}-\s+\S/
+const LIST_LINE = /^ {3,}-[ \t]+(\S+)[ \t]*$/
 
 /**
  * The lifecycle keys the adopted ForgeFlow handoff contract defines.
  *
  * Presence is upstream `handoff-check`'s business and is not duplicated here;
- * what this gate owns is that nothing outside the contract appears. The two
+ * what this gate owns is that nothing outside the contract appears. The
  * exceptions are `current_story` and `next_story`, which are required *and*
  * pinned to one value each, because their absence and their being filled in are
- * the same failure seen from two sides.
+ * the same failure seen from two sides, and `completed_stories`, which this
+ * gate reads and so must insist on being able to read.
  */
 const CONTRACT_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['workflow', new Set(['current_story', 'next_story', 'completed_stories', 'status'])],
@@ -133,55 +132,70 @@ const CONTRACT_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['verification', new Set(['last_command', 'result'])],
 ])
 
-/** The only value each work-queue field may hold, and why it holds it. */
+/** The only value each work-queue field may hold. ForgePilot holds the rest. */
 const PINNED_WORKFLOW_VALUES: ReadonlyMap<string, string> = new Map([
   ['current_story', 'none'],
   ['next_story', 'pending'],
 ])
 
+const COMPLETED = 'workflow.completed_stories'
+
 /**
- * Return the body of the single fenced `yaml` block.
+ * Return the body of the one fenced `yaml` block.
+ *
+ * Exactly one, not the first one. The handoff is five hundred lines of prose
+ * that quotes this block's own contents, and a non-greedy match for the first
+ * fence would read whichever example a later narrative section happened to put
+ * above the real block — a gate reconciling a quotation of itself, passing
+ * whatever the block below actually says. Nothing else in `specs/handoff.md`
+ * may be fenced as `yaml`; other examples are fenced as `text`.
  *
  * A missing block throws rather than yielding an empty body: checking nothing
  * would pass, and a gate that passes wherever its input has gone missing is a
  * gate that passes everywhere eventually.
  */
 export function lifecycleBlock(handoff: string): string {
-  const block = handoff.match(LIFECYCLE_BLOCK)
-  if (!block) throw new Error('specs/handoff.md has no lifecycle block')
-  return block[1] ?? ''
+  const blocks = [...handoff.matchAll(LIFECYCLE_FENCE)]
+
+  if (blocks.length === 0) throw new Error('specs/handoff.md has no lifecycle block')
+  if (blocks.length > 1) {
+    throw new Error(
+      `specs/handoff.md has ${blocks.length} fenced yaml blocks, so which one is the lifecycle ` +
+        'block is ambiguous — fence narrative examples as `text`'
+    )
+  }
+
+  return blocks[0]?.[1] ?? ''
+}
+
+/** What one pass over a lifecycle block body found. */
+export interface Reading {
+  readonly lifecycle: Lifecycle
+  readonly violations: readonly Violation[]
 }
 
 /**
- * Read the delivery claims out of a lifecycle block body.
+ * Read a lifecycle block body once: what it claims, and what it may not claim.
  *
- * `completed_stories` is the whole of what this reads. It is the one lifecycle
- * fact ForgePilot cannot hold — `.forgepilot/` is not committed, and most
- * delivered Stories predate the queue entirely — so it is the one this
- * repository reconciles for itself.
- */
-export function parseLifecycle(body: string): Lifecycle {
-  const list = body.match(COMPLETED_LIST)
-  if (!list) throw new Error('the lifecycle block records no completed_stories')
-
-  const completedStories = [...(list[1] ?? '').matchAll(LIST_ITEM)].map(([, id]) => id as string)
-
-  return { completedStories }
-}
-
-/**
- * Report every lifecycle statement the handoff is not allowed to make.
+ * One reader, deliberately. The delivery list and the contract check used to be
+ * two independent regexes over the same text, and they disagreed: a blank line
+ * inside `completed_stories` ended the list for one and meant nothing to the
+ * other, so a Story recorded below the gap was never reconciled against
+ * anything and never reported missing either. Two readers of one document is
+ * the same failure this gate exists to catch, one level down.
  *
- * The scan is deliberately literal rather than a YAML parse: this file imports
+ * The scan is literal rather than a YAML parse because this file imports
  * nothing, which is what makes "the gate does not reach the network" a property
- * of the file instead of a promise in its header. The shapes it accepts are the
- * shapes the contract's own example uses — a section, a two-space key, a list
- * item — and anything else is reported rather than interpreted, because a line
- * this gate cannot read is a line whose meaning nobody has checked.
+ * of the file instead of a promise in its header. It accepts the shapes the
+ * contract's own example uses — a section, a two-space key, a list item — and
+ * reports anything else rather than interpreting it, because a line this gate
+ * cannot read is a line whose meaning nobody has checked.
  */
-export function collectLifecycleViolations(body: string): Violation[] {
+export function readLifecycle(body: string): Reading {
   const violations: Violation[] = []
-  const seen = new Map<string, string>()
+  const values = new Map<string, string>()
+  const completedStories: string[] = []
+  const sections = new Set<string>()
 
   let section: string | null = null
   let known = false
@@ -195,12 +209,17 @@ export function collectLifecycleViolations(body: string): Violation[] {
       section = sectionLine[1] as string
       known = CONTRACT_KEYS.has(section)
       key = null
+
       if (!known) {
         violations.push({
           location: section,
           reason: 'is not a section the adopted ForgeFlow handoff contract defines',
         })
+      } else if (sections.has(section)) {
+        violations.push({ location: section, reason: 'is declared twice' })
       }
+
+      sections.add(section)
       continue
     }
 
@@ -220,11 +239,31 @@ export function collectLifecycleViolations(body: string): Violation[] {
         continue
       }
 
-      seen.set(location, value)
+      // Last-wins would make the verdict depend on line order: the same two
+      // lines in the other order refuse the handoff, and neither order says
+      // which value the writer meant.
+      if (values.has(location)) {
+        violations.push({ location, reason: 'is stated twice' })
+        continue
+      }
+
+      if (location === COMPLETED && value.length > 0) {
+        violations.push({
+          location,
+          reason: `is written inline as ${JSON.stringify(value)}; this gate reads it as a list of \`- <Story ID>\` items`,
+        })
+        continue
+      }
+
+      values.set(location, value)
       continue
     }
 
-    if (LIST_LINE.test(line)) continue
+    const listLine = line.match(LIST_LINE)
+    if (listLine) {
+      if (`${section}.${key}` === COMPLETED) completedStories.push(listLine[1] as string)
+      continue
+    }
 
     violations.push({
       location: key === null ? (section as string) : `${section}.${key}`,
@@ -234,13 +273,15 @@ export function collectLifecycleViolations(body: string): Violation[] {
 
   for (const [field, pinned] of PINNED_WORKFLOW_VALUES) {
     const location = `workflow.${field}`
-    const value = seen.get(location)
+    const value = values.get(location)
 
     if (value === undefined) {
-      violations.push({
-        location,
-        reason: `is not stated; the handoff contract requires the key, and this repository requires the value \`${pinned}\``,
-      })
+      if (!violations.some((violation) => violation.location === location)) {
+        violations.push({
+          location,
+          reason: `is not stated; the handoff contract requires the key, and this repository requires the value \`${pinned}\``,
+        })
+      }
       continue
     }
 
@@ -254,9 +295,15 @@ export function collectLifecycleViolations(body: string): Violation[] {
     }
   }
 
-  // Reported in the order they are found, then the pinned fields in the order
-  // the contract lists them: two runs over one handoff read the same way.
-  return violations
+  // The delivery list is what this gate reconciles; an empty one would
+  // reconcile nothing and pass.
+  if (completedStories.length === 0 && !violations.some((v) => v.location === COMPLETED)) {
+    violations.push({ location: COMPLETED, reason: 'records no Story' })
+  }
+
+  // Found order first, then the pinned fields in contract order, then the
+  // delivery list: two runs over one handoff read the same way.
+  return { lifecycle: { completedStories }, violations }
 }
 
 /**

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -16,6 +16,24 @@
 // unbacked claim is not necessarily false, it is unchecked, and an unchecked
 // claim survives by inertia until someone finally looks.
 //
+// ## The handoff records delivery, not a work queue
+//
+// DBCLI-016 removed the second half of what this block used to say. Which Story
+// is in progress, and which is next, are ForgePilot's answers: they are a
+// function of dependency edges, gates and evidence that change between commits,
+// so a copy in a committed file is stale the moment it is written — and was.
+// Measured at `141cf4c3`, the block held `current_story: pending` and
+// `next_story: pending`, which upstream's own checker rejects under both the
+// adopted 0.3.2 and the current 0.6.0, and nothing here looked at either field.
+//
+// So the fields are not merely unread now: naming a Story in them is refused,
+// and so is any key the adopted contract does not define. A convention would
+// have to be re-argued by every agent that opens the ForgeFlow handoff template
+// and finds blanks to fill; a refusal answers once. The sections themselves
+// stay, holding the contract's own spellings for "no Story is stated" — this
+// repository declares it adopted ForgeFlow, and deleting required keys would
+// make that declaration false. The reasoning is ADR-0025.
+//
 // It deliberately does not overlap upstream ForgeFlow's `story-check` and
 // `handoff-check`. Those are static structure checks over text a human wrote,
 // their own documentation is explicit that they never decide whether a
@@ -43,9 +61,14 @@
 
 /** The `workflow:` block's delivery claims. */
 export interface Lifecycle {
-  /** The Story in progress, or `null` when none is declared. */
-  readonly currentStory: string | null
   readonly completedStories: readonly string[]
+}
+
+/** One lifecycle statement the adopted handoff contract does not permit. */
+export interface Violation {
+  /** `section.key`, or the section alone when the section itself is unknown. */
+  readonly location: string
+  readonly reason: string
 }
 
 /** A Story delivered before commits carried `Story:` trailers. */
@@ -79,37 +102,161 @@ export interface ReconcileInput {
 const LIFECYCLE_BLOCK = /```yaml\n([\s\S]*?)```/
 const COMPLETED_LIST = /completed_stories:\n((?:[ \t]+-[ \t]+\S+\n)+)/
 const LIST_ITEM = /-\s+(\S+)/g
-const CURRENT_STORY = /^\s*current_story:\s*(\S+)\s*$/m
 const STORY_HEADING = /^#\s*Story:\s*(\S+)/m
 
-/** Values `current_story` may hold that name no Story. */
-const NO_CURRENT_STORY = new Set(['pending', 'none', 'null', '~'])
+const SECTION_LINE = /^([a-z_]+):$/
+const KEY_LINE = /^ {2}([a-z_]+):(?:[ \t]+(.*))?$/
+const LIST_LINE = /^\s{3,}-\s+\S/
 
 /**
- * Read the lifecycle block's delivery claims.
+ * The lifecycle keys the adopted ForgeFlow handoff contract defines.
  *
- * A missing block, or one recording no `completed_stories`, throws rather than
- * returning an empty result: reconciling nothing would pass, and a gate that
- * passes wherever its input has gone missing is a gate that passes everywhere
- * eventually.
+ * Presence is upstream `handoff-check`'s business and is not duplicated here;
+ * what this gate owns is that nothing outside the contract appears. The two
+ * exceptions are `current_story` and `next_story`, which are required *and*
+ * pinned to one value each, because their absence and their being filled in are
+ * the same failure seen from two sides.
  */
-export function parseLifecycle(handoff: string): Lifecycle {
+const CONTRACT_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ['workflow', new Set(['current_story', 'next_story', 'completed_stories', 'status'])],
+  [
+    'baseline',
+    new Set([
+      'repository',
+      'branch',
+      'commit',
+      'dirty_worktree',
+      'story_owned_paths',
+      'known_unrelated_paths',
+    ]),
+  ],
+  ['verification', new Set(['last_command', 'result'])],
+])
+
+/** The only value each work-queue field may hold, and why it holds it. */
+const PINNED_WORKFLOW_VALUES: ReadonlyMap<string, string> = new Map([
+  ['current_story', 'none'],
+  ['next_story', 'pending'],
+])
+
+/**
+ * Return the body of the single fenced `yaml` block.
+ *
+ * A missing block throws rather than yielding an empty body: checking nothing
+ * would pass, and a gate that passes wherever its input has gone missing is a
+ * gate that passes everywhere eventually.
+ */
+export function lifecycleBlock(handoff: string): string {
   const block = handoff.match(LIFECYCLE_BLOCK)
   if (!block) throw new Error('specs/handoff.md has no lifecycle block')
+  return block[1] ?? ''
+}
 
-  const body = block[1] ?? ''
+/**
+ * Read the delivery claims out of a lifecycle block body.
+ *
+ * `completed_stories` is the whole of what this reads. It is the one lifecycle
+ * fact ForgePilot cannot hold — `.forgepilot/` is not committed, and most
+ * delivered Stories predate the queue entirely — so it is the one this
+ * repository reconciles for itself.
+ */
+export function parseLifecycle(body: string): Lifecycle {
   const list = body.match(COMPLETED_LIST)
   if (!list) throw new Error('the lifecycle block records no completed_stories')
 
   const completedStories = [...(list[1] ?? '').matchAll(LIST_ITEM)].map(([, id]) => id as string)
 
-  // `current_story` is optional in a way `completed_stories` is not: between
-  // Stories there is genuinely none, and the protocol spells that state.
-  const declared = body.match(CURRENT_STORY)?.[1]
-  const currentStory =
-    declared === undefined || NO_CURRENT_STORY.has(declared.toLowerCase()) ? null : declared
+  return { completedStories }
+}
 
-  return { currentStory, completedStories }
+/**
+ * Report every lifecycle statement the handoff is not allowed to make.
+ *
+ * The scan is deliberately literal rather than a YAML parse: this file imports
+ * nothing, which is what makes "the gate does not reach the network" a property
+ * of the file instead of a promise in its header. The shapes it accepts are the
+ * shapes the contract's own example uses — a section, a two-space key, a list
+ * item — and anything else is reported rather than interpreted, because a line
+ * this gate cannot read is a line whose meaning nobody has checked.
+ */
+export function collectLifecycleViolations(body: string): Violation[] {
+  const violations: Violation[] = []
+  const seen = new Map<string, string>()
+
+  let section: string | null = null
+  let known = false
+  let key: string | null = null
+
+  for (const line of body.split('\n')) {
+    if (line.trim().length === 0) continue
+
+    const sectionLine = line.match(SECTION_LINE)
+    if (sectionLine) {
+      section = sectionLine[1] as string
+      known = CONTRACT_KEYS.has(section)
+      key = null
+      if (!known) {
+        violations.push({
+          location: section,
+          reason: 'is not a section the adopted ForgeFlow handoff contract defines',
+        })
+      }
+      continue
+    }
+
+    if (!known) continue
+
+    const keyLine = line.match(KEY_LINE)
+    if (keyLine) {
+      key = keyLine[1] as string
+      const location = `${section}.${key}`
+      const value = (keyLine[2] ?? '').trim()
+
+      if (!CONTRACT_KEYS.get(section as string)?.has(key)) {
+        violations.push({
+          location,
+          reason: 'is not a key the adopted ForgeFlow handoff contract defines',
+        })
+        continue
+      }
+
+      seen.set(location, value)
+      continue
+    }
+
+    if (LIST_LINE.test(line)) continue
+
+    violations.push({
+      location: key === null ? (section as string) : `${section}.${key}`,
+      reason: `carries an unsupported lifecycle indentation: ${JSON.stringify(line)}`,
+    })
+  }
+
+  for (const [field, pinned] of PINNED_WORKFLOW_VALUES) {
+    const location = `workflow.${field}`
+    const value = seen.get(location)
+
+    if (value === undefined) {
+      violations.push({
+        location,
+        reason: `is not stated; the handoff contract requires the key, and this repository requires the value \`${pinned}\``,
+      })
+      continue
+    }
+
+    if (value !== pinned) {
+      violations.push({
+        location,
+        reason:
+          `is \`${value}\`, but ForgePilot decides which Story is in progress and which is next — ` +
+          `record it there and leave this \`${pinned}\``,
+      })
+    }
+  }
+
+  // Reported in the order they are found, then the pinned fields in the order
+  // the contract lists them: two runs over one handoff read the same way.
+  return violations
 }
 
 /**
@@ -208,24 +355,7 @@ export async function reconcile({
   commitExists,
 }: ReconcileInput): Promise<Failure[]> {
   const failures: Failure[] = []
-  const { currentStory, completedStories } = lifecycle
-
-  // A Story cannot be both in progress and delivered. Whichever is true, the
-  // other is a stale line nobody deleted, and the two together say nothing.
-  if (currentStory !== null && completedStories.includes(currentStory)) {
-    failures.push({
-      story: currentStory,
-      reason:
-        'is recorded in both current_story and completed_stories — a Story is in progress or delivered, not both',
-    })
-  }
-
-  if (currentStory !== null && !directories.has(currentStory)) {
-    failures.push({
-      story: currentStory,
-      reason: 'is recorded as the current Story but has no specs/stories directory',
-    })
-  }
+  const { completedStories } = lifecycle
 
   for (const story of completedStories) {
     if (!directories.has(story)) {
@@ -276,6 +406,18 @@ export async function reconcile({
   }
 
   return failures
+}
+
+/** Render the violations as a report a reader can act on without opening a diff. */
+export function formatViolations(violations: readonly Violation[]): string {
+  const lines = violations.map(({ location, reason }) => `  ${location} ${reason}`)
+  return [
+    'ForgeFlow handoff contract violations in specs/handoff.md:',
+    '',
+    ...lines,
+    '',
+    `${violations.length} lifecycle statement(s) the adopted contract does not permit.`,
+  ].join('\n')
 }
 
 /** Render the failures as a report a reader can act on without opening a diff. */

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -141,6 +141,19 @@ const PINNED_WORKFLOW_VALUES: ReadonlyMap<string, string> = new Map([
 const COMPLETED = 'workflow.completed_stories'
 
 /**
+ * The keys the contract writes as a list of `- item` lines.
+ *
+ * A list item under a scalar key is neither read nor reported without this: a
+ * `- DBCLI-999` slipped under `status:` was silently nothing, which is the one
+ * outcome the scan promises never to produce.
+ */
+const LIST_KEYS: ReadonlySet<string> = new Set([
+  COMPLETED,
+  'baseline.story_owned_paths',
+  'baseline.known_unrelated_paths',
+])
+
+/**
  * Return the body of the one fenced `yaml` block.
  *
  * Exactly one, not the first one. The handoff is five hundred lines of prose
@@ -309,7 +322,17 @@ export function readLifecycle(body: string): Reading {
     }
 
     if (listLine) {
-      if (`${section}.${key}` === COMPLETED) completedStories.push(listLine[1] as string)
+      const location = `${section}.${key}`
+
+      if (!LIST_KEYS.has(location)) {
+        violations.push({
+          location: locate(section, key, line),
+          reason: `is a list item under a key the contract does not write as a list: ${JSON.stringify(line)}`,
+        })
+        continue
+      }
+
+      if (location === COMPLETED) completedStories.push(listLine[1] as string)
       continue
     }
 

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -509,12 +509,43 @@ Lifecycle 區塊，它們擋的是可查證的東西，成本也只有一次 CI�
 這條失效條件刻意不涵蓋 `specs/stories/*/acceptance.md`，也不涵蓋 `docs/adr/`。前者
 的成效已經量到，不需要再賭；後者早於這套流程存在，用它來評 ForgeFlow 會把因果記
 錯。
+## DBCLI-016：handoff 不再保存工作佇列
+
+這份檔案從此不說「現在做哪個 Story、下一個是哪個」。那兩個問題由 ForgePilot 回答，
+`specs/handoff.md` 留下的是 ForgePilot 結構上拿不走的東西：為什麼這樣決定、剩下哪些
+風險與假設、repository baseline，以及 `completed_stories`——由 `Story:` commit trailer
+逐條對帳的交付紀錄。理由寫在 ADR-0025，gate 在 `scripts/lib/forgeflow-handoff.ts`。
+
+促成這件事的不是潔癖，是量到的漂移。動工前在 `141cf4c3` 拿上游 `handoff-check` 跑這份
+檔案，採用中的 `v0.3.2` 與當前的 `v0.6.0` 都 FAIL：`current_story: pending` 不是契約
+承認的「沒有 Story」拼法（那是 `none`），`pending` 同時出現在 current 與 next 被判為
+自相矛盾，`verification.detail` 是契約沒有的 key，它底下六行折疊散文則是不受支援的縮排。
+`make verify` 一次都沒看見，因為上游 checker 住在 CI 沒有的 ForgeFlow checkout 裡。
+**block 裡沒人讀的那半，就是已經漂掉的那半**——`next_story` 與 `status` 在整個
+repository 沒有任何讀者。
+
+所以 gate 現在直接拒絕：具名的 current／next Story 不合法，契約沒定義的 key 也不合法。
+慣例會被下一個打開 ForgeFlow handoff 樣板、看到空欄位就想填的 agent 重新爭論一次；
+拒絕只回答一次。三個 section 都留著，用契約自己的 sentinel——宣稱採用了 ForgeFlow，
+就不能偷刪它要求的欄位。
+
+被搬出 block 的那段話留在這裡，它本來就是散文：DBCLI-015 的實作 commit 由 ForgePilot
+在確切 commit 的 detached worktree 連跑兩次 `make verify`，兩次都 PASS，那正是它的驗收
+要的決定性；同樣的形狀在那個 Story 之前給過一次 FAIL 一次 PASS。Evidence ID 與 revision
+刻意不抄在這裡——抄一次就要一個 commit，而那個 commit 會讓被抄的 evidence 立刻 stale。
+這個限制正是 DBCLI-017 要處理的題目。
+
+0.3.2 下還剩八條 `completed Story is not a Story ID: DBCLI-PLAT-*`，那是 0.3.2 的 Story
+ID 文法早於 `DBCLI-PLAT-*` 命名，0.6.0 已經放寬。不在這個 Story 的範圍，DBCLI-018 收。
 
 ## Lifecycle
 
+`current_story` 與 `next_story` 永久是契約的 sentinel。要知道現在該做什麼，問
+`forgepilot next`，不要問這個區塊。
+
 ```yaml
 workflow:
-  current_story: pending
+  current_story: none
   next_story: pending
   completed_stories:
     - DBCLI-001
@@ -540,32 +571,26 @@ workflow:
     - DBCLI-PLAT-007
     - DBCLI-014
     - DBCLI-015
+    - DBCLI-016
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: dbf2c5d74cac2d834b417d9212a5284a8dfb1280
+  commit: 141cf4c3ebc019b9693430bfaa1a9c1b2559ff90
   dirty_worktree: false
   story_owned_paths:
     - specs/handoff.md
-    - specs/stories/DBCLI-015-deterministic-blacklist-lookup-budget/task.md
-    - tests/perf/blacklist-performance.bench.ts
-    - tests/unit/core/blacklist-manager.test.ts
-    - specs/stories/DBCLI-014-forgepilot-dogfood/acceptance.md
-    - specs/stories/DBCLI-014-forgepilot-dogfood/story.md
-    - specs/stories/DBCLI-014-forgepilot-dogfood/task.md
-    - tests/contract/forgepilot-boundary.test.ts
+    - specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
+    - specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
+    - docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
+    - scripts/lib/forgeflow-handoff.ts
+    - scripts/check-forgeflow-handoff.ts
+    - tests/unit/scripts/forgeflow-handoff.test.ts
+    - AGENTS.md
   known_unrelated_paths: []
 
 verification:
   last_command: make verify
   result: pass
-  detail: >-
-    Run by ForgePilot in a detached worktree of the exact commit. DBCLI-015's
-    implementation commit was verified twice in a row and passed both times,
-    which is the determinism its acceptance asks for; the same shape produced
-    one FAIL and one PASS before this Story. Evidence IDs and revisions live in
-    ForgePilot's state, deliberately not restated here — restating them needs a
-    commit, and that commit invalidates the evidence being restated.
 ```

--- a/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
+++ b/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
@@ -1,0 +1,94 @@
+# Acceptance Criteria
+
+Every criterion names the evidence that decides it: a command and the result
+that counts as passing. A criterion whose evidence is "read the diff" is not
+acceptance, it is review.
+
+## Happy Path
+
+* [ ] `specs/handoff.md` names no live Story.
+      Evidence: `bun run forgeflow:check` → exit `0`, and
+      `sed -n '/^workflow:/,/^$/p' specs/handoff.md` shows
+      `current_story: none` and `next_story: pending`.
+* [ ] The delivery record still reconciles against git.
+      Evidence: `bun run forgeflow:check` prints
+      `forgeflow handoff reconciliation passed: 24 completed Stories
+      (23 by commit trailer, 1 by recorded delivering commit)`.
+* [ ] Nothing in the repository reads a next Story from the handoff.
+      Evidence: `grep -rn "next_story" scripts src tests` returns only the gate
+      rule that refuses a named one, and its tests.
+* [ ] ForgePilot answers what is actionable next.
+      Evidence: `forgepilot next` on a machine with ForgePilot installed selects
+      the Work Item for this Story while it is the only READY one; the delivery
+      report records the Work Item ID.
+
+## Business Rules
+
+* [ ] A named current Story is refused.
+      Evidence: a fixture lifecycle block with
+      `current_story: DBCLI-016` fails the rule, with a message naming
+      ForgePilot. Asserted in `tests/unit/scripts/forgeflow-handoff.test.ts`.
+* [ ] A named next Story is refused.
+      Evidence: a fixture with `next_story: DBCLI-017` fails the same way.
+* [ ] A lifecycle key outside the adopted contract is refused, naming the key.
+      Evidence: a fixture carrying `verification.detail` fails with
+      `verification.detail` in the message.
+* [ ] `completed_stories` reconciliation is unchanged.
+      Evidence: every existing test in
+      `tests/unit/scripts/forgeflow-handoff.test.ts` that does not name a
+      current Story passes unmodified, including the shallow-clone refusal, the
+      stale-exemption rule and the duplicate-directory refusal.
+* [ ] The gate needs no ForgePilot.
+      Evidence: `mv .forgepilot "$TMPDIR/fp-016" && env PATH=/usr/bin:/bin
+      bun run forgeflow:check` → exit `0`; then move it back.
+* [ ] `make verify` says exactly what it said before.
+      Evidence: `tests/contract/forgepilot-boundary.test.ts` passes with its
+      `REQUIRED_STEPS` roster unedited.
+* [ ] ForgePilot state stays out of Git.
+      Evidence: `git check-ignore .forgepilot/state.json` → exit `0`.
+
+## Failure Cases
+
+* [ ] A handoff with no lifecycle block still throws rather than passing.
+      Evidence: existing fixture test, unmodified.
+* [ ] A handoff whose block records no `completed_stories` still throws.
+      Evidence: existing fixture test, unmodified.
+* [ ] A shallow clone still refuses to render a verdict instead of passing.
+      Evidence: `shallowCloneRefusal` fixture tests, unmodified.
+* [ ] Reintroducing the duplicated state fails loudly rather than being
+      reconciled: a handoff naming a current Story that is also in
+      `completed_stories` fails on the refusal, and the failure text tells the
+      reader to delete the line, not to fix the contradiction.
+
+## Regression Requirements
+
+* [ ] `make verify` passes on the delivered commit, run by ForgePilot in a
+      detached worktree of that exact revision.
+* [ ] Upstream `handoff-check` from a `v0.3.2` ForgeFlow checkout no longer
+      reports `workflow.current_story must be one Story ID or none`,
+      `the same Story cannot be both current and next`,
+      `unknown lifecycle key: verification.detail`, or any
+      `unsupported lifecycle indentation` failure.
+      The `completed Story is not a Story ID: DBCLI-PLAT-*` failures remain and
+      are out of scope: 0.3.2's Story ID grammar predates `DBCLI-PLAT-*`, 0.6.0
+      widened it, and DBCLI-018 owns the upgrade. This criterion is met when the
+      remaining failures are exactly those eight.
+* [ ] No dbcli source, test fixture, or package manifest gains a reference to
+      ForgePilot.
+      Evidence: `tests/contract/forgepilot-boundary.test.ts`, unmodified.
+
+## Verification Notes
+
+`bun run forgeflow:check` is the gate that decides this Story, and it runs
+inside `make verify`. No step is added to `make verify`.
+
+The upstream `handoff-check` criterion is run by hand from a ForgeFlow checkout
+and is deliberately not wired into `make verify`: the checker lives in a
+repository CI does not have, and a gate that needs a second checkout fails for
+reasons unrelated to the code it guards. Record its output in the delivery
+report.
+
+The count in the second Happy Path criterion assumes this Story is delivered
+with its own `Story: DBCLI-016` trailer and added to `completed_stories`. If it
+is delivered without being recorded as completed, the expected count is 23 and
+the criterion is met with the earlier numbers.

--- a/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
+++ b/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
@@ -33,11 +33,13 @@ acceptance, it is review.
 * [ ] A lifecycle key outside the adopted contract is refused, naming the key.
       Evidence: a fixture carrying `verification.detail` fails with
       `verification.detail` in the message.
-* [ ] `completed_stories` reconciliation is unchanged.
-      Evidence: every existing test in
-      `tests/unit/scripts/forgeflow-handoff.test.ts` that does not name a
-      current Story passes unmodified, including the shallow-clone refusal, the
-      stale-exemption rule and the duplicate-directory refusal.
+* [ ] The `completed_stories` reconciliation rules are unchanged.
+      Evidence: every assertion in `tests/unit/scripts/forgeflow-handoff.test.ts`
+      that does not name a current Story survives, including the shallow-clone
+      refusal, the stale-exemption rule and the duplicate-directory refusal. The
+      only edit to those tests is the `Lifecycle` literal they pass in, which
+      lost a field. The rules are unchanged; the reader in front of them is not,
+      and every difference in it fails closed.
 * [ ] The gate needs no ForgePilot.
       Evidence: `mv .forgepilot "$TMPDIR/fp-016" && env PATH=/usr/bin:/bin
       bun run forgeflow:check` → exit `0`; then move it back.
@@ -51,10 +53,15 @@ acceptance, it is review.
 
 * [ ] A handoff with no lifecycle block still throws rather than passing.
       Evidence: existing fixture test, unmodified.
-* [ ] A handoff whose block records no `completed_stories` still throws.
-      Evidence: existing fixture test, unmodified.
+* [ ] A handoff whose block records no `completed_stories` cannot pass.
+      Evidence: `readLifecycle` reports `workflow.completed_stories records no
+      Story` and the gate exits 1. This is a violation rather than the throw the
+      first draft of this Story expected — one reader replaced two, so the case
+      that used to be a parse failure is now a reported one. The property being
+      accepted is that it fails, not the shape of the failure.
 * [ ] A shallow clone still refuses to render a verdict instead of passing.
-      Evidence: `shallowCloneRefusal` fixture tests, unmodified.
+      Evidence: `shallowCloneRefusal` fixture tests, whose assertions are
+      unchanged.
 * [ ] Reintroducing the duplicated state fails loudly rather than being
       reconciled: a handoff naming a current Story that is also in
       `completed_stories` fails on the refusal, and the failure text tells the
@@ -73,9 +80,12 @@ acceptance, it is review.
       are out of scope: 0.3.2's Story ID grammar predates `DBCLI-PLAT-*`, 0.6.0
       widened it, and DBCLI-018 owns the upgrade. This criterion is met when the
       remaining failures are exactly those eight.
-* [ ] No dbcli source, test fixture, or package manifest gains a reference to
-      ForgePilot.
-      Evidence: `tests/contract/forgepilot-boundary.test.ts`, unmodified.
+* [ ] No dbcli source file or package manifest gains a reference to ForgePilot.
+      Evidence: `tests/contract/forgepilot-boundary.test.ts`, unmodified — it
+      scans `src/` and `package.json`, which is the boundary that matters. The
+      gate's own rules and tests do name ForgePilot, deliberately: the refusal
+      message has to say where the state belongs, and a refusal that does not
+      name it sends the reader nowhere.
 
 ## Verification Notes
 

--- a/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
+++ b/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
@@ -1,0 +1,158 @@
+# Story: DBCLI-016 ForgePilot Is the Lifecycle Authority
+
+## Goal
+
+An agent or maintainer picking up dbcli gets one answer to "what is being worked
+on, and what is actionable next", and gets it from ForgePilot. `specs/handoff.md`
+can no longer state a second answer that disagrees with it.
+
+## Context
+
+Two components record operational lifecycle state today.
+
+ForgePilot holds READY, RUNNING, gate-blocked, REVIEW and DONE, the dependency
+edges between Work Items, and verification Evidence bound to an exact revision.
+`forgepilot next` is the only thing in this system that computes what is
+actionable. Nothing else can: `.forgepilot/` is gitignored, and a queue that
+lives in a committed file is a queue that goes stale between commits.
+
+`specs/handoff.md` carries `workflow.current_story`, `workflow.next_story` and
+`workflow.status` as well. Measured on 2026-09-08 at `141cf4c3`:
+
+* Nothing in this repository reads `next_story` or `status`.
+  `scripts/lib/forgeflow-handoff.ts` reads `current_story` and
+  `completed_stories`, and nothing else parses the block.
+* The block is already self-contradictory. It records `current_story: pending`
+  and `next_story: pending`. Running upstream `handoff-check` against it — from
+  a checkout of the adopted `v0.3.2`, and again from `v0.6.0` — fails both
+  times with `workflow.current_story must be one Story ID or none` and
+  `the same Story cannot be both current and next`, plus
+  `unknown lifecycle key: verification.detail` and six indentation failures from
+  the folded prose block under it.
+* `make verify` does not see any of that. Upstream's checkers live in a
+  ForgeFlow checkout CI does not have, which is the documented reason this
+  repository wrote its own gate instead.
+
+So the duplicated state is not a hypothetical conflict: the half nothing reads
+has already drifted into a shape the protocol rejects, and it drifted silently.
+
+`completed_stories` is a different thing wearing the same block.
+`bun run forgeflow:check` reconciles each entry against a `Story:` commit
+trailer, or against a recorded delivering commit for the one Story that predates
+trailers. Twenty-one of its twenty-three entries were delivered before ForgePilot
+existed and appear in no ForgePilot state; ForgePilot holds two Work Items. The
+delivery record is a repository fact, checkable offline from git alone, and
+ForgePilot is structurally unable to hold it. It stays.
+
+## Classification
+
+Both declarations are required. `yes` makes the matching section below
+mandatory.
+
+* Security sensitive: no
+* Baseline conformance: yes
+
+## Scope
+
+### In Scope
+
+* `specs/handoff.md` states no live Story: `current_story: none` and
+  `next_story: pending`, the two values the adopted handoff contract defines for
+  "no Story is stated".
+* The prose currently held in `verification.detail` moves out of the lifecycle
+  block into the surrounding narrative, where the contract puts prose.
+* `scripts/lib/forgeflow-handoff.ts` stops treating a named current Story as a
+  claim to reconcile and instead refuses it, and refuses lifecycle keys the
+  adopted handoff contract does not define.
+* `AGENTS.md` states which component owns which lifecycle question.
+* A decision record for the boundary, with the condition that would falsify it.
+
+### Out of Scope
+
+* Removing `completed_stories`, or any change to how it reconciles.
+* Removing the `workflow:`, `baseline:` or `verification:` sections. The adopted
+  ForgeFlow handoff contract requires all three; this repository does not fork
+  the contract it declares it adopted.
+* Changing `specs/.forgeflow-adoption`, the Story template, or the adopted
+  ForgeFlow version — DBCLI-018 owns that.
+* Exporting, committing, or reading ForgePilot state anywhere in this
+  repository — DBCLI-017 owns portable evidence.
+* Any change to the steps of `make verify`, or their order.
+* Any dbcli source, runtime, or packaging dependency on ForgePilot.
+* Running upstream `story-check` or `handoff-check` inside `make verify`.
+
+## Inputs
+
+* The `workflow:` block of `specs/handoff.md`.
+* `Story:` trailers in git history, and the Story IDs declared by each
+  `specs/stories/*/story.md` heading.
+* The adopted ForgeFlow handoff contract, `protocol/handoff.md` at 0.3.2.
+
+## Outputs
+
+* A handoff whose lifecycle block names no live or next Story.
+* A gate that fails if one is reintroduced.
+* One statement in `AGENTS.md` of who owns what.
+* An architecture decision record.
+
+## Rules
+
+* R1: `bun run forgeflow:check` fails when `workflow.current_story` is anything
+  but `none`, or `workflow.next_story` anything but `pending`. Single-source is
+  enforced, not requested.
+* R2: `completed_stories` reconciliation is unchanged — the same rules, the same
+  `DELIVERED_BEFORE_TRAILERS` ratchet, the same refusal on a shallow clone.
+* R3: The lifecycle block carries only keys the adopted handoff contract
+  defines. An unknown key fails, naming the key.
+* R4: The gate reads no ForgePilot state, requires no ForgePilot install, and
+  makes no network call. A clone with ForgePilot absent verifies identically.
+* R5: The step list of `make verify` is byte-identical before and after this
+  Story.
+* R6: Every rule this Story adds is decided in `scripts/lib/forgeflow-handoff.ts`
+  against arguments, testable from fixtures without a repository.
+
+## Expected Errors
+
+* A handoff naming a current or next Story fails `bun run forgeflow:check` with
+  a message that names ForgePilot as where that state belongs, so the reader
+  does not have to guess whether to delete the line or the tool.
+* A lifecycle key outside the contract fails, naming the key and the contract
+  that defines the permitted set.
+* A handoff with no lifecycle block, or with no `completed_stories`, still
+  throws rather than passing — unchanged.
+* A shallow clone still refuses to render a verdict — unchanged.
+
+## Dependencies
+
+* None. This Story adds no dependency on the ForgePilot binary, and removes
+  none.
+
+## Constraints
+
+* The adopted 0.3.2 handoff contract must remain satisfiable: all three
+  sections, every required key, and only values the contract permits.
+* The gate stays offline and needs no ForgeFlow checkout.
+* `specs/handoff.md` remains the place a human reads for why, context,
+  decisions, risks and the repository baseline. This Story removes a work queue
+  from it, not its narrative.
+
+## Superseded Behavior
+
+Required when `Baseline conformance: yes`; otherwise delete this section. Name
+each existing test or documented behavior this Story intentionally replaces.
+
+* `tests/unit/scripts/forgeflow-handoff.test.ts` — the two reconcile rules that
+  take a named `current_story` as valid input: "a Story cannot be both current
+  and delivered", and "a current Story must have a `specs/stories` directory".
+  A named current Story is now refused outright, so these rules are replaced by
+  the refusal rather than kept beside it. Keeping both would leave two
+  behaviours for one input and a rule nothing can reach.
+* `scripts/lib/forgeflow-handoff.ts` — `Lifecycle.currentStory` as a Story ID or
+  `null`, and `NO_CURRENT_STORY` as a set of accepted spellings. The protocol
+  defines exactly one spelling for "none"; accepting four was this repository
+  quietly widening a contract it did not own.
+* `specs/handoff.md` — `current_story: pending` and the `verification.detail`
+  key, neither of which the contract permits.
+* `AGENTS.md` lines 170–174 — the instruction to record "exactly one current
+  Story, exactly one next Story or `pending`" in the handoff. That instruction
+  is what produced the duplicated state.

--- a/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
+++ b/specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
@@ -118,8 +118,10 @@ mandatory.
   does not have to guess whether to delete the line or the tool.
 * A lifecycle key outside the contract fails, naming the key and the contract
   that defines the permitted set.
-* A handoff with no lifecycle block, or with no `completed_stories`, still
-  throws rather than passing — unchanged.
+* A handoff with no lifecycle block throws, naming the ambiguity when the cause
+  is more than one fenced block rather than none.
+* A handoff whose block records no `completed_stories`, or records them in a
+  shape this gate does not read, is refused rather than reconciled as empty.
 * A shallow clone still refuses to render a verdict — unchanged.
 
 ## Dependencies

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -189,6 +189,45 @@ describe('readLifecycle', () => {
     expect(found.some((violation) => /indentation/.test(violation.reason))).toBe(true)
   })
 
+  test('a quoted or annotated sentinel says what the bare one says', () => {
+    // Both are idiomatic YAML the contract permits. Refusing them told a reader
+    // who had deferred to ForgePilot that they had not.
+    expect(violations(body('  current_story: "none"\n  next_story: \'pending\'\n'))).toEqual([])
+    expect(
+      violations(body('  current_story: none # ForgePilot owns this\n  next_story: pending\n'))
+    ).toEqual([])
+  })
+
+  test('a key with no value states no Story, rather than the wrong one', () => {
+    const found = violations(body('  current_story:\n  next_story: pending\n'))
+    expect(found.map((violation) => violation.location)).toEqual(['workflow.current_story'])
+    expect(found[0]!.reason).toMatch(/is not stated/)
+  })
+
+  test('an unreadable line is attributed by its indentation, not by the last key seen', () => {
+    // A `---` after the block's final key used to be reported against that key,
+    // naming a statement the writer never made.
+    const found = violations(`${BODY}---\n`)
+    expect(found.map((violation) => violation.location)).toEqual(['lifecycle block'])
+  })
+
+  test('an unknown key does not also claim the lines beneath it', () => {
+    const found = violations(`${BODY}  detail: >-\n    a continuation\n`)
+    expect(found.map((violation) => violation.location)).toEqual([
+      'verification.detail',
+      'verification',
+    ])
+  })
+
+  test('a mis-capitalised section is reported, not swallowed', () => {
+    // `Workflow:` used to be skipped in silence and surface three rules later
+    // as `workflow.current_story is not stated`, sending the reader to add a
+    // key that was already in front of them.
+    const found = violations('Workflow:\n  current_story: none\n  next_story: pending\n')
+    expect(found[0]!.location).toBe('lifecycle block')
+    expect(found[0]!.reason).toMatch(/Workflow:/)
+  })
+
   test('a blank line inside the delivery list does not truncate it', () => {
     // Two readers of one list disagreed here: the list regex stopped at the
     // gap, the contract scan did not care, and a Story recorded below it was

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -1,6 +1,10 @@
 /**
  * The delivery gate reads Story IDs from Stories, not from directory names.
  *
+ * Since DBCLI-016 it reads only delivery claims. Which Story is in progress and
+ * which is next are ForgePilot's answers, and the gate's job around them is to
+ * refuse a handoff that gives a second one.
+ *
  * The old gate derived an ID with `/^(DBCLI-\d+).*$/` over the directory name.
  * `DBCLI-PLAT-001-capability-contract` does not match it, `String.replace`
  * hands back the input unchanged, and the Story ends up keyed under its own
@@ -20,8 +24,11 @@
 
 import { describe, test, expect } from 'bun:test'
 import {
+  collectLifecycleViolations,
   collectStoryIds,
   formatFailures,
+  formatViolations,
+  lifecycleBlock,
   parseLifecycle,
   readStoryId,
   reconcile,
@@ -29,16 +36,30 @@ import {
   type Exemption,
 } from '../../../scripts/lib/forgeflow-handoff'
 
-const lifecycleBlock = (body: string) => `# Handoff\n\nprose\n\n\`\`\`yaml\n${body}\`\`\`\n`
+const handoffFile = (body: string) => `# Handoff\n\nprose\n\n\`\`\`yaml\n${body}\`\`\`\n`
 
-const HANDOFF = lifecycleBlock(`workflow:
-  current_story: DBCLI-PLAT-013
-  next_story: DBCLI-PLAT-012
+const BODY = `workflow:
+  current_story: none
+  next_story: pending
   completed_stories:
     - DBCLI-001
     - DBCLI-PLAT-001
-  status: in_progress
-`)
+  status: done
+
+baseline:
+  repository: CarlLee1983/dbcli
+  branch: main
+  commit: 0000000000000000000000000000000000000000
+  dirty_worktree: false
+  story_owned_paths: []
+  known_unrelated_paths: []
+
+verification:
+  last_command: make verify
+  result: pass
+`
+
+const HANDOFF = handoffFile(BODY)
 
 const DIRECTORIES = new Map([
   ['DBCLI-001', 'DBCLI-001-contract-absence-and-invalid-drift'],
@@ -54,7 +75,7 @@ const absent = async () => false
 /** The default reconciliation: everything backed, nothing exempt. */
 function inputs(overrides: Partial<Parameters<typeof reconcile>[0]> = {}) {
   return {
-    lifecycle: parseLifecycle(HANDOFF),
+    lifecycle: parseLifecycle(BODY),
     directories: DIRECTORIES,
     trailers: new Set(['DBCLI-001', 'DBCLI-PLAT-001', 'DBCLI-PLAT-013']),
     exemptions: NO_EXEMPTIONS,
@@ -63,31 +84,98 @@ function inputs(overrides: Partial<Parameters<typeof reconcile>[0]> = {}) {
   }
 }
 
+describe('lifecycleBlock', () => {
+  test('returns the body of the single fenced yaml block', () => {
+    expect(lifecycleBlock(HANDOFF)).toBe(BODY)
+  })
+
+  test('a handoff with no lifecycle block is refused', () => {
+    expect(() => lifecycleBlock('# Handoff\n\njust prose\n')).toThrow(/lifecycle block/)
+  })
+})
+
 describe('parseLifecycle', () => {
-  test('reads the current Story and the completed list', () => {
-    expect(parseLifecycle(HANDOFF)).toEqual({
-      currentStory: 'DBCLI-PLAT-013',
+  test('reads the completed list, and nothing about work in progress', () => {
+    // The delivery record is the whole of what this gate parses. Current and
+    // next are ForgePilot's, and a second copy here is the drift DBCLI-016
+    // removed.
+    expect(parseLifecycle(BODY)).toEqual({
       completedStories: ['DBCLI-001', 'DBCLI-PLAT-001'],
     })
   })
 
-  test('a handoff with no lifecycle block is refused', () => {
-    expect(() => parseLifecycle('# Handoff\n\njust prose\n')).toThrow(/lifecycle block/)
-  })
-
   test('a lifecycle block recording no completed_stories is refused', () => {
-    expect(() => parseLifecycle(lifecycleBlock('workflow:\n  current_story: DBCLI-001\n'))).toThrow(
-      /completed_stories/
-    )
+    expect(() => parseLifecycle('workflow:\n  current_story: none\n')).toThrow(/completed_stories/)
+  })
+})
+
+describe('collectLifecycleViolations', () => {
+  const body = (workflow: string) => `workflow:\n${workflow}  completed_stories:\n    - DBCLI-001\n`
+
+  test('a block that names no live Story has nothing to report', () => {
+    expect(collectLifecycleViolations(BODY)).toEqual([])
   })
 
-  test('an absent current_story is null rather than a failure to parse', () => {
-    // `current_story` may legitimately be unset between Stories; the list is
-    // what this gate reconciles, and it is what must be present.
-    const lifecycle = parseLifecycle(
-      lifecycleBlock('workflow:\n  completed_stories:\n    - DBCLI-001\n')
+  test('a named current Story is refused, pointing at ForgePilot', () => {
+    const violations = collectLifecycleViolations(
+      body('  current_story: DBCLI-016\n  next_story: pending\n')
     )
-    expect(lifecycle.currentStory).toBeNull()
+    expect(violations).toHaveLength(1)
+    expect(violations[0]!.location).toBe('workflow.current_story')
+    expect(violations[0]!.reason).toMatch(/ForgePilot/)
+    expect(violations[0]!.reason).toMatch(/none/)
+  })
+
+  test('a named next Story is refused the same way', () => {
+    const violations = collectLifecycleViolations(
+      body('  current_story: none\n  next_story: DBCLI-017\n')
+    )
+    expect(violations.map((violation) => violation.location)).toEqual(['workflow.next_story'])
+    expect(violations[0]!.reason).toMatch(/ForgePilot/)
+  })
+
+  test('the value that shipped before DBCLI-016 is refused too', () => {
+    // `current_story: pending` is not the contract's spelling of "no Story",
+    // and it is what the handoff actually held while nothing was reading it.
+    const violations = collectLifecycleViolations(
+      body('  current_story: pending\n  next_story: pending\n')
+    )
+    expect(violations.map((violation) => violation.location)).toEqual(['workflow.current_story'])
+  })
+
+  test('an absent current or next Story is refused, because the contract requires both keys', () => {
+    const violations = collectLifecycleViolations(body(''))
+    expect(violations.map((violation) => violation.location)).toEqual([
+      'workflow.current_story',
+      'workflow.next_story',
+    ])
+    expect(violations[0]!.reason).toMatch(/is not stated/)
+  })
+
+  test('a key the adopted contract does not define is refused, naming it', () => {
+    const violations = collectLifecycleViolations(
+      `${BODY}  detail: something the contract has no field for\n`
+    )
+    expect(violations.map((violation) => violation.location)).toEqual(['verification.detail'])
+    expect(violations[0]!.reason).toMatch(/handoff contract/)
+  })
+
+  test('a section the contract does not define is refused', () => {
+    expect(
+      collectLifecycleViolations(`${BODY}\nnotes:\n  anything: here\n`).map(
+        (violation) => violation.location
+      )
+    ).toEqual(['notes'])
+  })
+
+  test('a folded prose continuation is refused as unsupported indentation', () => {
+    // The block held six lines of one, under a `detail:` key, and upstream's
+    // own checker is the only thing that ever objected.
+    const violations = collectLifecycleViolations(
+      `${BODY}  result_note: >-\n    a sentence continued\n    over two lines\n`
+    )
+    expect(violations.map((violation) => violation.location)).toContain('verification.result_note')
+    expect(violations.some((violation) => /indentation/.test(violation.reason))).toBe(true)
   })
 })
 
@@ -145,7 +233,7 @@ describe('reconcile', () => {
   test('a numeric Story backed by a trailer and a directory passes', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-001'] },
+        lifecycle: { completedStories: ['DBCLI-001'] },
       })
     )
     expect(failures).toEqual([])
@@ -154,19 +242,19 @@ describe('reconcile', () => {
   test('a PLAT Story backed by a trailer and a directory passes', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-PLAT-001'] },
+        lifecycle: { completedStories: ['DBCLI-PLAT-001'] },
       })
     )
     expect(failures).toEqual([])
   })
 
-  test('both families reconcile together, alongside a current Story', async () => {
+  test('both families reconcile together', async () => {
     expect(await reconcile(inputs())).toEqual([])
   })
 
   test('a completed Story with no directory fails closed', async () => {
     const failures = await reconcile(
-      inputs({ lifecycle: { currentStory: null, completedStories: ['DBCLI-PLAT-004'] } })
+      inputs({ lifecycle: { completedStories: ['DBCLI-PLAT-004'] } })
     )
     expect(failures).toHaveLength(1)
     expect(failures[0]!.story).toBe('DBCLI-PLAT-004')
@@ -179,28 +267,10 @@ describe('reconcile', () => {
     expect(failures[0]!.reason).toMatch(/`Story:` trailer/)
   })
 
-  test('a Story recorded as both current and completed fails closed', async () => {
-    const failures = await reconcile(
-      inputs({
-        lifecycle: { currentStory: 'DBCLI-PLAT-001', completedStories: ['DBCLI-PLAT-001'] },
-      })
-    )
-    expect(failures.map((failure) => failure.story)).toEqual(['DBCLI-PLAT-001'])
-    expect(failures[0]!.reason).toMatch(/current_story and completed_stories/)
-  })
-
-  test('a current Story with no directory fails closed', async () => {
-    const failures = await reconcile(
-      inputs({ lifecycle: { currentStory: 'DBCLI-PLAT-099', completedStories: ['DBCLI-001'] } })
-    )
-    expect(failures.map((failure) => failure.story)).toEqual(['DBCLI-PLAT-099'])
-    expect(failures[0]!.reason).toMatch(/no specs\/stories directory/)
-  })
-
   test('an exemption backs a Story delivered before trailers existed', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-001'] },
+        lifecycle: { completedStories: ['DBCLI-001'] },
         trailers: new Set<string>(),
         exemptions: new Map([['DBCLI-001', { commit: 'abc123', evidence: 'two named tests' }]]),
       })
@@ -211,7 +281,7 @@ describe('reconcile', () => {
   test('an exemption naming a commit this repository lacks fails', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-001'] },
+        lifecycle: { completedStories: ['DBCLI-001'] },
         trailers: new Set<string>(),
         exemptions: new Map([['DBCLI-001', { commit: 'abc123', evidence: 'two named tests' }]]),
         commitExists: absent,
@@ -223,7 +293,7 @@ describe('reconcile', () => {
   test('an exemption for a Story that has since acquired a trailer is stale', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-001'] },
+        lifecycle: { completedStories: ['DBCLI-001'] },
         exemptions: new Map([['DBCLI-001', { commit: 'abc123', evidence: 'two named tests' }]]),
       })
     )
@@ -233,7 +303,7 @@ describe('reconcile', () => {
   test('an exemption for a Story not recorded as completed fails', async () => {
     const failures = await reconcile(
       inputs({
-        lifecycle: { currentStory: null, completedStories: ['DBCLI-001'] },
+        lifecycle: { completedStories: ['DBCLI-001'] },
         exemptions: new Map([['DBCLI-777', { commit: 'abc123', evidence: 'x' }]]),
       })
     )
@@ -266,6 +336,17 @@ describe('formatFailures', () => {
     expect(report).toContain('DBCLI-777')
     expect(report).toContain('is not backed')
     expect(report).toContain('1 unbacked claim')
+  })
+})
+
+describe('formatViolations', () => {
+  test('every violation is named with its reason', () => {
+    const report = formatViolations([
+      { location: 'workflow.next_story', reason: 'is not the contract value' },
+    ])
+    expect(report).toContain('workflow.next_story')
+    expect(report).toContain('is not the contract value')
+    expect(report).toContain('1 lifecycle statement')
   })
 })
 

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -24,12 +24,11 @@
 
 import { describe, test, expect } from 'bun:test'
 import {
-  collectLifecycleViolations,
   collectStoryIds,
   formatFailures,
   formatViolations,
   lifecycleBlock,
-  parseLifecycle,
+  readLifecycle,
   readStoryId,
   reconcile,
   shallowCloneRefusal,
@@ -75,7 +74,7 @@ const absent = async () => false
 /** The default reconciliation: everything backed, nothing exempt. */
 function inputs(overrides: Partial<Parameters<typeof reconcile>[0]> = {}) {
   return {
-    lifecycle: parseLifecycle(BODY),
+    lifecycle: readLifecycle(BODY).lifecycle,
     directories: DIRECTORIES,
     trailers: new Set(['DBCLI-001', 'DBCLI-PLAT-001', 'DBCLI-PLAT-013']),
     exemptions: NO_EXEMPTIONS,
@@ -85,97 +84,131 @@ function inputs(overrides: Partial<Parameters<typeof reconcile>[0]> = {}) {
 }
 
 describe('lifecycleBlock', () => {
-  test('returns the body of the single fenced yaml block', () => {
+  test('returns the body of the one fenced yaml block', () => {
     expect(lifecycleBlock(HANDOFF)).toBe(BODY)
   })
 
   test('a handoff with no lifecycle block is refused', () => {
     expect(() => lifecycleBlock('# Handoff\n\njust prose\n')).toThrow(/lifecycle block/)
   })
+
+  test('a second fenced yaml block is refused rather than shadowing the real one', () => {
+    // The handoff is five hundred lines of prose that quotes this block. Taking
+    // the first fence would let a narrative example become the gate's input,
+    // and the block below it — the one a human reads and edits — would go
+    // unchecked entirely.
+    const quoted = `# Handoff\n\n\`\`\`yaml\nworkflow:\n  current_story: none\n\`\`\`\n\n${HANDOFF}`
+    expect(() => lifecycleBlock(quoted)).toThrow(/2 fenced yaml blocks/)
+  })
 })
 
-describe('parseLifecycle', () => {
+describe('readLifecycle', () => {
+  const body = (workflow: string) => `workflow:\n${workflow}  completed_stories:\n    - DBCLI-001\n`
+  const violations = (source: string) => readLifecycle(source).violations
+  const locations = (source: string) => violations(source).map((violation) => violation.location)
+
   test('reads the completed list, and nothing about work in progress', () => {
     // The delivery record is the whole of what this gate parses. Current and
     // next are ForgePilot's, and a second copy here is the drift DBCLI-016
     // removed.
-    expect(parseLifecycle(BODY)).toEqual({
+    expect(readLifecycle(BODY).lifecycle).toEqual({
       completedStories: ['DBCLI-001', 'DBCLI-PLAT-001'],
     })
   })
 
-  test('a lifecycle block recording no completed_stories is refused', () => {
-    expect(() => parseLifecycle('workflow:\n  current_story: none\n')).toThrow(/completed_stories/)
-  })
-})
-
-describe('collectLifecycleViolations', () => {
-  const body = (workflow: string) => `workflow:\n${workflow}  completed_stories:\n    - DBCLI-001\n`
-
   test('a block that names no live Story has nothing to report', () => {
-    expect(collectLifecycleViolations(BODY)).toEqual([])
+    expect(violations(BODY)).toEqual([])
   })
 
   test('a named current Story is refused, pointing at ForgePilot', () => {
-    const violations = collectLifecycleViolations(
-      body('  current_story: DBCLI-016\n  next_story: pending\n')
-    )
-    expect(violations).toHaveLength(1)
-    expect(violations[0]!.location).toBe('workflow.current_story')
-    expect(violations[0]!.reason).toMatch(/ForgePilot/)
-    expect(violations[0]!.reason).toMatch(/none/)
+    const found = violations(body('  current_story: DBCLI-016\n  next_story: pending\n'))
+    expect(found).toHaveLength(1)
+    expect(found[0]!.location).toBe('workflow.current_story')
+    expect(found[0]!.reason).toMatch(/ForgePilot/)
+    expect(found[0]!.reason).toMatch(/none/)
   })
 
   test('a named next Story is refused the same way', () => {
-    const violations = collectLifecycleViolations(
-      body('  current_story: none\n  next_story: DBCLI-017\n')
-    )
-    expect(violations.map((violation) => violation.location)).toEqual(['workflow.next_story'])
-    expect(violations[0]!.reason).toMatch(/ForgePilot/)
+    const found = violations(body('  current_story: none\n  next_story: DBCLI-017\n'))
+    expect(found.map((violation) => violation.location)).toEqual(['workflow.next_story'])
+    expect(found[0]!.reason).toMatch(/ForgePilot/)
   })
 
   test('the value that shipped before DBCLI-016 is refused too', () => {
     // `current_story: pending` is not the contract's spelling of "no Story",
     // and it is what the handoff actually held while nothing was reading it.
-    const violations = collectLifecycleViolations(
-      body('  current_story: pending\n  next_story: pending\n')
-    )
-    expect(violations.map((violation) => violation.location)).toEqual(['workflow.current_story'])
+    expect(locations(body('  current_story: pending\n  next_story: pending\n'))).toEqual([
+      'workflow.current_story',
+    ])
   })
 
   test('an absent current or next Story is refused, because the contract requires both keys', () => {
-    const violations = collectLifecycleViolations(body(''))
-    expect(violations.map((violation) => violation.location)).toEqual([
+    const found = violations(body(''))
+    expect(found.map((violation) => violation.location)).toEqual([
       'workflow.current_story',
       'workflow.next_story',
     ])
-    expect(violations[0]!.reason).toMatch(/is not stated/)
+    expect(found[0]!.reason).toMatch(/is not stated/)
+  })
+
+  test('a key stated twice is refused rather than resolved by line order', () => {
+    // Last-wins let a named Story be laundered past the refusal by writing the
+    // sentinel underneath it; the same two lines reversed were refused, and
+    // neither order says which value the writer meant.
+    const laundered = body(
+      '  current_story: DBCLI-016\n  next_story: pending\n  current_story: none\n'
+    )
+    expect(locations(laundered)).toEqual(['workflow.current_story', 'workflow.current_story'])
+    // Both statements are true and both are reported: the key is stated twice,
+    // and the value the writer put first names a Story.
+    expect(violations(laundered)[0]!.reason).toMatch(/twice/)
+    expect(violations(laundered)[1]!.reason).toMatch(/ForgePilot/)
+  })
+
+  test('a section declared twice is refused', () => {
+    expect(locations(`${BODY}\nworkflow:\n  status: done\n`)).toContain('workflow')
   })
 
   test('a key the adopted contract does not define is refused, naming it', () => {
-    const violations = collectLifecycleViolations(
-      `${BODY}  detail: something the contract has no field for\n`
-    )
-    expect(violations.map((violation) => violation.location)).toEqual(['verification.detail'])
-    expect(violations[0]!.reason).toMatch(/handoff contract/)
+    const found = violations(`${BODY}  detail: something the contract has no field for\n`)
+    expect(found.map((violation) => violation.location)).toEqual(['verification.detail'])
+    expect(found[0]!.reason).toMatch(/handoff contract/)
   })
 
   test('a section the contract does not define is refused', () => {
-    expect(
-      collectLifecycleViolations(`${BODY}\nnotes:\n  anything: here\n`).map(
-        (violation) => violation.location
-      )
-    ).toEqual(['notes'])
+    expect(locations(`${BODY}\nnotes:\n  anything: here\n`)).toEqual(['notes'])
   })
 
   test('a folded prose continuation is refused as unsupported indentation', () => {
     // The block held six lines of one, under a `detail:` key, and upstream's
     // own checker is the only thing that ever objected.
-    const violations = collectLifecycleViolations(
+    const found = violations(
       `${BODY}  result_note: >-\n    a sentence continued\n    over two lines\n`
     )
-    expect(violations.map((violation) => violation.location)).toContain('verification.result_note')
-    expect(violations.some((violation) => /indentation/.test(violation.reason))).toBe(true)
+    expect(found.map((violation) => violation.location)).toContain('verification.result_note')
+    expect(found.some((violation) => /indentation/.test(violation.reason))).toBe(true)
+  })
+
+  test('a blank line inside the delivery list does not truncate it', () => {
+    // Two readers of one list disagreed here: the list regex stopped at the
+    // gap, the contract scan did not care, and a Story recorded below it was
+    // reconciled against nothing and reported by nobody.
+    const gapped =
+      'workflow:\n  current_story: none\n  next_story: pending\n  completed_stories:\n    - DBCLI-001\n\n    - DBCLI-999\n  status: done\n'
+    expect(readLifecycle(gapped).lifecycle.completedStories).toEqual(['DBCLI-001', 'DBCLI-999'])
+  })
+
+  test('a delivery list written inline is refused rather than read as empty', () => {
+    const inline =
+      'workflow:\n  current_story: none\n  next_story: pending\n  completed_stories: [DBCLI-001]\n'
+    const found = violations(inline)
+    expect(found.map((violation) => violation.location)).toEqual(['workflow.completed_stories'])
+    expect(found[0]!.reason).toMatch(/inline/)
+  })
+
+  test('a block recording no completed Story is refused, not reconciled as empty', () => {
+    const empty = 'workflow:\n  current_story: none\n  next_story: pending\n  status: done\n'
+    expect(locations(empty)).toEqual(['workflow.completed_stories'])
   })
 })
 

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -228,6 +228,14 @@ describe('readLifecycle', () => {
     expect(found[0]!.reason).toMatch(/Workflow:/)
   })
 
+  test('a list item under a scalar key is reported rather than silently ignored', () => {
+    // Neither read nor reported is the one outcome the scan promises never to
+    // produce: a `- DBCLI-999` under `status:` was simply nothing.
+    const found = violations(`${BODY}    - DBCLI-999\n`)
+    expect(found.map((violation) => violation.location)).toEqual(['verification.result'])
+    expect(found[0]!.reason).toMatch(/does not write as a list/)
+  })
+
   test('a blank line inside the delivery list does not truncate it', () => {
     // Two readers of one list disagreed here: the list regex stopped at the
     // gap, the contract scan did not care, and a Story recorded below it was


### PR DESCRIPTION
ForgePilot 成為唯一的 operational lifecycle authority。`specs/handoff.md` 不再說「現在做哪個 Story、下一個是哪個」——那兩個問題由 `forgepilot next` 與 `forgepilot status` 回答。handoff 留下的是 ForgePilot 結構上拿不走的東西：敘事、決策、風險、repository baseline，以及由 `Story:` commit trailer 逐條對帳的 `completed_stories`。

## 為什麼

重複狀態不是假想的風險，動工前就已經壞了而且沒人看見。在 `141cf4c3` 拿上游 `handoff-check` 跑這份檔案，採用中的 v0.3.2 與當前的 v0.6.0 都 FAIL 共 16 條：`current_story: pending` 不是契約承認的「沒有 Story」拼法（那是 `none`），`pending` 同時出現在 current 與 next 被判自相矛盾，`verification.detail` 是契約沒有的 key，底下六行折疊散文是不受支援的縮排。`make verify` 一次都沒看見，因為上游 checker 住在 CI 沒有的 ForgeFlow checkout 裡。

**block 裡沒人讀的那半，就是已經漂掉的那半**——`next_story` 與 `status` 在整個 repository 沒有任何讀者。

`completed_stories` 是不同的東西穿著同一個 block：它由 git history 對帳，24 條裡有 21 條早於 ForgePilot 佇列，而 `.forgepilot/` 是 gitignored，ForgePilot 結構上拿不走它。所以它留下。

## 做了什麼

`workflow.current_story` 與 `next_story` 永久釘在契約自己的 sentinel（`none` / `pending`），並由 gate 拒絕任何具名 Story——單一來源是被強制的，不是被請求的。三個 section 都留著：宣稱採用了 ForgeFlow，就不能偷刪它要求的欄位。理由記在 ADR-0025（accepted），失效條件已寫明。

`Makefile` 一個字都沒動，沒有新增 verification step，`bun run forgeflow:check` 本來就在 `make verify` 裡。

## Review 找到的東西

Standards 與 Spec 兩條獨立 review 平行跑，一共擋下四個**可重現的假 PASS**，全部已修並各自有回歸測試：

1. `lifecycleBlock` 取的是第一個 ` ```yaml ` fence 而非唯一的。handoff 是五百行會引用自己那個 block 的散文，只要有人在 `## Lifecycle` 之前貼一段合格範例，gate 就去對帳那段引文，底下真正的 block 寫什麼都放行。現在超過一個 fence 直接拒絕。
2. 重複 key 是 last-wins：`current_story: DBCLI-016` 底下再補一行 `current_story: none` 就洗白，兩行對調卻會 FAIL——判決取決於行序。
3. `completed_stories` 中間空一行，list 的 regex 在缺口截斷，contract scan 又不管，缺口下面那個 Story 既沒對帳也沒被回報。
4. scalar key 底下的 list item 既不讀也不報。

共同成因是同一份文件有兩個讀者。修法不是各補各的：`collectLifecycleViolations` 與 `parseLifecycle` 合併成 `readLifecycle`，掃描器自己收 list item，一份文件一個讀者。

另外四條 MEDIUM 是拒絕理由指錯地方（引號與行尾註解的 sentinel 被誤判、空值印出空反引號、讀不懂的行掛在最後看到的 key 上、未知 section 底下整段吞掉），也都修了——理由講錯的拒絕比不拒絕更糟，它會把讀者送去改一個本來就對的東西。

acceptance.md 有三處說得比它自己指定的證據更滿，做了措辭訂正而非放寬，逐條記在 `f66b655d` 的 commit message 裡。

## Test plan

- `bun test tests/unit/scripts/forgeflow-handoff.test.ts` — 43 pass，含四個假 PASS 與四條 MEDIUM 的回歸案例
- `bun run forgeflow:check` — exit 0，`24 completed Stories (23 by commit trailer, 1 by recorded delivering commit)`
- 上游 `handoff-check` v0.6.0 **全 PASS**；v0.3.2 只剩八條 `DBCLI-PLAT-*` Story ID 文法失敗，是 0.3.2 的文法早於該命名，acceptance 事先寫明屬於 DBCLI-018
- gate 在 `.forgepilot/` 不存在、`PATH` 只有 bun 與系統目錄、forgepilot 未安裝下 exit 0
- `tests/contract/forgepilot-boundary.test.ts` 5 pass，`REQUIRED_STEPS` 未動；`git diff main...HEAD -- Makefile` 為空
- `git check-ignore .forgepilot/state.json` exit 0
- typecheck / typecheck:tests / lint / format:check / docs:check / contract:check / plugin:check / manifest:check 全過
- `make verify`：ForgePilot 正在 `980cc078` 的 detached worktree 上執行，結果會補在 PR 留言

Merge 前請等 `make verify` 的 PASS 綁定到最終 commit，以及 Human Review。

Story: DBCLI-016

https://claude.ai/code/session_016ergjTN99kDPMngzfquBBw
