### PR TITLE
DBCLI-017: make verify 寫出綁定 revision 的 Verification Attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,18 @@ jobs:
       # by `make verify` itself on both outcomes and names the exact revision,
       # so downloading it answers "was this commit verified" without trusting
       # the job summary or anyone's recollection. DBCLI-017.
+      #
+      # The artifact carries no SHA in its name on purpose. `github.sha` and the
+      # `git rev-parse HEAD` the attestation records agree only because the
+      # default `pull_request` checkout resolves both to the merge commit — an
+      # agreement by configuration, not by construction. A name that states a
+      # revision the file could contradict is worse than a name that states
+      # none: the document inside is the only thing that knows which commit ran.
       - name: Verification attestation
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: verification-attestation-${{ github.sha }}
+          name: verification-attestation
           path: .verification/attestation.json
           if-no-files-found: warn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,19 @@ jobs:
       - name: Canonical verification
         run: make verify
 
+      # `if: always()` because a FAIL is the result worth keeping: the run that
+      # passed is the one nobody needs a record of. The attestation is written
+      # by `make verify` itself on both outcomes and names the exact revision,
+      # so downloading it answers "was this commit verified" without trusting
+      # the job summary or anyone's recollection. DBCLI-017.
+      - name: Verification attestation
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-attestation-${{ github.sha }}
+          path: .verification/attestation.json
+          if-no-files-found: warn
+
       - name: Service logs (on failure)
         if: failure()
         run: docker compose -f docker-compose.test.yml logs --tail 100

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ graft/
 
 # ForgePilot local work-queue state — operational, not source (`forgepilot init`).
 .forgepilot/
+
+# Verification Attestation (DBCLI-017). Written by every `make verify` run,
+# never committed: a record inside the worktree would dirty the tree the next
+# verification refuses to run against, and each run would invalidate the last.
+.verification/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,15 @@ A bounded, machine-readable record of one explicit dbcli operation. It proves
 what dbcli observed or verified under a particular governed context; it never
 contains database rows, unredacted SQL, credentials, or an agent's conclusion.
 
+**Verification attestation**:
+A bounded, machine-readable record of one `make verify` run against one
+repository revision, written by that run and never committed. Its subject is a
+commit, not a database, and its reader is a reviewer, a CI job, or ForgePilot —
+so it is not an evidence receipt and not a verification artifact, and it lives
+in `scripts/` rather than being shipped. It states a revision; whether that
+revision is still HEAD is the reader's question, never the document's.
+_Avoid_: verification receipt, evidence receipt, build attestation
+
 **Evidence pack**:
 A reviewable collection that connects one or more human- or agent-authored
 claims to evidence receipts, verification artifacts, and audit references. A

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@
 # It passed locally only because macOS `/bin/sh` is bash. Nothing here pipes
 # anything, so `pipefail` was a fatal no-op.
 #
+# One thing was lost and is not being quietly accepted: each step used to be its
+# own recipe line, so make echoed it and a CI log showed which of the 24 checks
+# was running and which one failed. Joined and prefixed with `@`, it does not.
+# Debugging now leans on the failing tool's own output, which is fine for
+# `bun run test` and thin for `docs:check`. Restoring it properly means echoing
+# each step with its own timing, which is DBCLI-019's subject; it is recorded
+# here so that Story inherits a known cost rather than rediscovering it.
+#
 # Neither attestation phase can decide the verdict, which is the point of the
 # `|| run=''` and the `|| true`: `begin` failing leaves `run` empty so `finish`
 # refuses and says so, and neither failure is allowed to stand between a

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@
 # captures the status, the attestation is written either way, and the recipe
 # re-exits with the captured status.
 #
+# The recipe stays POSIX. GNU Make ignores the environment's `SHELL` and runs
+# `/bin/sh`, which is dash on the Ubuntu runner this gate's `integration` job
+# uses — and dash has no `pipefail`. An earlier version set it, which aborted
+# the recipe line before the subshell was entered: zero of the 24 steps ran, no
+# attestation was written, and the failure looked like a verification failure.
+# It passed locally only because macOS `/bin/sh` is bash. Nothing here pipes
+# anything, so `pipefail` was a fatal no-op.
+#
 # Neither attestation phase can decide the verdict, which is the point of the
 # `|| run=''` and the `|| true`: `begin` failing leaves `run` empty so `finish`
 # refuses and says so, and neither failure is allowed to stand between a
@@ -20,8 +28,7 @@
 # cannot leave state for the next run to pick up and describe as its own.
 # DBCLI-017, and `scripts/write-attestation.ts` for what the record says.
 verify:
-	@set -o pipefail; \
-	run=$$(bun run scripts/write-attestation.ts begin) || run=''; \
+	@run=$$(bun run scripts/write-attestation.ts begin) || run=''; \
 	( \
 		bun install --frozen-lockfile && \
 		bun run services:check && \

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,19 @@
 # at the first failing step, so an attestation written as a final line would only
 # ever describe a passing run — the case nobody needs evidence for. The subshell
 # captures the status, the attestation is written either way, and the recipe
-# re-exits with the captured status: writing a record never changes a verdict.
+# re-exits with the captured status.
+#
+# Neither attestation phase can decide the verdict, which is the point of the
+# `|| run=''` and the `|| true`: `begin` failing leaves `run` empty so `finish`
+# refuses and says so, and neither failure is allowed to stand between a
+# developer and their verification result. The two phases hand the revision
+# along this one shell rather than through a file, so a run killed halfway
+# cannot leave state for the next run to pick up and describe as its own.
 # DBCLI-017, and `scripts/write-attestation.ts` for what the record says.
 verify:
-	@bun run scripts/write-attestation.ts begin
-	@set -o pipefail; ( \
+	@set -o pipefail; \
+	run=$$(bun run scripts/write-attestation.ts begin) || run=''; \
+	( \
 		bun install --frozen-lockfile && \
 		bun run services:check && \
 		bun run audit && \
@@ -40,5 +48,5 @@ verify:
 		bun run plan:check && \
 		bun run forgeflow:check \
 	); status=$$?; \
-	bun run scripts/write-attestation.ts finish $$status; \
+	bun run scripts/write-attestation.ts finish $$status $$run || true; \
 	exit $$status

--- a/Makefile
+++ b/Makefile
@@ -5,28 +5,40 @@
 # put there: a fresh checkout got `prettier: command not found` and a `tsc`
 # resolved from PATH. `--frozen-lockfile` fails rather than resolving a set that
 # `bun.lock` does not pin.
+#
+# The steps run inside one subshell so that a FAIL is recorded too. `make` stops
+# at the first failing step, so an attestation written as a final line would only
+# ever describe a passing run — the case nobody needs evidence for. The subshell
+# captures the status, the attestation is written either way, and the recipe
+# re-exits with the captured status: writing a record never changes a verdict.
+# DBCLI-017, and `scripts/write-attestation.ts` for what the record says.
 verify:
-	bun install --frozen-lockfile
-	bun run services:check
-	bun run audit
-	bun run format:check
-	bun run agent-core:check
-	bun run core-stdout:check
-	bun run typecheck
-	bun run typecheck:tests
-	bun run lint
-	SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test
-	bun run build
-	bun run build:determinism
-	bun run dev -- --help
-	bun run dev -- --version
-	./dist/cli.mjs --help
-	./dist/cli.mjs --version
-	bun run test:perf
-	bun run platform:check
-	bun run plugin:check
-	bun run manifest:check
-	bun run docs:check
-	bun run contract:check
-	bun run plan:check
-	bun run forgeflow:check
+	@bun run scripts/write-attestation.ts begin
+	@set -o pipefail; ( \
+		bun install --frozen-lockfile && \
+		bun run services:check && \
+		bun run audit && \
+		bun run format:check && \
+		bun run agent-core:check && \
+		bun run core-stdout:check && \
+		bun run typecheck && \
+		bun run typecheck:tests && \
+		bun run lint && \
+		SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test && \
+		bun run build && \
+		bun run build:determinism && \
+		bun run dev -- --help && \
+		bun run dev -- --version && \
+		./dist/cli.mjs --help && \
+		./dist/cli.mjs --version && \
+		bun run test:perf && \
+		bun run platform:check && \
+		bun run plugin:check && \
+		bun run manifest:check && \
+		bun run docs:check && \
+		bun run contract:check && \
+		bun run plan:check && \
+		bun run forgeflow:check \
+	); status=$$?; \
+	bun run scripts/write-attestation.ts finish $$status; \
+	exit $$status

--- a/docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
+++ b/docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
@@ -55,13 +55,20 @@ decision, not a permanent refusal: it reopens if a consumer appears that needs
 the link and cannot compute it from the revision, and the shape it would take is
 a caller-supplied `context` object marked explicitly as unattested.
 
+It carries no repository name, for the same reason one level quieter. That field
+was a hardcoded constant — validated against a pattern, never observed — so it
+recorded what the author typed rather than where the run happened. Deriving it
+from `git remote get-url origin` would have been worse than leaving it: a remote
+URL can carry credentials, and keeping secrets out of the document is a rule this
+Story states outright. A commit SHA identifies its subject without help.
+
 It carries no staleness. The document states a revision; whether that revision
 is still HEAD is a question with a different answer every time it is asked, and
 an artifact that answers it is wrong immediately after being written.
 
-**Falsified if:** a second producer starts writing this document — anything
-other than `scripts/`'s writer invoked by `make verify` — or the attestation
-gains a field that `make verify` cannot verify for itself. Either means the
-artifact has stopped being a statement the repository can make about its own
-run, and the reason for keeping it out of `src/core/evidence-receipt` no longer
-holds.
+**Falsified if:** the attestation gains a field the producer did not observe —
+handed at call time, or fixed at authoring time as `repository` was — or a
+second producer starts writing the document, anything other than `scripts/`'s
+writer invoked by `make verify`. Either means the artifact has stopped being a
+statement the repository can make about its own run, and the reason for keeping
+it out of `src/core/evidence-receipt` no longer holds.

--- a/docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
+++ b/docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
@@ -1,0 +1,67 @@
+---
+status: proposed
+date: 2026-09-08
+---
+
+# A Verification Attestation is not an Evidence Receipt
+
+DBCLI-017 introduces a third evidence-shaped artifact, and the reason it is not
+one of the two that already exist is worth writing down before someone
+helpfully consolidates them.
+
+An **Evidence Receipt** (`src/core/evidence-receipt/`, defined in `CONTEXT.md`)
+records one dbcli operation against a database. A **Verification Artifact**
+(`src/core/verification/`) records an `assert`, `snapshot` or
+`recovery-verify` run against data. Both are product: shipped to users,
+versioned by constants the package publishes, consumed by agents operating
+databases.
+
+A **Verification Attestation** records one run of this repository's `make
+verify` against one revision. Its subject is a commit, not a database. Its
+consumer is a reviewer, a CI job, or ForgePilot — never a dbcli user. Its
+lifecycle is this repository's engineering process. Folding it into either
+existing format would move a published schema version for reasons no user can
+observe, and would ship process tooling to people who install dbcli to talk to
+their database. So it lives under `scripts/`, is absent from the package, and
+carries its own `schema_version`.
+
+The name matters as much as the boundary. `CONTEXT.md` already defines
+"evidence receipt" and "evidence pack"; calling this one an Evidence Receipt
+would give one term two subjects, which is the failure the domain vocabulary
+exists to prevent. "Attestation" appears nowhere in dbcli or ForgePilot.
+
+## The repository writes it, not ForgePilot
+
+The obvious design is `forgepilot evidence export`. It does not exist:
+ForgePilot's commands at `8ce2c12` are `init`, `migrate`, `goal`, `work`,
+`next`, `start`, `verify`, `gate`, `review` and `status`, and its development
+plan contains no export. Waiting would put this repository's delivery on another
+repository's schedule; reading `.forgepilot/state.json` would couple dbcli to
+ForgePilot's internal format, which DBCLI-014 forbade.
+
+So `make verify` writes it — the only participant that observes the result
+first-hand — and ForgePilot, CI, or a human reads the file afterwards. The
+integration is a file at a known path with a versioned schema. Nothing imports
+anything, and dbcli keeps working with no ForgePilot installed.
+
+## What the attestation deliberately does not say
+
+It carries no Work Item ID and no Story reference, though both were asked for
+and the omission was put to the human who asked, and accepted on 2026-09-08.
+`make verify` does not know them, and a field a producer cannot verify is a
+field that records whatever the caller claimed. ForgePilot already binds
+evidence to work by revision; it can bind this the same way. This is a deferred
+decision, not a permanent refusal: it reopens if a consumer appears that needs
+the link and cannot compute it from the revision, and the shape it would take is
+a caller-supplied `context` object marked explicitly as unattested.
+
+It carries no staleness. The document states a revision; whether that revision
+is still HEAD is a question with a different answer every time it is asked, and
+an artifact that answers it is wrong immediately after being written.
+
+**Falsified if:** a second producer starts writing this document — anything
+other than `scripts/`'s writer invoked by `make verify` — or the attestation
+gains a field that `make verify` cannot verify for itself. Either means the
+artifact has stopped being a statement the repository can make about its own
+run, and the reason for keeping it out of `src/core/evidence-receipt` no longer
+holds.

--- a/scripts/lib/verification-attestation.ts
+++ b/scripts/lib/verification-attestation.ts
@@ -163,6 +163,33 @@ function checkEnvironment(environment: AttestationEnvironment): AttestationEnvir
 }
 
 /**
+ * Read the bounded environment description from a process's own facts.
+ *
+ * The whole of what this does with `env` is ask whether `CI` is set. That is
+ * the point of it being a function over an argument rather than a read of
+ * `process.env` somewhere in the writer: "no environment variable's value
+ * reaches the document" stops being a promise a reviewer has to trust and
+ * becomes something a test can hand a hostile environment to and check.
+ *
+ * The value of `CI` is never copied. Presence is what a reader needs, and a
+ * copied value is one field's worth of harmless CI output today and an
+ * arbitrary caller-supplied string tomorrow.
+ */
+export function readEnvironment(source: {
+  readonly env: Readonly<Record<string, string | undefined>>
+  readonly platform: string
+  readonly arch: string
+  readonly bun: string
+}): AttestationEnvironment {
+  return {
+    os: source.platform,
+    arch: source.arch,
+    bun: source.bun,
+    ci: source.env.CI !== undefined,
+  }
+}
+
+/**
  * Build an attestation, refusing anything the repository cannot state.
  *
  * Validation is not defence against a hostile caller — the only caller is this

--- a/scripts/lib/verification-attestation.ts
+++ b/scripts/lib/verification-attestation.ts
@@ -274,6 +274,18 @@ export function parseAttestation(text: string): Attestation {
     refuse('environment', 'is not a JSON object')
   }
 
+  // Types before values. `buildAttestation` narrows the strings by regex and
+  // the number by range, but it reads `dirty_worktree` as `x === true` — so a
+  // document saying `"yes"` used to rebuild as `false`, match its own hash, and
+  // be handed back with the flag flipped. Every other reader of that file sees
+  // a dirty worktree; this one saw a clean one, and said nothing.
+  if (typeof record.dirty_worktree !== 'boolean') {
+    refuse('dirty_worktree', `must be a boolean, got ${JSON.stringify(record.dirty_worktree)}`)
+  }
+  if (typeof record.exit_code !== 'number') {
+    refuse('exit_code', `must be a number, got ${JSON.stringify(record.exit_code)}`)
+  }
+
   const attestation = buildAttestation({
     repository: record.repository as string,
     revision: record.revision as string,
@@ -286,8 +298,14 @@ export function parseAttestation(text: string): Attestation {
   })
 
   // Rebuilding and comparing is the whole check: every derived field — the
-  // result, the duration, the hash — has to follow from the stated ones, so a
-  // document whose hash matches but whose `result` was edited is still refused.
+  // result, the duration, the hash — has to follow from the stated ones.
+  //
+  // The two comparisons are not redundant. The hash catches an edit to a stated
+  // field, because the rebuild then produces a different digest. The result and
+  // duration comparison catches the opposite forgery: a derived field edited
+  // while the legitimate hash is left in place, where the rebuilt digest still
+  // matches. Without it the reader would silently hand back the corrected
+  // values for a file that says something else.
   if (record.attestation_hash !== attestation.attestation_hash) {
     refuse(
       'attestation_hash',

--- a/scripts/lib/verification-attestation.ts
+++ b/scripts/lib/verification-attestation.ts
@@ -18,6 +18,14 @@
  * already and can bind this the same way. ADR-0026 carries the reopening
  * condition.
  *
+ * There is no repository name either, for the same reason one level quieter.
+ * It was a hardcoded constant: validated, never observed, and therefore a
+ * record of what the author typed rather than of where the run happened — the
+ * exact thing this schema excludes `work_item` for. Deriving it from `git
+ * remote get-url origin` would have been worse: a remote URL can carry
+ * credentials, and R4 forbids exactly that. A commit SHA identifies its subject
+ * without help, so the field is gone rather than fixed.
+ *
  * There is no staleness either. The document states a revision; whether that
  * revision is still HEAD has a different answer every time it is asked, and an
  * artifact that answers it is wrong immediately after being written.
@@ -55,7 +63,6 @@ export interface AttestationEnvironment {
 
 export interface Attestation {
   readonly schema_version: number
-  readonly repository: string
   readonly revision: string
   readonly dirty_worktree: boolean
   readonly command: string
@@ -76,7 +83,6 @@ export interface Attestation {
 }
 
 export interface AttestationInput {
-  readonly repository: string
   readonly revision: string
   readonly dirtyWorktree: boolean
   readonly command: string
@@ -89,7 +95,6 @@ export interface AttestationInput {
 /** Key order is part of the format: two serialisations of one run must match. */
 const FIELDS = [
   'schema_version',
-  'repository',
   'revision',
   'dirty_worktree',
   'command',
@@ -105,10 +110,12 @@ const FIELDS = [
 const ENVIRONMENT_FIELDS = ['os', 'arch', 'bun', 'ci'] as const
 
 const REVISION = /^[0-9a-f]{40}$/
-const REPOSITORY = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}\/[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$/
 const INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 const SAFE_TEXT = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,63}$/
 const COMMAND = /^[a-z][a-z0-9 :-]{0,63}$/
+
+/** One day. Long enough for any real gate, short enough to catch a bad clock. */
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000
 
 function refuse(field: string, reason: string): never {
   throw new Error(`${field} ${reason}`)
@@ -199,7 +206,6 @@ export function readEnvironment(source: {
  * no document, because it will be believed.
  */
 export function buildAttestation(input: AttestationInput): Attestation {
-  const repository = requireMatch(input.repository, REPOSITORY, 'repository')
   const revision = requireMatch(input.revision, REVISION, 'revision')
   const command = requireMatch(input.command, COMMAND, 'command')
   const startedAt = requireMatch(input.startedAt, INSTANT, 'started_at')
@@ -212,9 +218,17 @@ export function buildAttestation(input: AttestationInput): Attestation {
   const duration = Date.parse(finishedAt) - Date.parse(startedAt)
   if (duration < 0) refuse('finished_at', `is before started_at, so the run has no duration`)
 
+  // A verification that took longer than a day did not take longer than a day.
+  // The realistic causes are a clock that jumped and arguments that shifted, and
+  // both produce a document that is internally consistent and plainly absurd,
+  // with nothing else in this file willing to say so. Refusing costs a record,
+  // never a verdict.
+  if (duration > MAX_DURATION_MS) {
+    refuse('finished_at', `is ${duration}ms after started_at, longer than a verification can run`)
+  }
+
   const body = {
     schema_version: ATTESTATION_SCHEMA_VERSION,
-    repository,
     revision,
     dirty_worktree: input.dirtyWorktree === true,
     command,
@@ -287,7 +301,6 @@ export function parseAttestation(text: string): Attestation {
   }
 
   const attestation = buildAttestation({
-    repository: record.repository as string,
     revision: record.revision as string,
     dirtyWorktree: record.dirty_worktree as boolean,
     command: record.command as string,

--- a/scripts/lib/verification-attestation.ts
+++ b/scripts/lib/verification-attestation.ts
@@ -1,0 +1,275 @@
+/**
+ * The Verification Attestation: what one `make verify` run decided, in a file.
+ *
+ * Verification evidence used to exist in exactly one place — ForgePilot's
+ * `.forgepilot/state.json`, on the machine that ran it, gitignored because a
+ * committed result would dirty the worktree the next verification refuses to
+ * run against, and because recording a result takes a commit that immediately
+ * invalidates the result being recorded. The evidence was real and unreachable.
+ * This document is the reachable half: one revision, one command, one outcome,
+ * written by the run itself and read by anyone.
+ *
+ * ## What it will not say
+ *
+ * The schema is closed, and deliberately smaller than the obvious design. There
+ * is no Work Item ID and no Story reference: `make verify` does not know either,
+ * so both would arrive from the caller, and a producer that cannot check a field
+ * records whatever it was handed. ForgePilot binds evidence to work by revision
+ * already and can bind this the same way. ADR-0026 carries the reopening
+ * condition.
+ *
+ * There is no staleness either. The document states a revision; whether that
+ * revision is still HEAD has a different answer every time it is asked, and an
+ * artifact that answers it is wrong immediately after being written.
+ *
+ * ## What it is not
+ *
+ * Not an Evidence Receipt (`src/core/evidence-receipt/`) and not a Verification
+ * Artifact (`src/core/verification/`). Those are product: they record dbcli
+ * operations against a database, ship to users, and carry published schema
+ * versions. This records a commit, is read by a reviewer or a CI job, and lives
+ * in `scripts/` where nothing publishes it. Folding it into either would move a
+ * shipped version for reasons no user can observe.
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * The artifact format version, which is not the package version.
+ *
+ * It moves when a field, its requiredness, or the meaning of a value changes.
+ * DBCLI-019's per-step detail is the next thing expected to move it.
+ */
+export const ATTESTATION_SCHEMA_VERSION = 1
+
+export type AttestationResult = 'PASS' | 'FAIL'
+
+/** The bounded description of where a run happened. Never an environment dump. */
+export interface AttestationEnvironment {
+  readonly os: string
+  readonly arch: string
+  readonly bun: string
+  /** Whether `CI` was set. The variable's value is never copied. */
+  readonly ci: boolean
+}
+
+export interface Attestation {
+  readonly schema_version: number
+  readonly repository: string
+  readonly revision: string
+  readonly dirty_worktree: boolean
+  readonly command: string
+  readonly result: AttestationResult
+  /**
+   * The verification run's own status, which is not `make`'s.
+   *
+   * `make` reports its own error code when a recipe fails; the number here is
+   * the one the failing step produced, because that is what a reader debugging
+   * the failure needs.
+   */
+  readonly exit_code: number
+  readonly started_at: string
+  readonly finished_at: string
+  readonly duration_ms: number
+  readonly environment: AttestationEnvironment
+  readonly attestation_hash: string
+}
+
+export interface AttestationInput {
+  readonly repository: string
+  readonly revision: string
+  readonly dirtyWorktree: boolean
+  readonly command: string
+  readonly exitCode: number
+  readonly startedAt: string
+  readonly finishedAt: string
+  readonly environment: AttestationEnvironment
+}
+
+/** Key order is part of the format: two serialisations of one run must match. */
+const FIELDS = [
+  'schema_version',
+  'repository',
+  'revision',
+  'dirty_worktree',
+  'command',
+  'result',
+  'exit_code',
+  'started_at',
+  'finished_at',
+  'duration_ms',
+  'environment',
+  'attestation_hash',
+] as const
+
+const ENVIRONMENT_FIELDS = ['os', 'arch', 'bun', 'ci'] as const
+
+const REVISION = /^[0-9a-f]{40}$/
+const REPOSITORY = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}\/[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$/
+const INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+const SAFE_TEXT = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,63}$/
+const COMMAND = /^[a-z][a-z0-9 :-]{0,63}$/
+
+function refuse(field: string, reason: string): never {
+  throw new Error(`${field} ${reason}`)
+}
+
+function requireMatch(value: unknown, pattern: RegExp, field: string): string {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    refuse(field, `must match ${pattern.source}, got ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+/**
+ * Serialise an attestation to its canonical bytes.
+ *
+ * Fixed key order, two-space indentation, LF endings, one trailing newline.
+ * `JSON.stringify` already emits LF and no locale-dependent numbers; the order
+ * is the part that has to be stated, because object key order is a property of
+ * how a value was built rather than of what it means.
+ */
+export function serialiseAttestation(attestation: Attestation): string {
+  const ordered: Record<string, unknown> = {}
+  for (const field of FIELDS) ordered[field] = attestation[field]
+  return `${JSON.stringify(ordered, null, 2)}\n`
+}
+
+/** The canonical bytes an attestation's hash is taken over: itself, less the hash. */
+function hashableBytes(attestation: Omit<Attestation, 'attestation_hash'>): string {
+  const ordered: Record<string, unknown> = {}
+  for (const field of FIELDS) {
+    if (field === 'attestation_hash') continue
+    ordered[field] = attestation[field]
+  }
+  return `${JSON.stringify(ordered, null, 2)}\n`
+}
+
+function checkEnvironment(environment: AttestationEnvironment): AttestationEnvironment {
+  const keys = Object.keys(environment)
+  if (keys.length !== ENVIRONMENT_FIELDS.length) {
+    refuse(
+      'environment',
+      `carries ${JSON.stringify(keys)}, not ${JSON.stringify([...ENVIRONMENT_FIELDS])}`
+    )
+  }
+
+  for (const field of ['os', 'arch', 'bun'] as const) {
+    requireMatch(environment[field], SAFE_TEXT, `environment.${field}`)
+  }
+  if (typeof environment.ci !== 'boolean') refuse('environment.ci', 'must be a boolean')
+
+  return { os: environment.os, arch: environment.arch, bun: environment.bun, ci: environment.ci }
+}
+
+/**
+ * Build an attestation, refusing anything the repository cannot state.
+ *
+ * Validation is not defence against a hostile caller — the only caller is this
+ * repository's own verification. It is defence against a plausible one: a
+ * shortened revision, a clock that ran backwards, a version string carrying
+ * something that is not a version. A document that records those is worse than
+ * no document, because it will be believed.
+ */
+export function buildAttestation(input: AttestationInput): Attestation {
+  const repository = requireMatch(input.repository, REPOSITORY, 'repository')
+  const revision = requireMatch(input.revision, REVISION, 'revision')
+  const command = requireMatch(input.command, COMMAND, 'command')
+  const startedAt = requireMatch(input.startedAt, INSTANT, 'started_at')
+  const finishedAt = requireMatch(input.finishedAt, INSTANT, 'finished_at')
+
+  if (!Number.isInteger(input.exitCode) || input.exitCode < 0 || input.exitCode > 255) {
+    refuse('exit_code', `must be an integer in 0..255, got ${JSON.stringify(input.exitCode)}`)
+  }
+
+  const duration = Date.parse(finishedAt) - Date.parse(startedAt)
+  if (duration < 0) refuse('finished_at', `is before started_at, so the run has no duration`)
+
+  const body = {
+    schema_version: ATTESTATION_SCHEMA_VERSION,
+    repository,
+    revision,
+    dirty_worktree: input.dirtyWorktree === true,
+    command,
+    result: (input.exitCode === 0 ? 'PASS' : 'FAIL') as AttestationResult,
+    exit_code: input.exitCode,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: duration,
+    environment: checkEnvironment(input.environment),
+  }
+
+  const digest = createHash('sha256').update(hashableBytes(body), 'utf8').digest('hex')
+
+  return { ...body, attestation_hash: `sha256:${digest}` }
+}
+
+/**
+ * Read an attestation, refusing anything this reader does not fully understand.
+ *
+ * An unknown `schema_version` is refused rather than read for the fields that
+ * happen to be recognised: a later version may change what a field means, and a
+ * reader that guesses produces a confident wrong answer about whether a commit
+ * was verified.
+ */
+export function parseAttestation(text: string): Attestation {
+  let document: unknown
+  try {
+    document = JSON.parse(text)
+  } catch (cause) {
+    refuse('attestation', `is not JSON: ${(cause as Error).message}`)
+  }
+
+  if (typeof document !== 'object' || document === null || Array.isArray(document)) {
+    refuse('attestation', 'is not a JSON object')
+  }
+
+  const record = document as Record<string, unknown>
+
+  if (record.schema_version !== ATTESTATION_SCHEMA_VERSION) {
+    refuse(
+      'schema_version',
+      `is ${JSON.stringify(record.schema_version)}; this reader knows ${ATTESTATION_SCHEMA_VERSION} only`
+    )
+  }
+
+  for (const field of FIELDS) {
+    if (!(field in record)) refuse(field, 'is missing')
+  }
+  for (const field of Object.keys(record)) {
+    if (!(FIELDS as readonly string[]).includes(field)) {
+      refuse(field, 'is not a field this attestation format defines')
+    }
+  }
+
+  const environment = record.environment
+  if (typeof environment !== 'object' || environment === null || Array.isArray(environment)) {
+    refuse('environment', 'is not a JSON object')
+  }
+
+  const attestation = buildAttestation({
+    repository: record.repository as string,
+    revision: record.revision as string,
+    dirtyWorktree: record.dirty_worktree as boolean,
+    command: record.command as string,
+    exitCode: record.exit_code as number,
+    startedAt: record.started_at as string,
+    finishedAt: record.finished_at as string,
+    environment: environment as AttestationEnvironment,
+  })
+
+  // Rebuilding and comparing is the whole check: every derived field — the
+  // result, the duration, the hash — has to follow from the stated ones, so a
+  // document whose hash matches but whose `result` was edited is still refused.
+  if (record.attestation_hash !== attestation.attestation_hash) {
+    refuse(
+      'attestation_hash',
+      `does not match the content: expected ${attestation.attestation_hash}`
+    )
+  }
+  if (record.result !== attestation.result || record.duration_ms !== attestation.duration_ms) {
+    refuse('attestation', 'states a result or duration that its own fields do not produce')
+  }
+
+  return attestation
+}

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -16,7 +16,7 @@
  * PASS.
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { $ } from 'bun'
@@ -30,16 +30,7 @@ const REPOSITORY = 'CarlLee1983/dbcli'
 
 const repoRoot = fileURLToPath(new URL('../', import.meta.url))
 const outputDirectory = join(repoRoot, '.verification')
-const runPath = join(outputDirectory, 'run.json')
 const attestationPath = join(outputDirectory, 'attestation.json')
-
-/** What `begin` recorded, for `finish` to complete. */
-interface Run {
-  readonly repository: string
-  readonly revision: string
-  readonly dirtyWorktree: boolean
-  readonly startedAt: string
-}
 
 const instant = () => new Date().toISOString().replace(/\.(\d{3})\d*Z$/, '.$1Z')
 
@@ -53,13 +44,20 @@ const environment = (): AttestationEnvironment => ({
 })
 
 /**
- * Resolve the commit under verification.
+ * Print what the run started as, for `finish` to be handed back.
+ *
+ * Through the recipe's own shell rather than a file on purpose. A `run.json`
+ * left behind by a killed run would be picked up by the next `finish` and
+ * produce one document describing two runs — a revision from one and a result
+ * from another, with nothing in the file admitting it. Passing the values along
+ * the one shell that owns both phases makes that impossible rather than
+ * unlikely.
  *
  * A repository that cannot answer is refused rather than recorded as unknown:
  * an attestation whose revision is a guess attests nothing, and it would be
  * believed anyway.
  */
-async function resolveRun(): Promise<Run> {
+async function begin(): Promise<void> {
   const resolved = await $`git rev-parse HEAD`.cwd(repoRoot).nothrow().quiet()
   if (resolved.exitCode !== 0) {
     throw new Error(
@@ -71,31 +69,38 @@ async function resolveRun(): Promise<Run> {
   const status = await $`git status --porcelain`.cwd(repoRoot).nothrow().quiet()
   if (status.exitCode !== 0) throw new Error('git status --porcelain failed')
 
-  return {
-    repository: REPOSITORY,
-    revision: resolved.text().trim(),
-    dirtyWorktree: status.text().trim().length > 0,
-    startedAt: instant(),
+  const worktree = status.text().trim().length > 0 ? 'dirty' : 'clean'
+  console.log(`${resolved.text().trim()} ${worktree} ${instant()}`)
+}
+
+async function finish(
+  exitCode: number,
+  revision: string | undefined,
+  worktree: string | undefined,
+  startedAt: string | undefined
+): Promise<void> {
+  if (revision === undefined || worktree === undefined || startedAt === undefined) {
+    throw new Error(
+      'finish was not given what begin resolved, so this run has no revision to attest — ' +
+        'the verification result stands and no attestation is written'
+    )
   }
-}
-
-async function begin(): Promise<void> {
-  const run = await resolveRun()
-  await mkdir(outputDirectory, { recursive: true })
-  await writeFile(runPath, `${JSON.stringify(run, null, 2)}\n`, 'utf8')
-}
-
-async function finish(exitCode: number): Promise<void> {
-  const run = JSON.parse(await readFile(runPath, 'utf8')) as Run
+  if (worktree !== 'clean' && worktree !== 'dirty') {
+    throw new Error(`worktree state must be clean or dirty, got ${JSON.stringify(worktree)}`)
+  }
 
   const attestation = buildAttestation({
-    ...run,
+    repository: REPOSITORY,
+    revision,
+    dirtyWorktree: worktree === 'dirty',
     command: 'make verify',
     exitCode,
+    startedAt,
     finishedAt: instant(),
     environment: environment(),
   })
 
+  await mkdir(outputDirectory, { recursive: true })
   await writeFile(attestationPath, serialiseAttestation(attestation), 'utf8')
   console.log(
     `verification attestation: ${attestation.result} at ${attestation.revision} ` +
@@ -103,24 +108,27 @@ async function finish(exitCode: number): Promise<void> {
   )
 }
 
-const [phase, status] = process.argv.slice(2)
+const [phase, ...rest] = process.argv.slice(2)
 
 try {
   if (phase === 'begin') {
     await begin()
   } else if (phase === 'finish') {
+    const [status, revision, worktree, startedAt] = rest
     const exitCode = Number.parseInt(status ?? '', 10)
     if (!Number.isInteger(exitCode)) {
       throw new Error(`finish needs the run's exit status, got ${JSON.stringify(status)}`)
     }
-    await finish(exitCode)
+    await finish(exitCode, revision, worktree, startedAt)
   } else {
-    throw new Error(`unknown phase ${JSON.stringify(phase)}; expected 'begin' or 'finish <status>'`)
+    throw new Error(
+      `unknown phase ${JSON.stringify(phase)}; expected 'begin' or 'finish <status> <revision> <clean|dirty> <started-at>'`
+    )
   }
 } catch (cause) {
-  // The verification's own result is authoritative. This failure is reported and
-  // the Makefile re-exits with the status it captured, so a broken attestation
-  // costs a record, never a verdict.
+  // The verification's own result is authoritative, in both directions. This
+  // failure is reported and nothing else: the recipe neither stops for it nor
+  // re-exits with it, so a broken attestation costs a record, never a verdict.
   console.error(`Failed to write verification attestation: ${(cause as Error).message}`)
   process.exitCode = 1
 }

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -16,14 +16,14 @@
  * PASS.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { $ } from 'bun'
 import {
   buildAttestation,
+  readEnvironment,
   serialiseAttestation,
-  type AttestationEnvironment,
 } from './lib/verification-attestation'
 
 const REPOSITORY = 'CarlLee1983/dbcli'
@@ -34,14 +34,13 @@ const attestationPath = join(outputDirectory, 'attestation.json')
 
 const instant = () => new Date().toISOString().replace(/\.(\d{3})\d*Z$/, '.$1Z')
 
-const environment = (): AttestationEnvironment => ({
-  os: process.platform,
-  arch: process.arch,
-  bun: Bun.version,
-  // Presence only. Copying the value would be harmless CI output today and an
-  // arbitrary caller-supplied string tomorrow.
-  ci: process.env.CI !== undefined,
-})
+const environment = () =>
+  readEnvironment({
+    env: process.env,
+    platform: process.platform,
+    arch: process.arch,
+    bun: Bun.version,
+  })
 
 /**
  * Print what the run started as, for `finish` to be handed back.
@@ -68,6 +67,12 @@ async function begin(): Promise<void> {
 
   const status = await $`git status --porcelain`.cwd(repoRoot).nothrow().quiet()
   if (status.exitCode !== 0) throw new Error('git status --porcelain failed')
+
+  // Any attestation still lying here belongs to an earlier run. Left in place,
+  // a run killed before `finish` — a CI timeout, a cancelled job — would let
+  // `if: always()` publish the previous run's verdict as this one's. No file is
+  // the honest answer to "was this revision verified"; a stale file is not.
+  await rm(attestationPath, { force: true })
 
   const worktree = status.text().trim().length > 0 ? 'dirty' : 'clean'
   console.log(`${resolved.text().trim()} ${worktree} ${instant()}`)

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -26,13 +26,13 @@ import {
   serialiseAttestation,
 } from './lib/verification-attestation'
 
-const REPOSITORY = 'CarlLee1983/dbcli'
-
 const repoRoot = fileURLToPath(new URL('../', import.meta.url))
 const outputDirectory = join(repoRoot, '.verification')
 const attestationPath = join(outputDirectory, 'attestation.json')
 
-const instant = () => new Date().toISOString().replace(/\.(\d{3})\d*Z$/, '.$1Z')
+// `toISOString` is specified to emit exactly three fractional digits for every
+// in-range date, so there is nothing here to normalise.
+const instant = () => new Date().toISOString()
 
 const environment = () =>
   readEnvironment({
@@ -96,7 +96,6 @@ async function finish(
   }
 
   const attestation = buildAttestation({
-    repository: REPOSITORY,
     revision,
     dirtyWorktree: worktree === 'dirty',
     command: 'make verify',

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -119,6 +119,17 @@ try {
   if (phase === 'begin') {
     await begin()
   } else if (phase === 'finish') {
+    // `$$run` is unquoted in the recipe so that begin's three words arrive as
+    // three arguments. The count is checked here rather than quoted there: an
+    // extra word was accepted in silence, and a word prepended — one line of
+    // unexpected stdout, a future banner — shifted everything and produced an
+    // error naming the wrong problem.
+    if (rest.length !== 4) {
+      throw new Error(
+        `finish takes <status> <revision> <clean|dirty> <started-at>, got ${rest.length} argument(s): ${JSON.stringify(rest)}`
+      )
+    }
+
     const [status, revision, worktree, startedAt] = rest
     const exitCode = Number.parseInt(status ?? '', 10)
     if (!Number.isInteger(exitCode)) {

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -57,6 +57,13 @@ const environment = () =>
  * believed anyway.
  */
 async function begin(): Promise<void> {
+  // First, before anything that can fail. Any attestation still lying here
+  // belongs to an earlier run, and deleting it is right whether or not git
+  // answers: a `begin` that failed used to leave the previous run's verdict in
+  // place for `if: always()` to upload as this one's — the very case the delete
+  // was added to prevent.
+  await rm(attestationPath, { force: true })
+
   const resolved = await $`git rev-parse HEAD`.cwd(repoRoot).nothrow().quiet()
   if (resolved.exitCode !== 0) {
     throw new Error(
@@ -67,12 +74,6 @@ async function begin(): Promise<void> {
 
   const status = await $`git status --porcelain`.cwd(repoRoot).nothrow().quiet()
   if (status.exitCode !== 0) throw new Error('git status --porcelain failed')
-
-  // Any attestation still lying here belongs to an earlier run. Left in place,
-  // a run killed before `finish` — a CI timeout, a cancelled job — would let
-  // `if: always()` publish the previous run's verdict as this one's. No file is
-  // the honest answer to "was this revision verified"; a stale file is not.
-  await rm(attestationPath, { force: true })
 
   const worktree = status.text().trim().length > 0 ? 'dirty' : 'clean'
   console.log(`${resolved.text().trim()} ${worktree} ${instant()}`)

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -1,0 +1,126 @@
+/**
+ * Write the Verification Attestation for a `make verify` run.
+ *
+ * Two phases, because the two facts are true at different times. `begin`
+ * resolves the revision and the worktree's cleanliness before the first step
+ * runs — resolving them afterwards would describe whatever the steps left
+ * behind. `finish` takes the run's exit status and writes the document.
+ *
+ * The rules live in `lib/verification-attestation.ts`. Everything here is the
+ * git and filesystem shell around them, so the format stays testable from
+ * fixtures rather than from a repository whose HEAD moves every delivery.
+ *
+ * Nothing here decides whether the verification passed. It records the status
+ * it was handed and gets out of the way: the Makefile re-exits with that same
+ * status, so a failure to write an attestation can never turn a FAIL into a
+ * PASS.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { $ } from 'bun'
+import {
+  buildAttestation,
+  serialiseAttestation,
+  type AttestationEnvironment,
+} from './lib/verification-attestation'
+
+const REPOSITORY = 'CarlLee1983/dbcli'
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url))
+const outputDirectory = join(repoRoot, '.verification')
+const runPath = join(outputDirectory, 'run.json')
+const attestationPath = join(outputDirectory, 'attestation.json')
+
+/** What `begin` recorded, for `finish` to complete. */
+interface Run {
+  readonly repository: string
+  readonly revision: string
+  readonly dirtyWorktree: boolean
+  readonly startedAt: string
+}
+
+const instant = () => new Date().toISOString().replace(/\.(\d{3})\d*Z$/, '.$1Z')
+
+const environment = (): AttestationEnvironment => ({
+  os: process.platform,
+  arch: process.arch,
+  bun: Bun.version,
+  // Presence only. Copying the value would be harmless CI output today and an
+  // arbitrary caller-supplied string tomorrow.
+  ci: process.env.CI !== undefined,
+})
+
+/**
+ * Resolve the commit under verification.
+ *
+ * A repository that cannot answer is refused rather than recorded as unknown:
+ * an attestation whose revision is a guess attests nothing, and it would be
+ * believed anyway.
+ */
+async function resolveRun(): Promise<Run> {
+  const resolved = await $`git rev-parse HEAD`.cwd(repoRoot).nothrow().quiet()
+  if (resolved.exitCode !== 0) {
+    throw new Error(
+      'git rev-parse HEAD failed, so there is no revision to attest — ' +
+        'a verification outside a repository produces no attestation'
+    )
+  }
+
+  const status = await $`git status --porcelain`.cwd(repoRoot).nothrow().quiet()
+  if (status.exitCode !== 0) throw new Error('git status --porcelain failed')
+
+  return {
+    repository: REPOSITORY,
+    revision: resolved.text().trim(),
+    dirtyWorktree: status.text().trim().length > 0,
+    startedAt: instant(),
+  }
+}
+
+async function begin(): Promise<void> {
+  const run = await resolveRun()
+  await mkdir(outputDirectory, { recursive: true })
+  await writeFile(runPath, `${JSON.stringify(run, null, 2)}\n`, 'utf8')
+}
+
+async function finish(exitCode: number): Promise<void> {
+  const run = JSON.parse(await readFile(runPath, 'utf8')) as Run
+
+  const attestation = buildAttestation({
+    ...run,
+    command: 'make verify',
+    exitCode,
+    finishedAt: instant(),
+    environment: environment(),
+  })
+
+  await writeFile(attestationPath, serialiseAttestation(attestation), 'utf8')
+  console.log(
+    `verification attestation: ${attestation.result} at ${attestation.revision} ` +
+      `(${attestation.attestation_hash})`
+  )
+}
+
+const [phase, status] = process.argv.slice(2)
+
+try {
+  if (phase === 'begin') {
+    await begin()
+  } else if (phase === 'finish') {
+    const exitCode = Number.parseInt(status ?? '', 10)
+    if (!Number.isInteger(exitCode)) {
+      throw new Error(`finish needs the run's exit status, got ${JSON.stringify(status)}`)
+    }
+    await finish(exitCode)
+  } else {
+    throw new Error(`unknown phase ${JSON.stringify(phase)}; expected 'begin' or 'finish <status>'`)
+  }
+} catch (cause) {
+  // The verification's own result is authoritative. This failure is reported and
+  // the Makefile re-exits with the status it captured, so a broken attestation
+  // costs a record, never a verdict.
+  console.error(`Failed to write verification attestation: ${(cause as Error).message}`)
+  process.exitCode = 1
+}

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -607,6 +607,30 @@ roster parser 有六種寫法能一邊維持綠燈一邊把 gate 掏空：recipe
 scaffolding 整個被丟掉，而 `toContain` 是對整個檔案搜尋、註解也算數。改成把
 prologue 與 epilogue 五行逐字釘死；六種寫法現在全部會 fail，逐一實測過。
 
+### 測試自己會偽造 attestation
+
+Security Fixture Matrix 的第一版是 spawn 真正的 writer 去測，而 writer 寫的是
+canonical 路徑。結果是每跑一次 `bun test` 就在 `.verification/attestation.json`
+留下一份 hash 正確、`result: PASS`、綁著當時 HEAD 的 attestation——沒有任何驗證
+跑過。`parseAttestation` 會收下它：hash 證明的是內部一致，從來不是「有一次執行
+發生過」。
+
+在 CI 會真的出事：`bun run test` 是 24 個 step 裡的第 10 個，`integration` job 的
+timeout 是 20 分鐘而這輪大約 15 分鐘。一旦逾時或被取消，`finish` 不會跑，而
+`if: always()` 的上傳步驟會把**測試寫的那份**當成這次的結果傳上去，審查者下載到
+一份「從未被驗證過的 revision 的 PASS」。
+
+修法不是把測試指到暫存目錄，是讓那個性質不需要跑 writer 就能測：環境讀取抽成
+`readEnvironment(source)`，它對 `env` 做的唯一一件事是問 `CI` 在不在。「沒有任何
+環境變數的值進得了文件」因此從一句要人相信的話，變成可以餵一組敵意環境進去檢查的
+東西。順帶也解掉 `new URL(...).pathname` 在 Windows 與含空白／CJK 路徑上會壞的問題
+——沒有 spawn 就沒有那個路徑。
+
+另外兩道防線：`begin` 會先刪掉任何殘留的 attestation，所以被中斷的 run 不會讓上一次
+的判決被當成這一次的；contract test 掃描 `tests/` 裡任何 spawn writer 的寫法並拒絕
+（pattern 是組出來的，寫死會抓到自己）。實測過：加一個會 spawn 的測試進去，這條
+就變紅。
+
 把 step 清單搬進 `scripts/` runner 的那個選項沒有被否決，只是延後：DBCLI-019 要的
 per-step 時間與失敗步驟幾乎是免費的，該由那個 Story 重新評估，而不是在這裡先猜。
 

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -538,6 +538,62 @@ repository 沒有任何讀者。
 0.3.2 下還剩八條 `completed Story is not a Story ID: DBCLI-PLAT-*`，那是 0.3.2 的 Story
 ID 文法早於 `DBCLI-PLAT-*` 命名，0.6.0 已經放寬。不在這個 Story 的範圍，DBCLI-018 收。
 
+## DBCLI-017：驗證證據終於離得開這台機器
+
+`make verify` 現在會寫出一份 Verification Attestation：一個 revision、一個指令、
+一個結果，PASS 與 FAIL 都寫。檔案在 `.verification/attestation.json`，gitignored。
+理由記在 ADR-0026，名詞進了 `CONTEXT.md`。
+
+在此之前，驗證證據只存在 `.forgepilot/state.json`，而且只存在跑它的那台機器上。
+那個檔案是刻意 gitignored 的：commit 進去會弄髒下一次驗證要求乾淨的工作樹，而且
+「記下結果」這個動作本身要一個 commit，那個 commit 會立刻讓被記下的結果失效。
+DBCLI-016 的交付報告只能寫「Evidence ID 留在 ForgePilot 的 state 裡，刻意不抄在
+這裡」，就是撞到這件事。
+
+兩個事實決定了設計，而不是 schema：
+
+**ForgePilot 沒有 export。** 它在 `8ce2c12` 的指令是 init／migrate／goal／work／
+next／start／verify／gate／review／status，development plan 裡也沒有 export 的規劃。
+等它等於把交付綁在另一個 repo 的行程上；直接讀 `.forgepilot/state.json` 則是把 dbcli
+綁上 ForgePilot 的內部格式，那正是 DBCLI-014 畫掉的界線。
+
+**`make verify` 是那個固定的指令**（ForgePilot 的 `internal/work/evidence.go` 與其
+測試），而且它是唯一第一手看到結果的參與者。所以由 repository 自己寫，ForgePilot／
+CI／人事後讀檔案。整合介面是一個路徑加一個版本化 schema，誰都不 import 誰。
+
+### 兩個已經被佔用的名字
+
+`Evidence receipt`（`src/core/evidence-receipt/`）與 `Verification artifact`
+（`src/core/verification/`）都是**產品**的東西：記的是 dbcli 對資料庫做的一次操作，
+會出貨、有發布的 schema 版本。這份記的是一個 commit，讀的人是審查者或 CI。把它塞進
+任何一個，等於為了使用者看不見的理由去動一個已發布的版本號，還會把流程工具出貨給
+只想連資料庫的人。所以叫 Verification Attestation，`attestation` 在 dbcli 與
+ForgePilot 都沒被用過。
+
+### 兩個刻意的減法
+
+沒有 `work_item`、沒有 `story`。`make verify` 不知道這兩個值，只能由呼叫端傳進來，
+而**產生者查不了的欄位，記下來的就是呼叫端說了什麼**。ForgePilot 本來就用 revision
+綁 Evidence，可以照同一條路綁這份檔案。這是 deferred decision，重啟條件寫在 ADR-0026。
+
+也沒有 staleness。文件只說 revision；那個 revision 是不是還是 HEAD，每次問答案都不同，
+一份自己回答這題的檔案在寫完的下一刻就是錯的。
+
+### FAIL 也要留紀錄，代價是 recipe 裡多了一段 shell
+
+`make` 在第一個失敗的 step 就停，所以寫在最後一行的 attestation 只會描述通過的那次
+——最不需要證據的那次。24 個 step 現在包在一個 subshell 裡以 `&&` 串接，捕捉狀態、
+寫檔、再以同一個狀態 exit。每個 step 都還在、順序沒動、也都還是阻斷性的；
+`tests/contract/forgepilot-boundary.test.ts` 的 roster 一個字沒改，只是改成從 subshell
+裡讀，並且順便擋掉 `|| true`、前置 `-` 與把 `&&` 換成 `;` 這三種偷偷放行的寫法。
+
+實測過 FAIL 這條路：在第一個 step 前插一個 `false`，`make verify` 以非零結束，
+attestation 寫出 `result: FAIL`、`exit_code: 1`、revision 正確。注意 `exit_code` 記的是
+失敗那個 step 的狀態，不是 `make` 自己的錯誤碼——除錯的人要的是前者。
+
+把 step 清單搬進 `scripts/` runner 的那個選項沒有被否決，只是延後：DBCLI-019 要的
+per-step 時間與失敗步驟幾乎是免費的，該由那個 Story 重新評估，而不是在這裡先猜。
+
 ## Lifecycle
 
 `current_story` 與 `next_story` 永久是契約的 sentinel。要知道現在該做什麼，問
@@ -572,22 +628,27 @@ workflow:
     - DBCLI-014
     - DBCLI-015
     - DBCLI-016
+    - DBCLI-017
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 141cf4c3ebc019b9693430bfaa1a9c1b2559ff90
+  commit: 980cc078b850f799615dce51b2993141b85c40c7
   dirty_worktree: false
   story_owned_paths:
     - specs/handoff.md
-    - specs/stories/DBCLI-016-forgepilot-lifecycle-authority/story.md
-    - specs/stories/DBCLI-016-forgepilot-lifecycle-authority/acceptance.md
-    - docs/adr/0025-the-handoff-records-delivery-not-a-work-queue.md
-    - scripts/lib/forgeflow-handoff.ts
-    - scripts/check-forgeflow-handoff.ts
-    - tests/unit/scripts/forgeflow-handoff.test.ts
-    - AGENTS.md
+    - specs/stories/DBCLI-017-portable-verification-attestation/story.md
+    - specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
+    - docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
+    - scripts/lib/verification-attestation.ts
+    - scripts/write-attestation.ts
+    - tests/unit/scripts/verification-attestation.test.ts
+    - tests/contract/forgepilot-boundary.test.ts
+    - Makefile
+    - .gitignore
+    - .github/workflows/ci.yml
+    - CONTEXT.md
   known_unrelated_paths: []
 
 verification:

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -591,6 +591,22 @@ ForgePilot 都沒被用過。
 attestation 寫出 `result: FAIL`、`exit_code: 1`、revision 正確。注意 `exit_code` 記的是
 失敗那個 step 的狀態，不是 `make` 自己的錯誤碼——除錯的人要的是前者。
 
+### review 抓到的兩個 CRITICAL
+
+`set -o pipefail` 不是 POSIX。GNU Make 忽略環境的 `SHELL` 直接用 `/bin/sh`，而
+`integration` job 跑的 ubuntu runner 上 `/bin/sh` 是 dash——實測 `ubuntu:24.04`
+與 `ubuntu:22.04` 都回 `set: Illegal option -o pipefail` 並以 exit 2 中止，24 個
+step 一個都不會跑，attestation 也不會寫，而且失敗看起來像驗證失敗。本機測不出來，
+因為 macOS 的 `/bin/sh` 是 bash。那 24 個 step 裡沒有任何一個 pipe，所以 pipefail
+本來就是個什麼都不保護的致命 no-op，直接刪掉。
+
+roster parser 有六種寫法能一邊維持綠燈一邊把 gate 掏空：recipe 行前面加 `-`
+（make 忽略錯誤，`make verify` 在有 step 失敗時 exit 0）、`exit $status` 換成
+`exit 0`、在開括號那一行或閉括號之後夾帶額外指令、以及在檔案後面再定義一次
+`verify:`（make 跑最後一個）。共同成因是 parser 只讀 subshell 裡面那一半，
+scaffolding 整個被丟掉，而 `toContain` 是對整個檔案搜尋、註解也算數。改成把
+prologue 與 epilogue 五行逐字釘死；六種寫法現在全部會 fail，逐一實測過。
+
 把 step 清單搬進 `scripts/` runner 的那個選項沒有被否決，只是延後：DBCLI-019 要的
 per-step 時間與失敗步驟幾乎是免費的，該由那個 Story 重新評估，而不是在這裡先猜。
 

--- a/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
@@ -62,9 +62,17 @@ that counts as passing.
       Evidence: the writer exits non-zero naming the missing revision, and no
       file is written — an attestation with an unknown revision attests nothing.
 * [ ] An unwritable output path does not change the verification result.
-      Evidence: make the directory unwritable, run a passing verification, and
-      confirm the write failure is reported while `make verify`'s own exit
-      status is unchanged.
+      Evidence: with `.verification` at mode `555` and no attestation file
+      present, the recipe's shell reports `EACCES` and still exits with the
+      verification's own status.
+* [ ] A failure in the phase that runs *before* the first step does not change
+      the verification result either.
+      Evidence: with `git` replaced by a stub that exits `1`, `begin` reports
+      that there is no revision to attest, `finish` reports that it was given
+      nothing, every step still runs, and the recipe exits with the
+      verification's own status. This is the direction the first implementation
+      got wrong: `begin` was a blocking recipe line, so an unwritable directory
+      failed the target before a single step ran.
 * [ ] A truncated or malformed attestation is refused by the reader, not
       partially read.
       Evidence: a fixture with a removed required field fails parsing with the
@@ -80,7 +88,8 @@ that counts as passing.
 * [ ] No dbcli source file or package manifest gains a reference to ForgePilot,
       and nothing reads `.forgepilot/`.
       Evidence: `tests/contract/forgepilot-boundary.test.ts`, plus a search for
-      `.forgepilot` under `src/` and `scripts/` returning nothing.
+      `.forgepilot` under `src/` and `scripts/` returning only prose — no
+      `readFile`, `Bun.file`, `import`, or path join reaching into it.
 
 ## Security Fixture Matrix
 
@@ -91,7 +100,7 @@ Every row is a required case. The expected result is one of `preserve`,
 | --- | --- | --- | --- | --- |
 | `env.DBCLI_PASSWORD` | `hunter2` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
 | `env.GITHUB_TOKEN` | `ghp_000000000000000000000000000000000000` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
-| `env.CI` | `true` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `env.CI` | `azure-pipelines` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
 | `env.USER` | `carl` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
 | `cwd` | `/Users/carl/Dev/CMG/Dbcli` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
 | `hostname` | `carls-macbook-air.local` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
@@ -99,8 +108,11 @@ Every row is a required case. The expected result is one of `preserve`,
 | `git.revision` | `980cc078b850f799615dce51b2993141b85c40c7` | preserve | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
 
 `env.CI` is `omit` for its *value*: the document records only whether the
-variable was present, as a boolean. Copying `true` would be one field's worth of
-harmless CI output today and an arbitrary string from a caller tomorrow.
+variable was present, as a boolean. The payload is deliberately not the literal
+`true` most providers set — as a substring that is indistinguishable from the
+boolean the schema records, so it could not tell a copied value from a correctly
+derived one. Copying the value would be one field's worth of harmless CI output
+today and an arbitrary string from a caller tomorrow.
 
 `step.stderr` is `omit` in this Story and stays that way. Per-step detail is
 DBCLI-019's, and whatever it records will have to answer this same question

--- a/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
@@ -19,7 +19,10 @@ that counts as passing.
 * [ ] The document travels off the machine that produced it.
       Evidence: the CI `integration` job uploads it; the artifact is
       downloadable from the workflow run, and its `revision` is the commit CI
-      checked out.
+      checked out. The artifact's name states no revision — `github.sha` and the
+      attestation's own `revision` agree only by the checkout's configuration,
+      and a name that could contradict the file it names is worse than one that
+      says nothing.
 
 ## Business Rules
 

--- a/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
@@ -1,0 +1,119 @@
+# Acceptance Criteria
+
+Every criterion names the evidence that decides it: a command and the result
+that counts as passing.
+
+## Happy Path
+
+* [ ] A passing `make verify` leaves `.verification/attestation.json`.
+      Evidence: run it, then `test -f .verification/attestation.json` → exit `0`.
+* [ ] The attestation names the revision that was verified.
+      Evidence: its `revision` equals `git rev-parse HEAD` at the time of the
+      run, as 40 lowercase hex characters, and `dirty_worktree` is `false`.
+* [ ] It states the command and the outcome.
+      Evidence: `command` is `make verify`, `result` is `PASS`, `exit_code` is
+      `0`.
+* [ ] It is machine-readable without a schema guess.
+      Evidence: `schema_version` is `1`; a reader given `schema_version: 2`
+      refuses the document rather than reading the fields it recognises.
+* [ ] The document travels off the machine that produced it.
+      Evidence: the CI `integration` job uploads it; the artifact is
+      downloadable from the workflow run, and its `revision` is the commit CI
+      checked out.
+
+## Business Rules
+
+* [ ] A failing `make verify` still writes an attestation, and still fails.
+      Evidence: break one step deliberately, run, then confirm `result` is
+      `FAIL` with the step's non-zero `exit_code`, and that `make verify` itself
+      exited non-zero. This is the criterion the Story exists for; a PASS-only
+      attestation records the case nobody needs.
+* [ ] A dirty worktree produces an attestation that says so.
+      Evidence: with an uncommitted change present, `dirty_worktree` is `true`
+      and `revision` is still the committed SHA — the document never implies the
+      commit was what ran.
+* [ ] The same run serialises to the same bytes.
+      Evidence: serialise one run's attestation twice; `cmp` reports no
+      difference. Keys are in the schema's fixed order, endings are LF, and the
+      file ends with exactly one newline.
+* [ ] `attestation_hash` is the identity of the content.
+      Evidence: it is `sha256:` plus the digest of the canonical bytes with the
+      hash field removed; recomputing it from the file reproduces the value, and
+      changing any field changes it.
+* [ ] Every step of `make verify` is still present, in order, and still
+      blocking.
+      Evidence: `tests/contract/forgepilot-boundary.test.ts` passes with its
+      `REQUIRED_STEPS` roster showing the same steps in the same order, and no
+      step gains `-`, `|| true`, or `continue-on-error`.
+* [ ] The attestation is never committed.
+      Evidence: `git check-ignore .verification/attestation.json` → exit `0`,
+      and `git status --porcelain` is empty immediately after a `make verify`
+      run — the property ForgePilot's clean-worktree requirement depends on.
+* [ ] The writer is repository tooling, not product.
+      Evidence: no file under `src/` references it; `npm pack --dry-run` lists
+      no `.verification` or attestation-writer path.
+* [ ] Staleness is the reader's answer, not the document's.
+      Evidence: the schema has no `current`, `stale`, or `applies_to_head`
+      field; the only revision statement is `revision`.
+
+## Failure Cases
+
+* [ ] A repository where `git rev-parse HEAD` fails produces no attestation.
+      Evidence: the writer exits non-zero naming the missing revision, and no
+      file is written — an attestation with an unknown revision attests nothing.
+* [ ] An unwritable output path does not change the verification result.
+      Evidence: make the directory unwritable, run a passing verification, and
+      confirm the write failure is reported while `make verify`'s own exit
+      status is unchanged.
+* [ ] A truncated or malformed attestation is refused by the reader, not
+      partially read.
+      Evidence: a fixture with a removed required field fails parsing with the
+      field named.
+
+## Regression Requirements
+
+* [ ] `make verify` passes on the delivered commit, run by ForgePilot in a
+      detached worktree of that exact revision, and that run's own attestation
+      names the same revision.
+* [ ] `bun run forgeflow:check` still passes, and DBCLI-016's refusal rules are
+      untouched.
+* [ ] No dbcli source file or package manifest gains a reference to ForgePilot,
+      and nothing reads `.forgepilot/`.
+      Evidence: `tests/contract/forgepilot-boundary.test.ts`, plus a search for
+      `.forgepilot` under `src/` and `scripts/` returning nothing.
+
+## Security Fixture Matrix
+
+Every row is a required case. The expected result is one of `preserve`,
+`redact`, `reject`, or `omit`.
+
+| Source field | Payload | Expected result | Persisted locations | Verification |
+| --- | --- | --- | --- | --- |
+| `env.DBCLI_PASSWORD` | `hunter2` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `env.GITHUB_TOKEN` | `ghp_000000000000000000000000000000000000` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `env.CI` | `true` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `env.USER` | `carl` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `cwd` | `/Users/carl/Dev/CMG/Dbcli` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `hostname` | `carls-macbook-air.local` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `step.stderr` | `error: connect ECONNREFUSED 127.0.0.1:5432` | omit | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+| `git.revision` | `980cc078b850f799615dce51b2993141b85c40c7` | preserve | `.verification/attestation.json` | `tests/unit/scripts/verification-attestation.test.ts` |
+
+`env.CI` is `omit` for its *value*: the document records only whether the
+variable was present, as a boolean. Copying `true` would be one field's worth of
+harmless CI output today and an arbitrary string from a caller tomorrow.
+
+`step.stderr` is `omit` in this Story and stays that way. Per-step detail is
+DBCLI-019's, and whatever it records will have to answer this same question
+about unbounded command output.
+
+## Verification Notes
+
+The FAIL criterion cannot be proven by a passing run. Break a step on a scratch
+branch, capture the attestation, and record it in the delivery report; do not
+leave a broken step behind.
+
+The CI upload criterion is proven by the workflow run for this Story's own pull
+request. Record the run URL and the artifact name.
+
+`make verify` is the authority for this Story as for every other one. The
+attestation records what it decided; it never decides anything.

--- a/specs/stories/DBCLI-017-portable-verification-attestation/story.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/story.md
@@ -149,6 +149,10 @@ mandatory.
 * `make verify` must keep working with no ForgePilot installed and no CI.
 * The schema must leave room for DBCLI-019's per-step detail to be added under a
   new `schema_version` without restating anything this Story defines.
+* Every field must be something `make verify` observed. A value that is only
+  ever handed to the producer records what the caller claimed, whether the
+  handing happens at call time or at authoring time — which is why this Story
+  carries no `work_item`, no `story`, and no `repository`.
 
 ## Trust Boundary Fields
 
@@ -179,6 +183,15 @@ Required when `Baseline conformance: yes`.
   argument is R2 and R3: every step stays, in order, still blocking; what
   changes is that the recipe no longer stops without recording that it stopped.
 * `Makefile` — the `verify` recipe as a bare list of steps.
+
+## Known Cost
+
+Joining the steps into one subshell loses make's per-step echo, so a CI log no
+longer names the check that was running when the gate failed. Diagnosis leans on
+the failing tool's own output instead. Restoring it properly means echoing each
+step with its own timing, which is DBCLI-019's subject; it is recorded here and
+in the `Makefile` so that Story inherits a known cost rather than rediscovering
+it.
 
 ## Recorded Decisions
 

--- a/specs/stories/DBCLI-017-portable-verification-attestation/story.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/story.md
@@ -106,8 +106,9 @@ mandatory.
   dirty worktree produces an attestation that says so, never one that implies
   the commit was what was tested.
 * R2: The attestation is written on FAIL as well as on PASS, and `make verify`
-  still exits non-zero on FAIL. Writing the attestation never changes the exit
-  status, and a failure to write it never turns a FAIL into a PASS.
+  still exits non-zero on FAIL. Neither attestation phase can change the exit
+  status in either direction: a failure to write never turns a FAIL into a PASS,
+  and never turns a PASS — or a run that has not started yet — into a failure.
 * R3: Every step of `make verify` present before this Story is still present
   after it, in the same order, and still blocking.
 * R4: The document contains no secret, credential, environment dump, absolute
@@ -129,7 +130,9 @@ mandatory.
   fails, refuses to write an attestation rather than writing one with an unknown
   revision.
 * An unwritable output path is reported, and the verification result stands
-  unchanged — the attestation records the run, it does not decide it.
+  unchanged — the attestation records the run, it does not decide it. This holds
+  for the phase that runs before the first step as much as for the one that runs
+  after the last.
 * A reader given an attestation whose `schema_version` it does not know refuses
   it rather than reading the fields it recognises.
 

--- a/specs/stories/DBCLI-017-portable-verification-attestation/story.md
+++ b/specs/stories/DBCLI-017-portable-verification-attestation/story.md
@@ -1,0 +1,202 @@
+# Story: DBCLI-017 Portable Verification Attestation
+
+## Goal
+
+A reviewer, a CI job, or a future session can answer "was this exact revision
+verified, by what command, with what result" from a file that travels — without
+a ForgePilot install, without `.forgepilot/state.json`, and without trusting
+anybody's recollection.
+
+## Context
+
+Verification evidence exists today in exactly one place: `.forgepilot/state.json`
+on the machine that ran it. That file is gitignored on purpose — committing it
+would make `make verify` dirty the worktree ForgePilot refuses to verify, and
+recording a result would take a commit that immediately invalidates the result
+being recorded. So the evidence is real, and it is unreachable from anywhere
+else. DBCLI-016's delivery report had to say "the Evidence IDs live in
+ForgePilot's state, deliberately not restated here" for exactly this reason.
+
+Two facts constrain the design more than the schema does.
+
+**ForgePilot has no export.** Its commands are `init`, `migrate`, `goal`,
+`work`, `next`, `start`, `verify`, `gate`, `review`, `status` — verified by
+reading `internal/cli/cli.go` at `8ce2c12`. `docs/development-plan.md` contains
+no export roadmap. Waiting for one would make this Story's delivery depend on
+another repository's schedule, and reaching into `.forgepilot/state.json` would
+couple dbcli to ForgePilot's internal format — the boundary DBCLI-014 drew.
+
+**`make verify` is the fixed command.** ForgePilot runs the managed project's
+`make verify` and records the exit code (`internal/work/evidence.go` and its
+tests). It is also the only participant that observes the result first-hand. So
+the attestation is written by the repository's own verification, and ForgePilot
+— or CI, or a human — reads the file afterwards. dbcli stays the producer of a
+standard artifact; nothing imports anything.
+
+Two names in this repository are already taken, and both are close enough to
+mislead:
+
+* **Evidence receipt** (`CONTEXT.md`, `src/core/evidence-receipt/`) is a product
+  artifact: a bounded record of one dbcli operation against a database, shipped
+  to users, versioned by `EVIDENCE_RECEIPT_VERSION`.
+* **Verification artifact** (`src/core/verification/`) is also a product
+  artifact, about `assert`, `snapshot` and `recovery-verify` runs against data.
+
+Neither is about a repository revision, neither is read by a reviewer of this
+repository, and reusing either would move a shipped schema version for reasons
+that have nothing to do with the product. This Story introduces a third term,
+**Verification Attestation**, and records why in an ADR. `attestation` appears
+nowhere in dbcli or ForgePilot today.
+
+## Classification
+
+Both declarations are required. `yes` makes the matching section below
+mandatory.
+
+* Security sensitive: yes
+* Baseline conformance: yes
+
+## Scope
+
+### In Scope
+
+* A Verification Attestation: one versioned, machine-readable JSON document
+  describing one run of `make verify` against one revision.
+* A writer under `scripts/`, invoked by `make verify`, that writes the
+  attestation on both PASS and FAIL to a gitignored path.
+* Canonical serialisation, so the same run serialises to the same bytes, and a
+  content hash that is the attestation's identity.
+* Uploading the attestation from the existing CI `integration` job as a GitHub
+  Actions artifact — the smallest real proof that the document travels.
+* `CONTEXT.md` gains the term; an ADR records the boundary and its falsification
+  condition.
+
+### Out of Scope
+
+* Any change to ForgePilot, and any read of `.forgepilot/`.
+* Per-step timings, step names, or a failed-step field — DBCLI-019 owns
+  verification observability, and this Story's schema must leave room for it
+  rather than pre-empt it.
+* PR checks, PR comments, and any external evidence store.
+* Signing, notarising, or any trust claim beyond "this file says what the run
+  said".
+* Reusing or extending `src/core/evidence-receipt` or `src/core/verification`.
+* Any dbcli runtime, packaging, or source dependency on the attestation writer.
+* Removing, reordering, weakening, or making non-blocking any existing step of
+  `make verify`.
+
+## Inputs
+
+* The revision `git rev-parse HEAD` resolves to, and whether the worktree is
+  clean, both read at the start of the run.
+* The exit status of the verification steps.
+* The wall-clock start and finish instants.
+* A bounded description of the environment: OS, architecture, Bun version, and
+  whether `CI` is set.
+
+## Outputs
+
+* `.verification/attestation.json`, gitignored, overwritten by each run.
+* On CI, the same document as a build artifact retrievable from the run.
+
+## Rules
+
+* R1: The attestation names the full 40-character revision resolved before the
+  first step ran, and states whether the worktree was clean. A run against a
+  dirty worktree produces an attestation that says so, never one that implies
+  the commit was what was tested.
+* R2: The attestation is written on FAIL as well as on PASS, and `make verify`
+  still exits non-zero on FAIL. Writing the attestation never changes the exit
+  status, and a failure to write it never turns a FAIL into a PASS.
+* R3: Every step of `make verify` present before this Story is still present
+  after it, in the same order, and still blocking.
+* R4: The document contains no secret, credential, environment dump, absolute
+  path, hostname, or user name. Only the fields the schema names appear.
+* R5: The same run serialises to identical bytes: keys in a fixed order, LF
+  endings, one trailing newline, no locale- or platform-dependent formatting.
+* R6: `schema_version` is an integer that moves when a field, its requiredness,
+  or the meaning of a value changes, and never because the npm package version
+  moved — the rule the other artifact versions already follow.
+* R7: The attestation is repository tooling, not product: no file under `src/`
+  imports the writer, and the published package does not contain it.
+* R8: Staleness is computed by the reader, not stored. The document states a
+  revision; whether that revision is still HEAD is a question the reader
+  answers, so an attestation can never claim to be current.
+
+## Expected Errors
+
+* A run in a repository with no git history, or where `git rev-parse HEAD`
+  fails, refuses to write an attestation rather than writing one with an unknown
+  revision.
+* An unwritable output path is reported, and the verification result stands
+  unchanged — the attestation records the run, it does not decide it.
+* A reader given an attestation whose `schema_version` it does not know refuses
+  it rather than reading the fields it recognises.
+
+## Dependencies
+
+* `git`, already required by `bun run forgeflow:check`.
+* Nothing else. No network, no ForgePilot, no ForgeFlow checkout.
+
+## Constraints
+
+* The output path must be gitignored. An attestation inside the worktree that
+  Git can see would dirty the tree ForgePilot requires to be clean, and would
+  make each verification invalidate the last one's record.
+* `make verify` must keep working with no ForgePilot installed and no CI.
+* The schema must leave room for DBCLI-019's per-step detail to be added under a
+  new `schema_version` without restating anything this Story defines.
+
+## Trust Boundary Fields
+
+Required when `Security sensitive: yes`.
+
+Every value that reaches the attestation from outside the writer's own control:
+
+* `environment.os`, `environment.arch` — from `process.platform` / `process.arch`
+* `environment.bun` — from `Bun.version`
+* `environment.ci` — from the presence of the `CI` environment variable, as a
+  boolean; the variable's value is never copied
+* `revision`, `dirty_worktree` — from `git rev-parse HEAD` and `git status
+  --porcelain`
+* `exit_code` — from the verification run
+* `started_at`, `finished_at` — from the system clock
+
+No other environment variable, no command output, and no filesystem path enters
+the document.
+
+## Superseded Behavior
+
+Required when `Baseline conformance: yes`.
+
+* `tests/contract/forgepilot-boundary.test.ts` — its `REQUIRED_STEPS` roster
+  pins the exact step list of `make verify`. This Story changes how the recipe
+  invokes those steps so that a result is recorded on both outcomes, which the
+  roster's own comment says must be argued for rather than done quietly. The
+  argument is R2 and R3: every step stays, in order, still blocking; what
+  changes is that the recipe no longer stops without recording that it stopped.
+* `Makefile` — the `verify` recipe as a bare list of steps.
+
+## Recorded Decisions
+
+**How `make verify` records a FAIL.** `make` stops at the first failing step, so
+an attestation written as a final step is written only on PASS — the case that
+matters least. Decided on 2026-09-08: wrap the existing steps in a subshell,
+capture the status, write the attestation, re-exit with that status. Every step
+stays visible in the `Makefile` and the boundary test's roster still reads them
+from there, which keeps the canonical gate's definition where this repository
+has always kept it. The cost accepted is a recipe that now contains shell a
+reader has to trust to propagate the exit code, which R2 and its failing-run
+criterion exist to hold to account.
+
+The alternative — moving the step list into a `scripts/` runner — was considered
+and deferred, not rejected: it is close to free for DBCLI-019's per-step timings
+and failed-step field, and reassessing it belongs to that Story rather than to a
+guess made here.
+
+**What the attestation does not carry.** Decided on 2026-09-08: no `work_item`
+and no `story` field. `make verify` does not know either value, so both would
+have to arrive from the caller, and a producer that cannot verify a field
+records whatever it was handed. ForgePilot already binds evidence to work by
+revision and can bind this the same way. This is a deferred decision with an
+explicit reopening condition, recorded in ADR-0026.

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -49,74 +49,105 @@ const REQUIRED_STEPS = [
 ] as const
 
 /**
- * The verification steps, read out of the `verify` recipe's subshell.
+ * Everything the `verify` recipe says that is not a verification step.
+ *
+ * Pinned literally, because a roster that only reads the steps polices the
+ * least interesting half of the recipe. A review of the first version found six
+ * shapes that kept this check green while gutting the gate: a `-` prefix on the
+ * line carrying the subshell (make ignores the error, `make verify` exits 0
+ * with a failing step), `exit 0` in place of `exit $$status`, a step smuggled
+ * onto the opening line or appended after the closing paren, and a second
+ * `verify:` target further down that make would run instead. Each of them
+ * changes one of these lines, so each of them now fails.
+ */
+const PROLOGUE = ["@run=$$(bun run scripts/write-attestation.ts begin) || run='';", '('] as const
+
+const EPILOGUE = [
+  '); status=$$?;',
+  'bun run scripts/write-attestation.ts finish $$status $$run || true;',
+  'exit $$status',
+] as const
+
+interface Recipe {
+  readonly prologue: readonly string[]
+  readonly steps: readonly string[]
+  readonly epilogue: readonly string[]
+}
+
+/**
+ * Read the `verify` recipe, split into its scaffolding and its steps.
  *
  * The steps are joined by `&&`, which is what keeps every one of them blocking:
- * a step that failed cannot be followed by the next. Reading them from between
- * the subshell's parentheses means this check still fails if a step is removed,
- * reordered, or quietly made non-fatal with `;` or `|| true`.
+ * a step that failed cannot be followed by the next. Nothing is discarded — a
+ * line that is neither prologue, step, nor epilogue has nowhere to hide, which
+ * is the property the earlier version lacked.
  */
-const verifyRecipe = async (): Promise<string[]> => {
+const verifyRecipe = async (): Promise<Recipe> => {
   const makefile = await readRoot('Makefile')
   const lines = makefile.split('\n')
+
+  // Make runs the *last* definition of a target; this check would otherwise
+  // read the first and report on a recipe that never executes.
+  expect(lines.filter((line) => line.startsWith('verify:'))).toHaveLength(1)
+
   const start = lines.findIndex((line) => line.startsWith('verify:'))
-  expect(start).toBeGreaterThanOrEqual(0)
-
   const recipe: string[] = []
-  let inSubshell = false
-
   for (const line of lines.slice(start + 1)) {
     if (!line.startsWith('\t')) break
     const text = line.slice(1).replace(/\\$/, '').trim()
-
-    if (!inSubshell) {
-      if (text.endsWith('(')) inSubshell = true
-      continue
-    }
-    if (text.startsWith(');')) break
-
-    const step = text.replace(/\s*&&$/, '')
-    expect(step).not.toMatch(/\|\|\s*true|^-|;\s*$/)
-    if (step.length > 0 && !step.startsWith('#')) recipe.push(step)
+    if (text.length > 0 && !text.startsWith('#')) recipe.push(text)
   }
 
-  return recipe
+  const opening = recipe.indexOf('(')
+  const closing = recipe.findIndex((line) => line.startsWith(');'))
+  expect(opening).toBeGreaterThanOrEqual(0)
+  expect(closing).toBeGreaterThan(opening)
+
+  const steps = recipe.slice(opening + 1, closing).map((line) => {
+    expect(line).not.toMatch(/\|\|\s*true|^-|;/)
+    return line.replace(/\s*&&$/, '')
+  })
+
+  return { prologue: recipe.slice(0, opening + 1), steps, epilogue: recipe.slice(closing) }
 }
 
 describe('make verify runs from a clean checkout', () => {
   test('installs the pinned dependency set before any step that consumes it', async () => {
-    const recipe = await verifyRecipe()
+    const { steps } = await verifyRecipe()
 
-    expect(recipe[0]).toBe('bun install --frozen-lockfile')
+    expect(steps[0]).toBe('bun install --frozen-lockfile')
   })
 
-  test('records the run whether it passed or failed', async () => {
-    // The attestation is the reason the steps moved into a subshell. Written
+  test('records the run whether it passed or failed, and neither phase decides it', async () => {
+    // The attestation is the reason the steps moved into a subshell: written
     // only on the passing path it would describe the case nobody needs evidence
-    // for, and the recipe must still exit with the status it captured.
-    const makefile = await readRoot('Makefile')
+    // for. And a record of a run must never stand between a developer and their
+    // result — `begin` was briefly a blocking recipe line, so an unwritable
+    // output directory failed the whole target before a single step ran.
+    //
+    // Both properties live in these five lines, compared literally. Asserting
+    // `toContain` over the whole file was satisfied by a comment.
+    const { prologue, epilogue } = await verifyRecipe()
 
-    expect(makefile).toContain('scripts/write-attestation.ts begin')
-    expect(makefile).toContain('scripts/write-attestation.ts finish $$status')
-    expect(makefile).toContain('exit $$status')
+    expect(prologue).toEqual([...PROLOGUE])
+    expect(epilogue).toEqual([...EPILOGUE])
   })
 
-  test('neither attestation phase can decide the verdict', async () => {
-    // A record of the run must never stand between a developer and their
-    // verification result. `begin` was briefly a blocking recipe line: with an
-    // unwritable output directory it failed the whole target before a single
-    // step ran, which is the attestation deciding the outcome — the one thing
-    // the Story forbids outright.
+  test('stays POSIX, because make runs /bin/sh and CI runs dash', async () => {
+    // `set -o pipefail` is not POSIX. On ubuntu-latest — the only runner where
+    // `make verify` runs — dash answers `set: Illegal option -o pipefail` and
+    // aborts the recipe line before any step, which reads as a verification
+    // failure. Verified against `ubuntu:24.04`, exit 2.
     const makefile = await readRoot('Makefile')
+    const recipeText = makefile.slice(makefile.indexOf('verify:'))
 
-    expect(makefile).toMatch(/write-attestation\.ts begin\) \|\| run=''/)
-    expect(makefile).toMatch(/write-attestation\.ts finish \$\$status \$\$run \|\| true/)
+    expect(recipeText).not.toContain('pipefail')
   })
 
   test('keeps every step it had before, in the same order', async () => {
-    const recipe = await verifyRecipe()
+    const { steps } = await verifyRecipe()
 
-    expect(recipe.slice(1)).toEqual([...REQUIRED_STEPS])
+    expect(steps.slice(1)).toEqual([...REQUIRED_STEPS])
   })
 
   test('keeps its operational output out of version control', async () => {

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -101,6 +101,18 @@ describe('make verify runs from a clean checkout', () => {
     expect(makefile).toContain('exit $$status')
   })
 
+  test('neither attestation phase can decide the verdict', async () => {
+    // A record of the run must never stand between a developer and their
+    // verification result. `begin` was briefly a blocking recipe line: with an
+    // unwritable output directory it failed the whole target before a single
+    // step ran, which is the attestation deciding the outcome — the one thing
+    // the Story forbids outright.
+    const makefile = await readRoot('Makefile')
+
+    expect(makefile).toMatch(/write-attestation\.ts begin\) \|\| run=''/)
+    expect(makefile).toMatch(/write-attestation\.ts finish \$\$status \$\$run \|\| true/)
+  })
+
   test('keeps every step it had before, in the same order', async () => {
     const recipe = await verifyRecipe()
 

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -16,6 +16,11 @@ const readRoot = (relative: string): Promise<string> => readFile(join(ROOT, rela
  * whole point — `make verify` is the repository's verification contract, and a
  * control plane that runs it in a clean checkout must not become a reason to
  * make it say less.
+ *
+ * DBCLI-017 moved these steps inside a subshell so that a failing run is
+ * recorded as well as a passing one. That is the argued-for change the comment
+ * above demands: the roster below is unchanged, every step is still blocking,
+ * and what the recipe gained is the ability to say that it stopped.
  */
 const REQUIRED_STEPS = [
   'bun run services:check',
@@ -43,6 +48,14 @@ const REQUIRED_STEPS = [
   'bun run forgeflow:check',
 ] as const
 
+/**
+ * The verification steps, read out of the `verify` recipe's subshell.
+ *
+ * The steps are joined by `&&`, which is what keeps every one of them blocking:
+ * a step that failed cannot be followed by the next. Reading them from between
+ * the subshell's parentheses means this check still fails if a step is removed,
+ * reordered, or quietly made non-fatal with `;` or `|| true`.
+ */
 const verifyRecipe = async (): Promise<string[]> => {
   const makefile = await readRoot('Makefile')
   const lines = makefile.split('\n')
@@ -50,11 +63,23 @@ const verifyRecipe = async (): Promise<string[]> => {
   expect(start).toBeGreaterThanOrEqual(0)
 
   const recipe: string[] = []
+  let inSubshell = false
+
   for (const line of lines.slice(start + 1)) {
     if (!line.startsWith('\t')) break
-    const step = line.slice(1).trim()
+    const text = line.slice(1).replace(/\\$/, '').trim()
+
+    if (!inSubshell) {
+      if (text.endsWith('(')) inSubshell = true
+      continue
+    }
+    if (text.startsWith(');')) break
+
+    const step = text.replace(/\s*&&$/, '')
+    expect(step).not.toMatch(/\|\|\s*true|^-|;\s*$/)
     if (step.length > 0 && !step.startsWith('#')) recipe.push(step)
   }
+
   return recipe
 }
 
@@ -65,10 +90,63 @@ describe('make verify runs from a clean checkout', () => {
     expect(recipe[0]).toBe('bun install --frozen-lockfile')
   })
 
+  test('records the run whether it passed or failed', async () => {
+    // The attestation is the reason the steps moved into a subshell. Written
+    // only on the passing path it would describe the case nobody needs evidence
+    // for, and the recipe must still exit with the status it captured.
+    const makefile = await readRoot('Makefile')
+
+    expect(makefile).toContain('scripts/write-attestation.ts begin')
+    expect(makefile).toContain('scripts/write-attestation.ts finish $$status')
+    expect(makefile).toContain('exit $$status')
+  })
+
   test('keeps every step it had before, in the same order', async () => {
     const recipe = await verifyRecipe()
 
     expect(recipe.slice(1)).toEqual([...REQUIRED_STEPS])
+  })
+
+  test('keeps its operational output out of version control', async () => {
+    const ignored = await $`git check-ignore .verification/attestation.json`
+      .cwd(ROOT)
+      .nothrow()
+      .quiet()
+
+    expect(ignored.exitCode).toBe(0)
+  })
+})
+
+describe('the verification attestation is repository tooling, not product', () => {
+  test('no shipped source reaches into the writer', async () => {
+    // The attestation records this repository's engineering process. A product
+    // file importing it would put a process concern behind a published schema
+    // version, which is the reason it is not an evidence receipt. ADR-0026.
+    const sources = await readdir(join(ROOT, 'src'), { recursive: true, withFileTypes: true })
+
+    const offenders: string[] = []
+    for (const entry of sources) {
+      if (!entry.isFile()) continue
+      if (!/\.(ts|tsx|mts|cts|js|mjs|cjs|json)$/.test(entry.name)) continue
+      const path = join(entry.parentPath, entry.name)
+      const source = await readFile(path, 'utf8')
+      if (/verification-attestation|write-attestation/.test(source)) {
+        offenders.push(path.slice(ROOT.length + 1))
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  test('the published package does not carry it', async () => {
+    const manifest = JSON.parse(await readRoot('package.json')) as { files?: string[] }
+    const published = manifest.files ?? []
+
+    // One `scripts/` entry is published on purpose: the postinstall Bun check.
+    expect(published.filter((entry) => entry.startsWith('scripts/'))).toEqual([
+      'scripts/postinstall-check-bun.mjs',
+    ])
+    expect(published.filter((entry) => entry.includes('.verification'))).toEqual([])
   })
 })
 

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -82,9 +82,10 @@ interface Recipe {
  * line that is neither prologue, step, nor epilogue has nowhere to hide, which
  * is the property the earlier version lacked.
  */
-const verifyRecipe = async (): Promise<Recipe> => {
-  const makefile = await readRoot('Makefile')
-  const lines = makefile.split('\n')
+const parseVerifyRecipe = (makefile: string): Recipe => {
+  // Line endings are the checkout's, not the recipe's. A CRLF checkout makes
+  // every literal comparison below compare against a trailing `\r`.
+  const lines = makefile.replace(/\r\n/g, '\n').split('\n')
 
   // Make runs the *last* definition of a target; this check would otherwise
   // read the first and report on a recipe that never executes.
@@ -120,6 +121,8 @@ const verifyRecipe = async (): Promise<Recipe> => {
   return { prologue: recipe.slice(0, opening + 1), steps, epilogue: recipe.slice(closing) }
 }
 
+const verifyRecipe = async (): Promise<Recipe> => parseVerifyRecipe(await readRoot('Makefile'))
+
 describe('make verify runs from a clean checkout', () => {
   test('installs the pinned dependency set before any step that consumes it', async () => {
     const { steps } = await verifyRecipe()
@@ -140,6 +143,21 @@ describe('make verify runs from a clean checkout', () => {
 
     expect(prologue).toEqual([...PROLOGUE])
     expect(epilogue).toEqual([...EPILOGUE])
+  })
+
+  test('reads the same recipe however the checkout terminated its lines', async () => {
+    // GitHub's windows runner checks out with core.autocrlf=true and this
+    // repository pins no .gitattributes, so the Makefile arrives as CRLF. Every
+    // comparison in the parser is literal, and `verify:\r` starts with
+    // `verify:` without being equal to it: three tests here failed on
+    // windows-latest and on no other runner. The recipe's contract is its
+    // lines, never how a checkout chose to end them — asserted here because the
+    // platform that breaks it is the one nobody runs locally.
+    const makefile = await readRoot('Makefile')
+
+    expect(parseVerifyRecipe(makefile.replace(/\r?\n/g, '\r\n'))).toEqual(
+      parseVerifyRecipe(makefile)
+    )
   })
 
   test('stays POSIX, because make runs /bin/sh and CI runs dash', async () => {

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -181,6 +181,43 @@ describe('the verification attestation is repository tooling, not product', () =
     expect(offenders).toEqual([])
   })
 
+  test('no test can forge the artifact', async () => {
+    // A test that spawned the writer left a hash-valid PASS attestation for
+    // whatever HEAD was, produced by no verification at all — and `bun run test`
+    // is step 10 of 24, with the CI upload running `if: always()`. A job killed
+    // after step 10 would have published it. The environment read is a function
+    // over an argument for exactly this reason: the property is testable
+    // without anything running the writer.
+    const suites = await readdir(join(ROOT, 'tests'), { recursive: true, withFileTypes: true })
+
+    // Naming the writer is fine — this file pins the Makefile lines that call
+    // it. Running it is not, so what is looked for is a spawn: the mention with
+    // a process-starting call close enough above it to be the thing starting it.
+    // Assembled rather than written out, because a check for its own text finds
+    // itself: the previous version's regex literal was the only match.
+    const writer = ['write', 'attestation'].join('-')
+    const RUNS = new RegExp(
+      `(?:spawnSync|spawn|execFileSync|execSync|exec)\\b[\\s\\S]{0,400}?${writer}`
+    )
+
+    const offenders: string[] = []
+    for (const entry of suites) {
+      if (!entry.isFile() || !/\.ts$/.test(entry.name)) continue
+      const path = join(entry.parentPath, entry.name)
+      // Comments are stripped first, or this file's own explanation of what it
+      // looks for would be the thing it finds.
+      const source = (await readFile(path, 'utf8'))
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '')
+
+      if (RUNS.test(source) || new RegExp(`\\$\`[^\`]*${writer}`).test(source)) {
+        offenders.push(path.slice(ROOT.length + 1))
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
   test('the published package does not carry it', async () => {
     const manifest = JSON.parse(await readRoot('package.json')) as { files?: string[] }
     const published = manifest.files ?? []

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -90,6 +90,15 @@ const verifyRecipe = async (): Promise<Recipe> => {
   // read the first and report on a recipe that never executes.
   expect(lines.filter((line) => line.startsWith('verify:'))).toHaveLength(1)
 
+  // An `include` brings in definitions this file cannot see, and a later one
+  // replaces the target outright — reproduced: make ran the included recipe and
+  // exited 0 while all five scaffolding lines here still matched.
+  expect(lines.filter((line) => /^[-\s]*include\s/.test(line))).toEqual([])
+
+  // The target line itself, not just its prefix. `verify: sneak` runs `sneak`
+  // before the recipe, and nothing below would look at it.
+  expect(lines.filter((line) => line.startsWith('verify:'))[0]).toBe('verify:')
+
   const start = lines.findIndex((line) => line.startsWith('verify:'))
   const recipe: string[] = []
   for (const line of lines.slice(start + 1)) {

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -162,6 +162,32 @@ describe('parseAttestation', () => {
     expect(() => parseAttestation(text)).toThrow(/attestation_hash/)
   })
 
+  test('a flag stated as anything but a boolean is refused, not coerced', () => {
+    // `"yes"` used to rebuild as `false`, match its own hash, and be handed back
+    // with the worktree flag flipped: every other reader of that file saw a
+    // dirty worktree, this one saw a clean one and said nothing.
+    const document = JSON.parse(serialiseAttestation(buildAttestation(INPUT))) as Record<
+      string,
+      unknown
+    >
+    document.dirty_worktree = 'yes'
+
+    expect(() => parseAttestation(JSON.stringify(document))).toThrow(/dirty_worktree/)
+  })
+
+  test('a derived field edited under a legitimate hash is refused', () => {
+    // The two comparisons are not redundant. The hash catches an edit to a
+    // stated field; this catches the opposite forgery, where a derived field is
+    // edited and the original hash left in place, so the rebuild still matches.
+    const document = JSON.parse(serialiseAttestation(buildAttestation(INPUT))) as Record<
+      string,
+      unknown
+    >
+    document.result = 'FAIL'
+
+    expect(() => parseAttestation(JSON.stringify(document))).toThrow(/result or duration/)
+  })
+
   test('a field the schema does not define is refused', () => {
     const document = JSON.parse(serialiseAttestation(buildAttestation(INPUT))) as Record<
       string,

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -171,3 +171,83 @@ describe('parseAttestation', () => {
     expect(() => parseAttestation(JSON.stringify(document))).toThrow(/work_item/)
   })
 })
+
+/**
+ * The Security Fixture Matrix, run against the real writer.
+ *
+ * `buildAttestation` cannot leak an environment variable — it never reads one.
+ * The writer can, so the matrix is asserted where the risk is: spawn it with
+ * every payload the Story names present in its environment, then read what it
+ * actually wrote. It writes to the repository's gitignored `.verification/`,
+ * which every `make verify` run overwrites anyway.
+ */
+describe('the security fixture matrix', () => {
+  const REVISION = '980cc078b850f799615dce51b2993141b85c40c7'
+
+  const PAYLOADS = {
+    DBCLI_PASSWORD: 'hunter2',
+    GITHUB_TOKEN: 'ghp_000000000000000000000000000000000000',
+    // Not the literal `true` a CI provider usually sets: as a substring it is
+    // indistinguishable from the boolean the schema records, so it could not
+    // tell a copied value from a correctly derived one.
+    CI: 'azure-pipelines',
+    USER: 'carl',
+    HOSTNAME: 'carls-macbook-air.local',
+    PWD_PAYLOAD: '/Users/carl/Dev/CMG/Dbcli',
+    STDERR_PAYLOAD: 'error: connect ECONNREFUSED 127.0.0.1:5432',
+  } as const
+
+  const written = async (): Promise<string> => {
+    const root = new URL('../../../', import.meta.url).pathname
+    const spawned = Bun.spawnSync({
+      cmd: [
+        'bun',
+        'run',
+        'scripts/write-attestation.ts',
+        'finish',
+        '0',
+        REVISION,
+        'clean',
+        '2026-09-08T04:00:00.000Z',
+      ],
+      cwd: root,
+      env: {
+        ...process.env,
+        DBCLI_PASSWORD: PAYLOADS.DBCLI_PASSWORD,
+        GITHUB_TOKEN: PAYLOADS.GITHUB_TOKEN,
+        CI: PAYLOADS.CI,
+        USER: PAYLOADS.USER,
+        HOSTNAME: PAYLOADS.HOSTNAME,
+      },
+    })
+
+    expect(spawned.exitCode).toBe(0)
+    return Bun.file(`${root}.verification/attestation.json`).text()
+  }
+
+  test('no payload the Story names reaches the document', async () => {
+    const document = await written()
+
+    for (const payload of Object.values(PAYLOADS)) {
+      expect(document).not.toContain(payload)
+    }
+  })
+
+  test("CI's presence is recorded, its value is not", async () => {
+    const attestation = parseAttestation(await written())
+
+    expect(attestation.environment.ci).toBe(true)
+    expect(JSON.stringify(attestation)).not.toContain(PAYLOADS.CI)
+  })
+
+  test('the revision is preserved, because it is the one thing being attested', async () => {
+    expect(parseAttestation(await written()).revision).toBe(REVISION)
+  })
+
+  test('the document carries the twelve schema fields and nothing else', async () => {
+    const document = JSON.parse(await written()) as Record<string, unknown>
+
+    expect(Object.keys(document)).toHaveLength(12)
+    expect(Object.keys(document.environment as object)).toEqual(['os', 'arch', 'bun', 'ci'])
+  })
+})

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -20,7 +20,6 @@ import {
 const REVISION = '980cc078b850f799615dce51b2993141b85c40c7'
 
 const INPUT: AttestationInput = {
-  repository: 'CarlLee1983/dbcli',
   revision: REVISION,
   dirtyWorktree: false,
   command: 'make verify',
@@ -72,7 +71,6 @@ describe('buildAttestation', () => {
 
     expect(keys).toEqual([
       'schema_version',
-      'repository',
       'revision',
       'dirty_worktree',
       'command',
@@ -107,9 +105,6 @@ describe('buildAttestation', () => {
         environment: { ...INPUT.environment, bun: '1.3.10; rm -rf /' },
       })
     ).toThrow(/environment.bun/)
-    expect(() => buildAttestation({ ...INPUT, repository: '../../etc/passwd' })).toThrow(
-      /repository/
-    )
   })
 })
 

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A Verification Attestation states what one `make verify` run decided.
+ *
+ * Everything here runs on fixtures. The writer's own value — that a FAIL leaves
+ * a record bound to the revision it failed at — is not something a unit test can
+ * prove; what it can pin is that the document says only what the repository can
+ * verify for itself, and that it says it the same way twice.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  ATTESTATION_SCHEMA_VERSION,
+  buildAttestation,
+  parseAttestation,
+  serialiseAttestation,
+  type AttestationInput,
+} from '../../../scripts/lib/verification-attestation'
+
+const REVISION = '980cc078b850f799615dce51b2993141b85c40c7'
+
+const INPUT: AttestationInput = {
+  repository: 'CarlLee1983/dbcli',
+  revision: REVISION,
+  dirtyWorktree: false,
+  command: 'make verify',
+  exitCode: 0,
+  startedAt: '2026-09-08T04:00:00.000Z',
+  finishedAt: '2026-09-08T04:15:30.500Z',
+  environment: { os: 'darwin', arch: 'arm64', bun: '1.3.10', ci: false },
+}
+
+describe('buildAttestation', () => {
+  test('states the revision, the command and what happened', () => {
+    const attestation = buildAttestation(INPUT)
+
+    expect(attestation.schema_version).toBe(ATTESTATION_SCHEMA_VERSION)
+    expect(attestation.revision).toBe(REVISION)
+    expect(attestation.command).toBe('make verify')
+    expect(attestation.result).toBe('PASS')
+    expect(attestation.exit_code).toBe(0)
+    expect(attestation.duration_ms).toBe(930500)
+  })
+
+  test('a non-zero exit is a FAIL, and the code is kept', () => {
+    const attestation = buildAttestation({ ...INPUT, exitCode: 2 })
+
+    expect(attestation.result).toBe('FAIL')
+    expect(attestation.exit_code).toBe(2)
+  })
+
+  test('a dirty worktree is stated, not silently attributed to the commit', () => {
+    const attestation = buildAttestation({ ...INPUT, dirtyWorktree: true })
+
+    expect(attestation.dirty_worktree).toBe(true)
+    expect(attestation.revision).toBe(REVISION)
+  })
+
+  test('the hash is the identity of the content', () => {
+    const hash = buildAttestation(INPUT).attestation_hash
+
+    expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(buildAttestation(INPUT).attestation_hash).toBe(hash)
+    expect(buildAttestation({ ...INPUT, exitCode: 1 }).attestation_hash).not.toBe(hash)
+  })
+
+  test('nothing the repository cannot verify for itself gets in', () => {
+    // The schema is closed. A caller handing over a Work Item, a path or an
+    // environment dump has handed over a claim the producer cannot check, and a
+    // field that records whatever it was given records nothing.
+    const keys = Object.keys(buildAttestation(INPUT))
+
+    expect(keys).toEqual([
+      'schema_version',
+      'repository',
+      'revision',
+      'dirty_worktree',
+      'command',
+      'result',
+      'exit_code',
+      'started_at',
+      'finished_at',
+      'duration_ms',
+      'environment',
+      'attestation_hash',
+    ])
+    expect(Object.keys(buildAttestation(INPUT).environment)).toEqual(['os', 'arch', 'bun', 'ci'])
+  })
+
+  test('a revision that is not a full commit SHA is refused', () => {
+    expect(() => buildAttestation({ ...INPUT, revision: '980cc07' })).toThrow(/revision/)
+    expect(() => buildAttestation({ ...INPUT, revision: REVISION.toUpperCase() })).toThrow(
+      /revision/
+    )
+  })
+
+  test('a finish before its own start is refused rather than recorded as negative', () => {
+    expect(() => buildAttestation({ ...INPUT, finishedAt: '2026-09-08T03:00:00.000Z' })).toThrow(
+      /finished_at/
+    )
+  })
+
+  test('an unsafe value in a bounded field is refused', () => {
+    expect(() =>
+      buildAttestation({
+        ...INPUT,
+        environment: { ...INPUT.environment, bun: '1.3.10; rm -rf /' },
+      })
+    ).toThrow(/environment.bun/)
+    expect(() => buildAttestation({ ...INPUT, repository: '../../etc/passwd' })).toThrow(
+      /repository/
+    )
+  })
+})
+
+describe('serialiseAttestation', () => {
+  test('the same run serialises to the same bytes', () => {
+    expect(serialiseAttestation(buildAttestation(INPUT))).toBe(
+      serialiseAttestation(buildAttestation(INPUT))
+    )
+  })
+
+  test('keys are in the schema order, and the file ends in exactly one newline', () => {
+    const text = serialiseAttestation(buildAttestation(INPUT))
+
+    expect(text.endsWith('}\n')).toBe(true)
+    expect(text.endsWith('}\n\n')).toBe(false)
+    expect(text).not.toContain('\r')
+    expect(text.indexOf('"revision"')).toBeLessThan(text.indexOf('"command"'))
+  })
+})
+
+describe('parseAttestation', () => {
+  test('reads back what was written', () => {
+    const attestation = buildAttestation(INPUT)
+
+    expect(parseAttestation(serialiseAttestation(attestation))).toEqual(attestation)
+  })
+
+  test('a schema version it does not know is refused, not partially read', () => {
+    const text = serialiseAttestation(buildAttestation(INPUT)).replace(
+      '"schema_version": 1',
+      '"schema_version": 2'
+    )
+
+    expect(() => parseAttestation(text)).toThrow(/schema_version/)
+  })
+
+  test('a missing required field is refused, naming the field', () => {
+    const document = JSON.parse(serialiseAttestation(buildAttestation(INPUT))) as Record<
+      string,
+      unknown
+    >
+    delete document.revision
+
+    expect(() => parseAttestation(JSON.stringify(document))).toThrow(/revision/)
+  })
+
+  test('a hash that does not match the content is refused', () => {
+    const text = serialiseAttestation(buildAttestation(INPUT)).replace(REVISION, 'a'.repeat(40))
+
+    expect(() => parseAttestation(text)).toThrow(/attestation_hash/)
+  })
+
+  test('a field the schema does not define is refused', () => {
+    const document = JSON.parse(serialiseAttestation(buildAttestation(INPUT))) as Record<
+      string,
+      unknown
+    >
+    document.work_item = 'WI-004'
+
+    expect(() => parseAttestation(JSON.stringify(document))).toThrow(/work_item/)
+  })
+})

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -12,6 +12,7 @@ import {
   ATTESTATION_SCHEMA_VERSION,
   buildAttestation,
   parseAttestation,
+  readEnvironment,
   serialiseAttestation,
   type AttestationInput,
 } from '../../../scripts/lib/verification-attestation'
@@ -173,81 +174,74 @@ describe('parseAttestation', () => {
 })
 
 /**
- * The Security Fixture Matrix, run against the real writer.
+ * The Security Fixture Matrix.
  *
- * `buildAttestation` cannot leak an environment variable — it never reads one.
- * The writer can, so the matrix is asserted where the risk is: spawn it with
- * every payload the Story names present in its environment, then read what it
- * actually wrote. It writes to the repository's gitignored `.verification/`,
- * which every `make verify` run overwrites anyway.
+ * An earlier version of this suite spawned the real writer, which wrote to the
+ * repository's canonical `.verification/attestation.json`. That produced a
+ * hash-valid PASS attestation for whatever HEAD happened to be, from a test run
+ * rather than a verification — and in CI, where `bun run test` is step 10 of 24
+ * and the upload step runs `if: always()`, a job killed after step 10 would
+ * have published it. A test that can forge the artifact it is testing is worse
+ * than no test.
+ *
+ * So the environment read is a function over an argument now, and the matrix is
+ * asserted by handing it every payload the Story names. Nothing spawns and
+ * nothing is written, which is also what makes it safe on a runner whose
+ * checkout path contains a space, a non-ASCII character, or a drive letter.
  */
 describe('the security fixture matrix', () => {
-  const REVISION = '980cc078b850f799615dce51b2993141b85c40c7'
-
   const PAYLOADS = {
     DBCLI_PASSWORD: 'hunter2',
     GITHUB_TOKEN: 'ghp_000000000000000000000000000000000000',
-    // Not the literal `true` a CI provider usually sets: as a substring it is
-    // indistinguishable from the boolean the schema records, so it could not
-    // tell a copied value from a correctly derived one.
+    // Deliberately not the literal `true` most providers set: as a substring
+    // that is indistinguishable from the boolean the schema records, so it
+    // could not tell a copied value from a correctly derived one.
     CI: 'azure-pipelines',
     USER: 'carl',
     HOSTNAME: 'carls-macbook-air.local',
-    PWD_PAYLOAD: '/Users/carl/Dev/CMG/Dbcli',
-    STDERR_PAYLOAD: 'error: connect ECONNREFUSED 127.0.0.1:5432',
+    PWD: '/Users/carl/Dev/CMG/Dbcli',
+    npm_lifecycle_script: 'error: connect ECONNREFUSED 127.0.0.1:5432',
   } as const
 
-  const written = async (): Promise<string> => {
-    const root = new URL('../../../', import.meta.url).pathname
-    const spawned = Bun.spawnSync({
-      cmd: [
-        'bun',
-        'run',
-        'scripts/write-attestation.ts',
-        'finish',
-        '0',
-        REVISION,
-        'clean',
-        '2026-09-08T04:00:00.000Z',
-      ],
-      cwd: root,
-      env: {
-        ...process.env,
-        DBCLI_PASSWORD: PAYLOADS.DBCLI_PASSWORD,
-        GITHUB_TOKEN: PAYLOADS.GITHUB_TOKEN,
-        CI: PAYLOADS.CI,
-        USER: PAYLOADS.USER,
-        HOSTNAME: PAYLOADS.HOSTNAME,
-      },
+  const hostile = () =>
+    buildAttestation({
+      ...INPUT,
+      environment: readEnvironment({
+        env: PAYLOADS,
+        platform: 'linux',
+        arch: 'x64',
+        bun: '1.3.10',
+      }),
     })
 
-    expect(spawned.exitCode).toBe(0)
-    return Bun.file(`${root}.verification/attestation.json`).text()
-  }
-
-  test('no payload the Story names reaches the document', async () => {
-    const document = await written()
+  test('no payload the Story names reaches the document', () => {
+    const document = serialiseAttestation(hostile())
 
     for (const payload of Object.values(PAYLOADS)) {
       expect(document).not.toContain(payload)
     }
   })
 
-  test("CI's presence is recorded, its value is not", async () => {
-    const attestation = parseAttestation(await written())
-
-    expect(attestation.environment.ci).toBe(true)
-    expect(JSON.stringify(attestation)).not.toContain(PAYLOADS.CI)
+  test("CI's presence is recorded, its value is not", () => {
+    expect(hostile().environment.ci).toBe(true)
   })
 
-  test('the revision is preserved, because it is the one thing being attested', async () => {
-    expect(parseAttestation(await written()).revision).toBe(REVISION)
+  test('an absent CI is recorded as absent, not guessed', () => {
+    const environment = readEnvironment({
+      env: {},
+      platform: 'darwin',
+      arch: 'arm64',
+      bun: '1.3.10',
+    })
+
+    expect(environment.ci).toBe(false)
   })
 
-  test('the document carries the twelve schema fields and nothing else', async () => {
-    const document = JSON.parse(await written()) as Record<string, unknown>
+  test('the environment description carries four fields and nothing else', () => {
+    expect(Object.keys(hostile().environment)).toEqual(['os', 'arch', 'bun', 'ci'])
+  })
 
-    expect(Object.keys(document)).toHaveLength(12)
-    expect(Object.keys(document.environment as object)).toEqual(['os', 'arch', 'bun', 'ci'])
+  test('the revision is preserved, because it is the one thing being attested', () => {
+    expect(hostile().revision).toBe(REVISION)
   })
 })


### PR DESCRIPTION
`make verify` 現在自己寫出一份 Verification Attestation：一個 revision、一個指令、一個結果，PASS 與 FAIL 都寫，落在 gitignored 的 `.verification/attestation.json`，CI 以 `if: always()` 上傳。

## 為什麼不是等 ForgePilot

驗證證據在此之前只存在 `.forgepilot/state.json`，而且只存在跑它的那台機器上。那個檔案刻意 gitignored：commit 進去會弄髒下一次驗證要求乾淨的工作樹，而「記下結果」本身要一個 commit，那個 commit 會立刻讓被記下的結果失效。DBCLI-016 的交付報告只能寫「Evidence ID 刻意不抄在這裡」，就是撞到這件事。

顯而易見的設計是 `forgepilot evidence export`。**它不存在**：ForgePilot 在 `8ce2c12` 的指令是 init／migrate／goal／work／next／start／verify／gate／review／status，development plan 也沒有 export 的規劃。等它等於把交付綁在另一個 repo 的行程上；直接讀 `state.json` 則是綁上它的內部格式，那是 DBCLI-014 畫掉的界線。`make verify` 是 ForgePilot 固定執行的指令，也是唯一第一手看到結果的參與者，所以由 repository 自己寫、別人事後讀檔案。整合介面是一個路徑加一個版本化 schema，誰都不 import 誰。

## 為什麼不叫 Evidence Receipt

那個詞在這個 repo 已經被佔用，而且指的是完全不同的東西：`src/core/evidence-receipt/` 是**產品**，記 dbcli 對資料庫的一次操作，會出貨、有發布的 schema 版本；`src/core/verification/` 的 Verification Artifact 同理。這份記的是一個 commit，讀的人是審查者或 CI。塞進任一個等於為了使用者看不見的理由動一個已發布的版本號，還把流程工具出貨給只想連資料庫的人。新詞是 Verification Attestation（`attestation` 在 dbcli 與 ForgePilot 都沒被用過），進了 `CONTEXT.md`，邊界與失效條件在 ADR-0026。

## 文件刻意不說的事

沒有 `work_item`、沒有 `story`、沒有 `repository`。前兩個 `make verify` 不知道，只能由呼叫端傳進來；第三個原本是寫死的常數，通過了 regex、從來沒被觀察過。三者失敗於同一條標準——**產生者查不了的欄位，記下來的只是它被交了什麼**——差別只在「呼叫時交給你」與「撰寫時就填好」。`repository` 沒有改成從 `git remote get-url origin` 推導，那樣更糟：remote URL 可以帶憑證。commit SHA 本來就不需要別人幫忙識別主體。

也沒有 staleness：那題每次問答案都不同，一份自己回答它的檔案在寫完的下一刻就是錯的。

## FAIL 也要留紀錄

`make` 在第一個失敗的 step 就停，所以寫在最後一行的 attestation 只會描述通過的那次——最不需要證據的那次。24 個 step 現在包在一個 subshell 裡以 `&&` 串接，捕捉狀態、寫檔、再以同一個狀態 exit。每個 step 都還在、順序沒動、都還是阻斷性的。兩個階段都不准決定 verdict（`|| run=''` 與 `|| true`），四種情況實測過。

## Review 找到的東西

兩份獨立 review 共提 11 條。1 條我實測後反駁、reviewer 撤回，其餘全數處理。三條值得單獨講：

**測試會偽造 attestation。** Security Fixture Matrix 的第一版 spawn 真正的 writer，而 writer 寫的是 canonical 路徑，於是每跑一次 `bun test` 就留下一份 hash 正確、`result: PASS`、綁著當時 HEAD 的文件——沒有任何驗證跑過。`bun run test` 是 24 個 step 裡的第 10 個，`integration` job 逾時或取消時 `finish` 不會跑，`if: always()` 會把測試寫的那份當成這次的結果送上去。修法是讓那個性質不需要跑 writer 就能測：環境讀取抽成 `readEnvironment(source)`，它對 `env` 做的唯一一件事是問 `CI` 在不在。

**`set -o pipefail` 讓 CI 上的 gate 每次都死。** GNU Make 忽略環境的 `SHELL` 直接用 `/bin/sh`，`integration` job 的 ubuntu runner 上是 dash——`ubuntu:24.04` 與 `22.04` 實測都回 `set: Illegal option -o pipefail` 並以 exit 2 中止，24 個 step 一個都不會跑，而且失敗看起來像驗證失敗。本機測不出來，因為 macOS 的 `/bin/sh` 是 bash。（順帶：`debian:stable-slim` 的 dash 接受它，拿 Debian 測會得到假結論。）沒有任何 step 有 pipe，所以直接刪掉。

**roster parser 有九種寫法能一邊維持綠燈一邊把 gate 掏空**：recipe 行前面加 `-`、`exit $status` 換成 `exit 0`、在開括號那行或閉括號之後夾帶指令、再定義一次 `verify:`、`trap 'exit 0' EXIT`、`include` 一行換掉整個 target、`verify: sneak` 塞一個 prerequisite。共同成因是 parser 只讀 subshell 裡面那一半。現在 prologue 與 epilogue 五行逐字比對、`verify:` 只准出現一次且必須剛好等於 `verify:`、不准有 `include`。九種寫法逐一改進真的 Makefile 跑真的 test，全部會紅。

## Test plan

- `bun test tests/unit/scripts/verification-attestation.test.ts` — 22 pass，含 Security Fixture Matrix 八列與兩種偽造情境
- `bun test tests/contract/forgepilot-boundary.test.ts` — 11 pass，`REQUIRED_STEPS` roster 一字未改
- `make verify`：ForgePilot 在 `284b5211a19fa8d0d8dcc85995c3692d429f7809` 的 detached worktree 執行，**PASS**，evidence `EV-012`，與本 PR HEAD 同一個 commit
- FAIL／不可寫輸出／`git` 壞掉／PASS 四條路徑逐一實測，exit code 在每一條都不受 attestation 影響
- typecheck / typecheck:tests / lint / format:check / forgeflow:check 全過

## 已知限制與未修項

**ForgePilot 本機執行的 attestation 會消失。** `forgepilot verify` 在 detached worktree 裡跑，`.verification/` 跟著 worktree 一起被清掉——剛才那次 PASS 的文件已經不在了。CI 的上傳不受影響，那也是驗收指定的可攜性證據。要讓本機執行也留得住，得由 ForgePilot 把檔案複製出來，那是它的改動，不在本 Story 範圍。這一條是觀察真實執行才發現的，尚未寫進 handoff，避免為了一行文件再花一輪 15 分鐘驗證。

**逐步 echo 沒了。** 24 個 step 併成一行後 make 不再逐步 echo，CI log 不會說失敗時正在跑哪一個檢查。逐步 echo 加計時是 DBCLI-019 的題目，已記進 `Makefile` 註解與 story 的 Known Cost，讓那個 Story 繼承一個已知成本。reviewer 同意這是正確的 scope 判斷。

## Merge 前

需要 Human Review。ADR-0026 是 `status: proposed`，那個邊界決定歸人。

Story: DBCLI-017

https://claude.ai/code/session_016ergjTN99kDPMngzfquBBw
