### PR TITLE
DBCLI-018: 升級到 ForgeFlow 0.6.0，並讓那份契約真的被檢查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,10 @@ jobs:
           revision="$(sed -n 's/^revision=//p' specs/.forgeflow-adoption)"
           git clone --quiet https://github.com/CarlLee1983/ForgeFlowV2.git "$RUNNER_TEMP/forgeflow"
           git -C "$RUNNER_TEMP/forgeflow" checkout --quiet "$revision"
+      # No `bun install` on purpose, and it is an invariant rather than an
+      # omission: the gate imports only `bun`, `node:path` and `node:url`. Give
+      # it a dependency and this job starts failing with a module resolution
+      # error that looks nothing like its cause.
       - name: ForgeFlow contract
         run: FORGEFLOW_ROOT="$RUNNER_TEMP/forgeflow" bun run forgeflow:contract
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,32 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.test.yml down -v
 
+  forgeflow-contract:
+    # Upstream ForgeFlow's own checkers, run against this repository's Stories.
+    #
+    # Not a `make verify` step: it needs a second checkout, and the canonical
+    # gate has to run from a clone of this repository alone. The two offline
+    # ForgeFlow gates stay inside `make verify` — they check what this
+    # repository says about itself, where this job checks it against the rules
+    # this repository declared it adopted.
+    #
+    # The revision comes from `specs/.forgeflow-adoption` and the gate refuses a
+    # checkout at any other one, so an upgrade cannot land half-done with the
+    # marker moved and the rules still the old ones.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: ForgeFlow at the adopted revision
+        run: |
+          revision="$(sed -n 's/^revision=//p' specs/.forgeflow-adoption)"
+          git clone --quiet https://github.com/CarlLee1983/ForgeFlowV2.git "$RUNNER_TEMP/forgeflow"
+          git -C "$RUNNER_TEMP/forgeflow" checkout --quiet "$revision"
+      - name: ForgeFlow contract
+        run: FORGEFLOW_ROOT="$RUNNER_TEMP/forgeflow" bun run forgeflow:contract
+
   docs-parity:
     # Drift guards: fail the build when the CLI, SKILL.md, reference.md, managed
     # platform copies, or user docs fall out of sync. Runs once (not per matrix).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,15 @@ repository-local `story-development` Skill and:
 5. Repair failures without changing the Story or weakening acceptance criteria,
    and rerun the gate until it passes.
 
+A Story may now declare `## Authority`, `## Risk`, `## Architecture` and a
+`Task mode:` bullet, and its acceptance may carry an `## Acceptance Evidence`
+map — ForgeFlow 0.6.0, all optional, all in `specs/stories/_template/`. They are
+checked by upstream's own checkers, which CI runs as the `forgeflow-contract`
+job against the revision `specs/.forgeflow-adoption` pins; `make verify` stays
+offline and does not run them. Authority is per-permission and nothing implies
+anything else: `modify` does not grant `commit`, and `commit` does not grant
+`push`.
+
 `make verify` is the automated completion authority. PASS makes work eligible
 for human review; it does not approve or merge it. Do not bypass repository
 verification, remove failing tests to obtain PASS, or expand Story scope without

--- a/docs/adr/0027-upstream-forgeflow-checkers-are-run-not-reimplemented.md
+++ b/docs/adr/0027-upstream-forgeflow-checkers-are-run-not-reimplemented.md
@@ -6,12 +6,23 @@ date: 2026-09-08
 # Upstream ForgeFlow's checkers are run, not reimplemented
 
 DBCLI-018 moved the adopted contract from 0.3.2 to 0.6.0, which brings
-Authority, Risk, Task mode and an Acceptance Evidence map. Every one of them is
-enforced by an upstream checker and by nothing else, and those checkers live in
-a ForgeFlow checkout this repository does not contain. So the version bump on
-its own would have changed what a Story is permitted to say and nothing about
-what is checked — an adoption that exists only as a number, which is the shape
-DBCLI-013 and DBCLI-016 each had to close after the fact.
+Authority, Risk, Task mode and an Acceptance Evidence map. Each is enforced by
+an upstream checker and by nothing else, and those checkers live in a ForgeFlow
+checkout this repository does not contain. So the version bump on its own would
+have changed what a Story is permitted to say and nothing about what is checked
+— an adoption that exists only as a number, which is the shape DBCLI-013 and
+DBCLI-016 each had to close after the fact.
+
+One of the four is not closed by this decision, and saying so is the point of
+this paragraph. Authority, Risk and Task mode are checked in `story-check`'s
+default mode, which is the mode CI runs. The Acceptance Evidence map is a
+readiness check: it runs only under `story-check --ready`, along with checkbox
+AC identifiers, Goal and Scope. This gate does not pass `--ready`, so Acceptance
+Evidence is available to authors and enforced by nobody — including in
+DBCLI-018's own Story, which fails `--ready` on exactly those two findings.
+Turning `--ready` on is a decision about every future Story and a second
+exemption set for the twenty-five that predate it; it is named out of scope in
+the Story rather than left to be discovered.
 
 Two ways to close it. Reimplement the rules in `scripts/`, offline, inside
 `make verify` — the shape of every other gate here. Or fetch the adopted

--- a/docs/adr/0027-upstream-forgeflow-checkers-are-run-not-reimplemented.md
+++ b/docs/adr/0027-upstream-forgeflow-checkers-are-run-not-reimplemented.md
@@ -1,0 +1,60 @@
+---
+status: proposed
+date: 2026-09-08
+---
+
+# Upstream ForgeFlow's checkers are run, not reimplemented
+
+DBCLI-018 moved the adopted contract from 0.3.2 to 0.6.0, which brings
+Authority, Risk, Task mode and an Acceptance Evidence map. Every one of them is
+enforced by an upstream checker and by nothing else, and those checkers live in
+a ForgeFlow checkout this repository does not contain. So the version bump on
+its own would have changed what a Story is permitted to say and nothing about
+what is checked — an adoption that exists only as a number, which is the shape
+DBCLI-013 and DBCLI-016 each had to close after the fact.
+
+Two ways to close it. Reimplement the rules in `scripts/`, offline, inside
+`make verify` — the shape of every other gate here. Or fetch the adopted
+revision in CI and run upstream's own checkers.
+
+Reimplementation was refused. `scripts/lib/forgeflow-handoff.ts` states in its
+header that it "deliberately does not overlap upstream's `story-check`", and
+that boundary is why the two gates have stayed small and stayed true: one checks
+what this repository claims about itself, the other checks structure. Writing a
+second implementation of a contract this repository does not own would put those
+two on diverging schedules, and the copy would be the one nobody updates.
+
+So CI clones ForgeFlow at the revision `specs/.forgeflow-adoption` records and
+runs `story-check` and `handoff-check` through
+`scripts/check-forgeflow-contract.ts`. The revision is part of the check: a
+checkout at any other one is refused, because a different ForgeFlow enforces a
+different contract, and because an upgrade must not be able to land half-done
+with the marker moved and the rules still the old ones. An absent checkout is
+refused rather than skipped, for the reason the sibling gate refuses a shallow
+clone — a gate that passes wherever its evidence is missing passes in CI and
+nowhere else.
+
+It is a CI job and not a `make verify` step. The canonical gate has to run from
+a clone of this repository alone, and it has to run offline; a step that needs a
+second checkout and a network fetch would make `make verify` describe a machine
+rather than a checkout. The two offline ForgeFlow gates stay where they are.
+
+## The twenty-one admitted findings
+
+Five delivered Stories fail upstream `story-check`, on findings that failed
+identically under 0.3.2 — the upgrade caused none of them, and nothing had ever
+run the checker. They are listed exactly, per Story, as a ratchet that may
+shrink and never grow: a new finding fails, a fixed one fails as a stale entry,
+and any Story without an entry must be clean.
+
+Listing them rather than fixing them is deliberate. Sixteen are matrix cells
+whose real values have to be re-derived from the code they describe, and all of
+them are edits to acceptance text a human already accepted — a change to the
+record, not a formatting pass. That is its own Story. What this decision buys is
+that the debt is bounded and visible instead of unknown.
+
+**Falsified if:** the exemption list grows, or a rule from upstream's contract
+is reimplemented in `scripts/` rather than run from a checkout. The first means
+the gate has become a list of things it has agreed not to check; the second
+means there are two answers to what a Story must contain, and the repository has
+started maintaining the one it does not own.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "core-stdout:check": "bun run scripts/check-core-no-stdout.ts",
     "plan:check": "bun run scripts/check-plan-acceptance.ts",
     "forgeflow:check": "bun run scripts/check-forgeflow-adoption.ts && bun run scripts/check-forgeflow-handoff.ts",
+    "forgeflow:contract": "bun run scripts/check-forgeflow-contract.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:tests": "tsc --noEmit --pretty false -p tsconfig.tests.json",
     "test:perf": "bun test ./tests/perf/*.bench.ts",

--- a/scripts/check-forgeflow-contract.ts
+++ b/scripts/check-forgeflow-contract.ts
@@ -20,6 +20,7 @@ import {
   checkoutRefusal,
   formatContractFailures,
   PREDATING_FINDINGS,
+  readCheckerRun,
   reconcileFindings,
   type StoryResult,
 } from './lib/forgeflow-contract'
@@ -51,6 +52,19 @@ if (refusal !== null) {
   process.exit(1)
 }
 
+/** Refuse rather than continue: an unusable run says nothing about any Story. */
+function refuse(reason: string): never {
+  console.error(`ForgeFlow contract check cannot run: ${reason}`)
+  process.exit(1)
+}
+
+// A checkout at the right revision can still be unusable — a partial clone, a
+// non-executable script. Bun's `.nothrow()` swallows the spawn failure and
+// hands back zero findings for every Story, which reads exactly like a clean
+// repository.
+const storyCheck = join(checkout as string, 'scripts/story-check')
+if (!(await Bun.file(storyCheck).exists())) refuse(`${storyCheck} does not exist`)
+
 const storiesRoot = join(repoRoot, 'specs/stories')
 const directories = (await Array.fromAsync(new Bun.Glob('*/story.md').scan({ cwd: storiesRoot })))
   .map((entry) => entry.replace(/[/\\]story\.md$/, ''))
@@ -60,17 +74,18 @@ const directories = (await Array.fromAsync(new Bun.Glob('*/story.md').scan({ cwd
 const results: StoryResult[] = []
 for (const directory of directories) {
   const path = join(storiesRoot, directory)
-  const checked = await $`${join(checkout as string, 'scripts/story-check')} ${path}`
-    .nothrow()
-    .quiet()
+  const checked = await $`${storyCheck} ${path}`.nothrow().quiet()
 
-  const output = `${checked.stdout.toString()}${checked.stderr.toString()}`
+  const read = readCheckerRun(directory, {
+    exitCode: checked.exitCode,
+    output: `${checked.stdout.toString()}${checked.stderr.toString()}`,
+  })
+
+  if (typeof read === 'string') refuse(read)
+
   results.push({
     story: directory,
-    findings: output
-      .split('\n')
-      .filter((line) => line.startsWith('FAIL'))
-      .map((line) => line.replace(`FAIL  ${path}: `, '').trim()),
+    findings: read.map((line) => line.replace(`FAIL  ${path}: `, '').trim()),
   })
 }
 
@@ -84,11 +99,18 @@ const handoff =
     .nothrow()
     .quiet()
 
-if (handoff.exitCode !== 0) {
-  const output = `${handoff.stdout.toString()}${handoff.stderr.toString()}`
-  for (const line of output.split('\n').filter((entry) => entry.startsWith('FAIL'))) {
-    failures.push({ subject: 'specs/handoff.md', reason: line.replace(/^FAIL\s+/, '') })
-  }
+const handoffRead = readCheckerRun('specs/handoff.md', {
+  exitCode: handoff.exitCode,
+  output: `${handoff.stdout.toString()}${handoff.stderr.toString()}`,
+})
+
+// A deleted, emptied or unreadable handoff exits non-zero with no FAIL lines —
+// the states the handoff contract exists to prevent — and used to be reported
+// as "handoff contract OK".
+if (typeof handoffRead === 'string') refuse(handoffRead)
+
+for (const line of handoffRead) {
+  failures.push({ subject: 'specs/handoff.md', reason: line.replace(/^FAIL\s+/, '') })
 }
 
 if (failures.length > 0) {

--- a/scripts/check-forgeflow-contract.ts
+++ b/scripts/check-forgeflow-contract.ts
@@ -19,73 +19,12 @@ import { fileURLToPath } from 'node:url'
 import {
   checkoutRefusal,
   formatContractFailures,
+  PREDATING_FINDINGS,
   reconcileFindings,
-  type Exemptions,
   type StoryResult,
 } from './lib/forgeflow-contract'
 
 const repoRoot = fileURLToPath(new URL('../', import.meta.url))
-
-/**
- * Findings that predate this gate, exactly as upstream `story-check` states
- * them.
- *
- * All twenty-one failed identically under 0.3.2; the upgrade did not cause one
- * of them. They are three kinds of wording — a trust-boundary field written as
- * prose, a security fixture cell written as prose instead of an exact value in
- * backticks, and one Story whose Classification contradicts its own Superseded
- * Behavior section. Fixing them means re-deriving sixteen matrix cells from the
- * code they describe and editing acceptance text a human already accepted, so
- * it is its own Story rather than a paragraph of this one.
- *
- * A ratchet: entries may be deleted and never added.
- */
-const PREDATING_FINDINGS: Exemptions = new Map([
-  [
-    'DBCLI-PLAT-004-operation-envelope-v1',
-    ['every trust-boundary field must name an exact field, not prose'],
-  ],
-  [
-    'DBCLI-PLAT-005-agent-json-mode',
-    [
-      'every trust-boundary field must name an exact field, not prose',
-      'Story declares Baseline conformance: no but declares superseded behavior',
-    ],
-  ],
-  [
-    'DBCLI-PLAT-006-correlation-id',
-    [
-      'security fixture row 1 states verification as prose instead of an exact value',
-      'security fixture row 2 states verification as prose instead of an exact value',
-      'security fixture row 3 states verification as prose instead of an exact value',
-      'security fixture row 4 states verification as prose instead of an exact value',
-      'security fixture row 5 states verification as prose instead of an exact value',
-      'security fixture row 6 states verification as prose instead of an exact value',
-    ],
-  ],
-  [
-    'DBCLI-PLAT-007-bounded-evidence-receipts',
-    [
-      'security fixture row 1 states source field as prose instead of an exact value',
-      'security fixture row 2 states source field as prose instead of an exact value',
-      'security fixture row 3 states source field as prose instead of an exact value',
-      'security fixture row 4 states source field as prose instead of an exact value',
-      'security fixture row 5 states source field as prose instead of an exact value',
-      'security fixture row 6 states source field as prose instead of an exact value',
-      'security fixture row 7 states source field as prose instead of an exact value',
-      'security fixture row 8 states source field as prose instead of an exact value',
-      'every trust-boundary field must name an exact field, not prose',
-    ],
-  ],
-  [
-    'DBCLI-PLAT-012-schema-cache-write-boundary',
-    [
-      'security fixture row 10 states source field as prose instead of an exact value',
-      'security fixture row 10 states persisted locations as prose instead of an exact value',
-      'every trust-boundary field must name an exact field, not prose',
-    ],
-  ],
-])
 
 const adopted = (await Bun.file(join(repoRoot, 'specs/.forgeflow-adoption')).text())
   .split('\n')

--- a/scripts/check-forgeflow-contract.ts
+++ b/scripts/check-forgeflow-contract.ts
@@ -20,9 +20,9 @@ import {
   checkoutRefusal,
   formatContractFailures,
   PREDATING_FINDINGS,
+  parseStoryCheck,
   readCheckerRun,
   reconcileFindings,
-  type StoryResult,
 } from './lib/forgeflow-contract'
 
 const repoRoot = fileURLToPath(new URL('../', import.meta.url))
@@ -39,14 +39,23 @@ if (adopted === undefined) {
 }
 
 const forgeflowRoot = process.env.FORGEFLOW_ROOT
-const checkout = forgeflowRoot === undefined ? undefined : forgeflowRoot
 
-const revision =
-  checkout === undefined
-    ? undefined
-    : (await $`git -C ${checkout} rev-parse HEAD`.nothrow().quiet()).text().trim() || undefined
+/** Ask git a question of the checkout, or report that it could not answer. */
+async function ask(root: string, ...argv: string[]): Promise<string | undefined> {
+  const answered = await $`git -C ${root} ${argv}`.nothrow().quiet()
+  return answered.exitCode === 0 ? answered.text() : undefined
+}
 
-const refusal = checkoutRefusal(adopted, revision)
+const refusal = checkoutRefusal(adopted, {
+  root: forgeflowRoot,
+  revision:
+    forgeflowRoot === undefined
+      ? undefined
+      : (await ask(forgeflowRoot, 'rev-parse', 'HEAD'))?.trim(),
+  status:
+    forgeflowRoot === undefined ? undefined : await ask(forgeflowRoot, 'status', '--porcelain'),
+})
+
 if (refusal !== null) {
   console.error(refusal)
   process.exit(1)
@@ -58,36 +67,23 @@ function refuse(reason: string): never {
   process.exit(1)
 }
 
-// A checkout at the right revision can still be unusable — a partial clone, a
-// non-executable script. Bun's `.nothrow()` swallows the spawn failure and
-// hands back zero findings for every Story, which reads exactly like a clean
-// repository.
-const storyCheck = join(checkout as string, 'scripts/story-check')
+const checkout = forgeflowRoot as string
+const storyCheck = join(checkout, 'scripts/story-check')
 if (!(await Bun.file(storyCheck).exists())) refuse(`${storyCheck} does not exist`)
 
-const storiesRoot = join(repoRoot, 'specs/stories')
-const directories = (await Array.fromAsync(new Bun.Glob('*/story.md').scan({ cwd: storiesRoot })))
-  .map((entry) => entry.replace(/[/\\]story\.md$/, ''))
-  .filter((directory) => !directory.startsWith('_'))
-  .sort()
+// One run, with no arguments, from the repository root: upstream discovers the
+// Story directories itself. Globbing for them here was directory selection
+// reimplemented, and it hid a directory holding an `acceptance.md` and no
+// `story.md` — upstream ERRORs on that; the glob simply did not see it.
+const checked = await $`${storyCheck}`.cwd(repoRoot).nothrow().quiet()
+const read = readCheckerRun('specs/stories', {
+  exitCode: checked.exitCode,
+  output: `${checked.stdout.toString()}${checked.stderr.toString()}`,
+})
 
-const results: StoryResult[] = []
-for (const directory of directories) {
-  const path = join(storiesRoot, directory)
-  const checked = await $`${storyCheck} ${path}`.nothrow().quiet()
+if (typeof read === 'string') refuse(read)
 
-  const read = readCheckerRun(directory, {
-    exitCode: checked.exitCode,
-    output: `${checked.stdout.toString()}${checked.stderr.toString()}`,
-  })
-
-  if (typeof read === 'string') refuse(read)
-
-  results.push({
-    story: directory,
-    findings: read.map((line) => line.replace(`FAIL  ${path}: `, '').trim()),
-  })
-}
+const results = parseStoryCheck(`${checked.stdout.toString()}${checked.stderr.toString()}`)
 
 const failures = reconcileFindings(results, PREDATING_FINDINGS)
 
@@ -95,7 +91,7 @@ const failures = reconcileFindings(results, PREDATING_FINDINGS)
 // give: it reconciles delivery claims against git, this checks the block's
 // shape against the protocol.
 const handoff =
-  await $`${join(checkout as string, 'scripts/handoff-check')} ${join(repoRoot, 'specs/handoff.md')}`
+  await $`${join(checkout, 'scripts/handoff-check')} ${join(repoRoot, 'specs/handoff.md')}`
     .nothrow()
     .quiet()
 
@@ -121,5 +117,5 @@ if (failures.length > 0) {
 const admitted = [...PREDATING_FINDINGS.values()].reduce((total, list) => total + list.length, 0)
 console.log(
   `forgeflow contract check passed against ${adopted.slice(0, 8)}: ` +
-    `${directories.length} Stories, ${admitted} admitted pre-existing finding(s), handoff contract OK`
+    `${results.length} Stories, ${admitted} admitted pre-existing finding(s), handoff contract OK`
 )

--- a/scripts/check-forgeflow-contract.ts
+++ b/scripts/check-forgeflow-contract.ts
@@ -1,0 +1,164 @@
+/**
+ * Gate: this repository satisfies the ForgeFlow contract it says it adopted.
+ *
+ * The rules live in `lib/forgeflow-contract.ts` next to the reasoning for why
+ * each is drawn where it is. Everything here is the subprocess and filesystem
+ * shell around them: fetch what upstream says, hand it over, print the verdict.
+ *
+ * Not a `make verify` step, deliberately. It needs a ForgeFlow checkout, and
+ * the canonical gate has to run from a clone of this repository alone. CI runs
+ * it as its own job, which is also why the two sibling gates —
+ * `check-forgeflow-adoption.ts` and `check-forgeflow-handoff.ts` — stay offline
+ * and stay in `make verify`: they check what this repository says about itself,
+ * where this one checks it against somebody else's rules.
+ */
+
+import { $ } from 'bun'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  checkoutRefusal,
+  formatContractFailures,
+  reconcileFindings,
+  type Exemptions,
+  type StoryResult,
+} from './lib/forgeflow-contract'
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url))
+
+/**
+ * Findings that predate this gate, exactly as upstream `story-check` states
+ * them.
+ *
+ * All twenty-one failed identically under 0.3.2; the upgrade did not cause one
+ * of them. They are three kinds of wording — a trust-boundary field written as
+ * prose, a security fixture cell written as prose instead of an exact value in
+ * backticks, and one Story whose Classification contradicts its own Superseded
+ * Behavior section. Fixing them means re-deriving sixteen matrix cells from the
+ * code they describe and editing acceptance text a human already accepted, so
+ * it is its own Story rather than a paragraph of this one.
+ *
+ * A ratchet: entries may be deleted and never added.
+ */
+const PREDATING_FINDINGS: Exemptions = new Map([
+  [
+    'DBCLI-PLAT-004-operation-envelope-v1',
+    ['every trust-boundary field must name an exact field, not prose'],
+  ],
+  [
+    'DBCLI-PLAT-005-agent-json-mode',
+    [
+      'every trust-boundary field must name an exact field, not prose',
+      'Story declares Baseline conformance: no but declares superseded behavior',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-006-correlation-id',
+    [
+      'security fixture row 1 states verification as prose instead of an exact value',
+      'security fixture row 2 states verification as prose instead of an exact value',
+      'security fixture row 3 states verification as prose instead of an exact value',
+      'security fixture row 4 states verification as prose instead of an exact value',
+      'security fixture row 5 states verification as prose instead of an exact value',
+      'security fixture row 6 states verification as prose instead of an exact value',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-007-bounded-evidence-receipts',
+    [
+      'security fixture row 1 states source field as prose instead of an exact value',
+      'security fixture row 2 states source field as prose instead of an exact value',
+      'security fixture row 3 states source field as prose instead of an exact value',
+      'security fixture row 4 states source field as prose instead of an exact value',
+      'security fixture row 5 states source field as prose instead of an exact value',
+      'security fixture row 6 states source field as prose instead of an exact value',
+      'security fixture row 7 states source field as prose instead of an exact value',
+      'security fixture row 8 states source field as prose instead of an exact value',
+      'every trust-boundary field must name an exact field, not prose',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-012-schema-cache-write-boundary',
+    [
+      'security fixture row 10 states source field as prose instead of an exact value',
+      'security fixture row 10 states persisted locations as prose instead of an exact value',
+      'every trust-boundary field must name an exact field, not prose',
+    ],
+  ],
+])
+
+const adopted = (await Bun.file(join(repoRoot, 'specs/.forgeflow-adoption')).text())
+  .split('\n')
+  .find((line) => line.startsWith('revision='))
+  ?.slice('revision='.length)
+  .trim()
+
+if (adopted === undefined) {
+  console.error('specs/.forgeflow-adoption records no revision')
+  process.exit(1)
+}
+
+const forgeflowRoot = process.env.FORGEFLOW_ROOT
+const checkout = forgeflowRoot === undefined ? undefined : forgeflowRoot
+
+const revision =
+  checkout === undefined
+    ? undefined
+    : (await $`git -C ${checkout} rev-parse HEAD`.nothrow().quiet()).text().trim() || undefined
+
+const refusal = checkoutRefusal(adopted, revision)
+if (refusal !== null) {
+  console.error(refusal)
+  process.exit(1)
+}
+
+const storiesRoot = join(repoRoot, 'specs/stories')
+const directories = (await Array.fromAsync(new Bun.Glob('*/story.md').scan({ cwd: storiesRoot })))
+  .map((entry) => entry.replace(/[/\\]story\.md$/, ''))
+  .filter((directory) => !directory.startsWith('_'))
+  .sort()
+
+const results: StoryResult[] = []
+for (const directory of directories) {
+  const path = join(storiesRoot, directory)
+  const checked = await $`${join(checkout as string, 'scripts/story-check')} ${path}`
+    .nothrow()
+    .quiet()
+
+  const output = `${checked.stdout.toString()}${checked.stderr.toString()}`
+  results.push({
+    story: directory,
+    findings: output
+      .split('\n')
+      .filter((line) => line.startsWith('FAIL'))
+      .map((line) => line.replace(`FAIL  ${path}: `, '').trim()),
+  })
+}
+
+const failures = reconcileFindings(results, PREDATING_FINDINGS)
+
+// Upstream's own view of the handoff, which the offline sibling gate cannot
+// give: it reconciles delivery claims against git, this checks the block's
+// shape against the protocol.
+const handoff =
+  await $`${join(checkout as string, 'scripts/handoff-check')} ${join(repoRoot, 'specs/handoff.md')}`
+    .nothrow()
+    .quiet()
+
+if (handoff.exitCode !== 0) {
+  const output = `${handoff.stdout.toString()}${handoff.stderr.toString()}`
+  for (const line of output.split('\n').filter((entry) => entry.startsWith('FAIL'))) {
+    failures.push({ subject: 'specs/handoff.md', reason: line.replace(/^FAIL\s+/, '') })
+  }
+}
+
+if (failures.length > 0) {
+  console.error(formatContractFailures(failures))
+  process.exit(1)
+}
+
+const admitted = [...PREDATING_FINDINGS.values()].reduce((total, list) => total + list.length, 0)
+console.log(
+  `forgeflow contract check passed against ${adopted.slice(0, 8)}: ` +
+    `${directories.length} Stories, ${admitted} admitted pre-existing finding(s), handoff contract OK`
+)

--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -159,3 +159,79 @@ export function formatContractFailures(failures: readonly ContractFailure[]): st
     `${failures.length} finding(s) upstream ForgeFlow reports that this repository has not admitted to.`,
   ].join('\n')
 }
+
+/**
+ * Findings that predate this gate, exactly as upstream `story-check` states
+ * them.
+ *
+ * All twenty-one failed identically under 0.3.2; the upgrade did not cause one
+ * of them. They are three kinds of wording — a trust-boundary field written as
+ * prose, a security fixture cell written as prose instead of an exact value in
+ * backticks, and one Story whose Classification contradicts its own Superseded
+ * Behavior section. Fixing them means re-deriving sixteen matrix cells from the
+ * code they describe and editing acceptance text a human already accepted, so
+ * it is its own Story rather than a paragraph of DBCLI-018.
+ *
+ * The ratchet's two directions are enforced differently, and the difference is
+ * worth knowing. Shrinking is mechanical: a finding that has been fixed makes
+ * the gate fail as a stale entry. Growing is caught by the counts below, which
+ * a test compares this map against — adding an entry fails until someone
+ * lowers, never raises, those numbers, which is the deliberate act the rule is
+ * asking for. Neither direction is left to a reviewer noticing.
+ */
+export const PREDATING_FINDINGS: Exemptions = new Map([
+  [
+    'DBCLI-PLAT-004-operation-envelope-v1',
+    ['every trust-boundary field must name an exact field, not prose'],
+  ],
+  [
+    'DBCLI-PLAT-005-agent-json-mode',
+    [
+      'every trust-boundary field must name an exact field, not prose',
+      'Story declares Baseline conformance: no but declares superseded behavior',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-006-correlation-id',
+    [
+      'security fixture row 1 states verification as prose instead of an exact value',
+      'security fixture row 2 states verification as prose instead of an exact value',
+      'security fixture row 3 states verification as prose instead of an exact value',
+      'security fixture row 4 states verification as prose instead of an exact value',
+      'security fixture row 5 states verification as prose instead of an exact value',
+      'security fixture row 6 states verification as prose instead of an exact value',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-007-bounded-evidence-receipts',
+    [
+      'security fixture row 1 states source field as prose instead of an exact value',
+      'security fixture row 2 states source field as prose instead of an exact value',
+      'security fixture row 3 states source field as prose instead of an exact value',
+      'security fixture row 4 states source field as prose instead of an exact value',
+      'security fixture row 5 states source field as prose instead of an exact value',
+      'security fixture row 6 states source field as prose instead of an exact value',
+      'security fixture row 7 states source field as prose instead of an exact value',
+      'security fixture row 8 states source field as prose instead of an exact value',
+      'every trust-boundary field must name an exact field, not prose',
+    ],
+  ],
+  [
+    'DBCLI-PLAT-012-schema-cache-write-boundary',
+    [
+      'security fixture row 10 states source field as prose instead of an exact value',
+      'security fixture row 10 states persisted locations as prose instead of an exact value',
+      'every trust-boundary field must name an exact field, not prose',
+    ],
+  ],
+])
+
+/**
+ * How many findings this repository has admitted to, and across how many
+ * Stories.
+ *
+ * These numbers may be lowered and never raised. They exist so that "the list
+ * may shrink and never grow" is a check rather than a sentence in a header.
+ */
+export const ADMITTED_FINDINGS = 21
+export const ADMITTED_STORIES = 5

--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -1,0 +1,161 @@
+// Reconciliation rules for running upstream ForgeFlow's own checkers.
+//
+// The gate is `scripts/check-forgeflow-contract.ts`; everything decidable
+// without a filesystem or a subprocess lives here, next to the reasoning for
+// why each rule is drawn where it is — the same split, and for the same
+// reasons, as `forgeflow-handoff.ts`.
+//
+// ## Why this exists at all
+//
+// DBCLI-018 upgraded the adopted contract from 0.3.2 to 0.6.0, which brings
+// Authority, Risk, Task mode and an Acceptance Evidence map. Every one of them
+// is enforced by an upstream checker and by nothing else, and those checkers
+// live in a ForgeFlow checkout this repository does not contain. So a version
+// bump on its own would have changed what a Story is permitted to say and
+// nothing about what is checked — the shape of adoption that produced the two
+// drifts DBCLI-013 and DBCLI-016 already had to close.
+//
+// The alternative was to reimplement the rules here. That was refused: the
+// sibling gate's header states outright that it "deliberately does not overlap
+// upstream's story-check", and two implementations of one contract diverge on a
+// schedule nobody controls. So CI fetches the adopted revision and runs
+// upstream's own checkers against this repository's Stories.
+//
+// ## The revision is part of the check
+//
+// A checkout of some other ForgeFlow enforces some other contract. The gate
+// refuses unless the checkout's revision is the one `specs/.forgeflow-adoption`
+// records, so "these are the rules we said we adopted" is verified rather than
+// assumed — and an upgrade cannot be half-done, with the marker moved and the
+// rules still the old ones.
+//
+// ## The exemptions are a ratchet
+//
+// Five delivered Stories fail upstream `story-check` today, on twenty-one
+// findings that have nothing to do with the upgrade: they failed identically
+// under 0.3.2, and nothing ran the checker, so nobody knew. Rewriting the
+// acceptance text of Stories a human has already accepted is a change to the
+// record, not a formatting fix — sixteen of the findings are matrix cells whose
+// real values have to be re-derived from the code. That is its own Story.
+//
+// Until then the findings are listed, exactly, so that they are bounded rather
+// than tolerated: a new finding in an exempt Story fails, a finding that has
+// been fixed fails as a stale entry, and any Story not on the list must pass.
+// The list may shrink and never grow.
+
+/** One upstream finding, as the checker stated it, minus the path prefix. */
+export type Finding = string
+
+/** What `story-check` said about one Story directory. */
+export interface StoryResult {
+  readonly story: string
+  readonly findings: readonly Finding[]
+}
+
+/** One reason this repository does not satisfy the contract it adopted. */
+export interface ContractFailure {
+  readonly subject: string
+  readonly reason: string
+}
+
+/**
+ * Findings that predate the gate, per Story, exactly as upstream states them.
+ *
+ * A ratchet, not an amnesty. Entries may be deleted and never added: adding one
+ * is how a gate becomes a list of things it has agreed not to check.
+ */
+export type Exemptions = ReadonlyMap<string, readonly Finding[]>
+
+/**
+ * Decide whether the checkout CI fetched is the contract this repository
+ * adopted.
+ *
+ * Both halves matter. A mismatched revision enforces rules nobody agreed to,
+ * and an absent checkout is refused rather than skipped, because a gate that
+ * passes wherever its evidence is missing passes in CI and nowhere else.
+ */
+export function checkoutRefusal(
+  adoptedRevision: string,
+  checkoutRevision: string | undefined
+): string | null {
+  if (checkoutRevision === undefined) {
+    return (
+      'ForgeFlow contract check cannot run: no ForgeFlow checkout was provided.\n\n' +
+      '  Set FORGEFLOW_ROOT to a checkout of the adopted revision:\n\n' +
+      `    git clone https://github.com/CarlLee1983/ForgeFlowV2 forgeflow\n` +
+      `    git -C forgeflow checkout ${adoptedRevision}\n` +
+      '    FORGEFLOW_ROOT=forgeflow bun run forgeflow:contract\n'
+    )
+  }
+
+  if (checkoutRevision !== adoptedRevision) {
+    return (
+      `ForgeFlow contract check cannot run: the checkout is at ${checkoutRevision}, ` +
+      `but specs/.forgeflow-adoption records ${adoptedRevision}.\n\n` +
+      '  A checkout of some other ForgeFlow enforces some other contract. Check\n' +
+      '  out the adopted revision, or upgrade the adoption first.\n'
+    )
+  }
+
+  return null
+}
+
+/**
+ * Compare what upstream found against what this repository has admitted to.
+ *
+ * Findings are compared as sets rather than counted: a Story that traded one
+ * finding for another would keep its total and change its meaning.
+ */
+export function reconcileFindings(
+  results: readonly StoryResult[],
+  exemptions: Exemptions
+): ContractFailure[] {
+  const failures: ContractFailure[] = []
+  const seen = new Set<string>()
+
+  for (const { story, findings } of results) {
+    seen.add(story)
+    const admitted = exemptions.get(story)
+
+    if (admitted === undefined) {
+      for (const finding of findings) {
+        failures.push({ subject: story, reason: finding })
+      }
+      continue
+    }
+
+    for (const finding of findings) {
+      if (!admitted.includes(finding)) {
+        failures.push({ subject: story, reason: `${finding} — this finding is new` })
+      }
+    }
+
+    for (const finding of admitted) {
+      if (!findings.includes(finding)) {
+        failures.push({
+          subject: story,
+          reason: `no longer reports "${finding}" — delete the exemption entry`,
+        })
+      }
+    }
+  }
+
+  for (const story of exemptions.keys()) {
+    if (!seen.has(story)) {
+      failures.push({ subject: story, reason: 'has exemptions but no Story directory' })
+    }
+  }
+
+  return failures
+}
+
+/** Render the failures as a report a reader can act on without opening a diff. */
+export function formatContractFailures(failures: readonly ContractFailure[]): string {
+  return [
+    'ForgeFlow contract check failed:',
+    '',
+    ...failures.map(({ subject, reason }) => `  ${subject}: ${reason}`),
+    '',
+    `${failures.length} finding(s) upstream ForgeFlow reports that this repository has not admitted to.`,
+  ].join('\n')
+}

--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -125,30 +125,87 @@ export type Exemptions = ReadonlyMap<string, readonly Finding[]>
  * and an absent checkout is refused rather than skipped, because a gate that
  * passes wherever its evidence is missing passes in CI and nowhere else.
  */
-export function checkoutRefusal(
-  adoptedRevision: string,
-  checkoutRevision: string | undefined
-): string | null {
-  if (checkoutRevision === undefined) {
+export interface Checkout {
+  /** `undefined` when FORGEFLOW_ROOT was not set at all. */
+  readonly root: string | undefined
+  /** `undefined` when `git rev-parse HEAD` could not answer. */
+  readonly revision: string | undefined
+  /** `git status --porcelain`, or `undefined` when it could not answer. */
+  readonly status: string | undefined
+}
+
+export function checkoutRefusal(adoptedRevision: string, checkout: Checkout): string | null {
+  const instructions =
+    '  Set FORGEFLOW_ROOT to a checkout of the adopted revision:\n\n' +
+    '    git clone https://github.com/CarlLee1983/ForgeFlowV2 forgeflow\n' +
+    `    git -C forgeflow checkout ${adoptedRevision}\n` +
+    '    FORGEFLOW_ROOT=forgeflow bun run forgeflow:contract\n'
+
+  if (checkout.root === undefined) {
+    return `ForgeFlow contract check cannot run: FORGEFLOW_ROOT is not set.\n\n${instructions}`
+  }
+
+  // Distinguished from "not set" on purpose: both used to print the same
+  // sentence, so a path that was a typo, or a directory that is not a git
+  // repository, sent the reader to set a variable they had already set.
+  if (checkout.revision === undefined || checkout.status === undefined) {
     return (
-      'ForgeFlow contract check cannot run: no ForgeFlow checkout was provided.\n\n' +
-      '  Set FORGEFLOW_ROOT to a checkout of the adopted revision:\n\n' +
-      `    git clone https://github.com/CarlLee1983/ForgeFlowV2 forgeflow\n` +
-      `    git -C forgeflow checkout ${adoptedRevision}\n` +
-      '    FORGEFLOW_ROOT=forgeflow bun run forgeflow:contract\n'
+      `ForgeFlow contract check cannot run: ${checkout.root} is not a readable git ` +
+      `checkout — git could not report its revision or its status.\n\n${instructions}`
     )
   }
 
-  if (checkoutRevision !== adoptedRevision) {
+  if (checkout.revision !== adoptedRevision) {
     return (
-      `ForgeFlow contract check cannot run: the checkout is at ${checkoutRevision}, ` +
+      `ForgeFlow contract check cannot run: the checkout is at ${checkout.revision}, ` +
       `but specs/.forgeflow-adoption records ${adoptedRevision}.\n\n` +
       '  A checkout of some other ForgeFlow enforces some other contract. Check\n' +
       '  out the adopted revision, or upgrade the adoption first.\n'
     )
   }
 
+  // A dirty tree is not at any revision. Editing `scripts/story-check` to stop
+  // emitting a finding leaves `rev-parse HEAD` untouched, so the banner would go
+  // on asserting "passed against 51ab1f20" while the rules being run were
+  // somebody's local edit.
+  if (checkout.status.trim() !== '') {
+    return (
+      `ForgeFlow contract check cannot run: the checkout at ${checkout.root} has ` +
+      `uncommitted changes, so the rules it would run are not the ones ` +
+      `${adoptedRevision} defines:\n\n${checkout.status.trim()}\n`
+    )
+  }
+
   return null
+}
+
+/**
+ * Read one no-argument `story-check` run into findings per Story.
+ *
+ * Upstream discovers Story directories itself — `specs/stories/*`, skipping
+ * `_template`, erroring on a directory with no `story.md`. This gate used to
+ * glob for them instead, which is directory selection reimplemented, and a
+ * directory holding an `acceptance.md` and no `story.md` was invisible to it:
+ * not checked, not counted, not reported. ADR-0027's whole claim is that
+ * upstream's rules are run rather than rewritten, and discovery is one of them.
+ *
+ * `INFO` names every Story upstream saw; `FAIL` names what it found. A Story
+ * with an INFO line and no FAIL lines is clean.
+ */
+export function parseStoryCheck(output: string): StoryResult[] {
+  const findings = new Map<string, Finding[]>()
+
+  for (const line of output.split('\n')) {
+    const match = line.match(/^(INFO|FAIL)\s+specs\/stories\/([^/:]+):\s*(.*)$/)
+    if (!match) continue
+
+    const [, kind, story, detail] = match as unknown as [string, string, string, string]
+    const list = findings.get(story) ?? []
+    if (kind === 'FAIL') list.push(detail.trim())
+    findings.set(story, list)
+  }
+
+  return [...findings.entries()].map(([story, list]) => ({ story, findings: list }))
 }
 
 /**
@@ -175,19 +232,26 @@ export function reconcileFindings(
       continue
     }
 
+    // Compared as multisets, not sets. With `includes` in both directions, two
+    // identical findings in one Story matched a single exemption entry, and a
+    // duplicated entry was never reported stale — the count would agree while
+    // one real finding went unadmitted.
+    const remaining = [...admitted]
+
     for (const finding of findings) {
-      if (!admitted.includes(finding)) {
+      const at = remaining.indexOf(finding)
+      if (at === -1) {
         failures.push({ subject: story, reason: `${finding} — this finding is new` })
+        continue
       }
+      remaining.splice(at, 1)
     }
 
-    for (const finding of admitted) {
-      if (!findings.includes(finding)) {
-        failures.push({
-          subject: story,
-          reason: `no longer reports "${finding}" — delete the exemption entry`,
-        })
-      }
+    for (const finding of remaining) {
+      failures.push({
+        subject: story,
+        reason: `no longer reports "${finding}" — delete the exemption entry`,
+      })
     }
   }
 

--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -8,12 +8,19 @@
 // ## Why this exists at all
 //
 // DBCLI-018 upgraded the adopted contract from 0.3.2 to 0.6.0, which brings
-// Authority, Risk, Task mode and an Acceptance Evidence map. Every one of them
-// is enforced by an upstream checker and by nothing else, and those checkers
-// live in a ForgeFlow checkout this repository does not contain. So a version
-// bump on its own would have changed what a Story is permitted to say and
-// nothing about what is checked — the shape of adoption that produced the two
-// drifts DBCLI-013 and DBCLI-016 already had to close.
+// Authority, Risk, Task mode and an Acceptance Evidence map. Each is enforced
+// by an upstream checker and by nothing else, and those checkers live in a
+// ForgeFlow checkout this repository does not contain. So a version bump on its
+// own would have changed what a Story is permitted to say and nothing about
+// what is checked — the shape of adoption that produced the two drifts
+// DBCLI-013 and DBCLI-016 already had to close.
+//
+// Three of the four are closed by this gate. Authority, Risk and Task mode are
+// checked in `story-check`'s default mode, which is what runs here. The
+// Acceptance Evidence map is a `--ready` check, and this gate does not pass
+// `--ready`, so it is expressible and unenforced — including in DBCLI-018's own
+// Story. Adopting `--ready` needs its own exemption set for the twenty-five
+// Stories that predate it, so it is out of scope rather than quietly missing.
 //
 // The alternative was to reimplement the rules here. That was refused: the
 // sibling gate's header states outright that it "deliberately does not overlap
@@ -42,6 +49,50 @@
 // than tolerated: a new finding in an exempt Story fails, a finding that has
 // been fixed fails as a stale entry, and any Story not on the list must pass.
 // The list may shrink and never grow.
+
+/**
+ * What one run of an upstream checker actually said.
+ *
+ * The exit code is part of the reading, not a detail. Upstream reports
+ * operational failures — a missing, empty, unreadable or symlinked `story.md`
+ * or `acceptance.md` — on stderr with an `ERROR` prefix and exit 2, printing no
+ * `FAIL` lines at all. A reader that only looks for `FAIL` sees nothing wrong
+ * and counts the Story as clean, so a Story upstream *refused to read* was
+ * reported as satisfying the contract. That is the exact false PASS this gate
+ * exists to make impossible, and it was reproduced before this function
+ * existed.
+ *
+ * So the three outcomes are named. Anything that is not one of them — exit 0
+ * with findings, exit 1 without them, a checker that could not be spawned at
+ * all — is a failure of the gate rather than a verdict about a Story.
+ */
+export interface CheckerRun {
+  readonly exitCode: number
+  readonly output: string
+}
+
+/**
+ * Read a checker run, refusing to turn an unreadable result into a clean one.
+ *
+ * Returns the findings when the run is one this gate understands, or a string
+ * naming why the run itself cannot be trusted.
+ */
+export function readCheckerRun(subject: string, run: CheckerRun): Finding[] | string {
+  const findings = run.output
+    .split('\n')
+    .filter((line) => line.startsWith('FAIL'))
+    .map((line) => line.trim())
+
+  if (run.exitCode === 0 && findings.length === 0) return []
+  if (run.exitCode === 1 && findings.length > 0) return findings
+
+  const detail = run.output.trim() === '' ? '(no output)' : run.output.trim()
+  return (
+    `${subject}: the checker exited ${run.exitCode} with ${findings.length} FAIL line(s), ` +
+    `which is neither a clean run nor a set of findings — the gate cannot say whether ` +
+    `the contract is satisfied:\n\n${detail}`
+  )
+}
 
 /** One upstream finding, as the checker stated it, minus the path prefix. */
 export type Finding = string

--- a/specs/.forgeflow-adoption
+++ b/specs/.forgeflow-adoption
@@ -1,2 +1,2 @@
-version=0.3.2
-revision=7bbdf443ead484780e23df9abf055095d4c629e2
+version=0.6.0
+revision=51ab1f20defffc9477c02989989dcda244df791e

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -64,7 +64,7 @@ DBCLI-001 的交付狀態已驗證並結案。它跨十份交接紀錄被記為�
 
 ## 流程版本
 
-採用 ForgeFlow 0.3.2。權威記錄是 `specs/.forgeflow-adoption`，這裡只是複述，
+採用 ForgeFlow 0.6.0。權威記錄是 `specs/.forgeflow-adoption`，這裡只是複述，
 而複述正是 DBCLI-013 要修的東西：這段話在 marker 與 `specs/stories/README.md`
 都已經推進到 0.3.2 之後，還原樣說著 0.3.1，跨兩個已合併的 PR 沒有人看。
 
@@ -634,6 +634,73 @@ timeout 是 20 分鐘而這輪大約 15 分鐘。一旦逾時或被取消，`fin
 把 step 清單搬進 `scripts/` runner 的那個選項沒有被否決，只是延後：DBCLI-019 要的
 per-step 時間與失敗步驟幾乎是免費的，該由那個 Story 重新評估，而不是在這裡先猜。
 
+## DBCLI-018：升級到 0.6.0，並且讓那份契約真的被檢查
+
+採用版本從 0.3.2 推到 0.6.0，走的是上游自己的 `./scripts/bootstrap --upgrade`，
+不是手改版本號。動工前量到的三件事決定了這個 Story 的形狀：
+
+**升級不弄壞任何東西。** 25 個 Story 在 v0.3.2 與 v0.6.0 的 `story-check` 下失敗
+清單完全相同——21 條、集中在 5 個 Story，0.6.0 沒有新增任何一條。
+
+**升級修好一件事。** `handoff-check` 從 `HANDOFF_CONTRACT_INCOMPLETE` 變成
+`HANDOFF_CONTRACT_OK`：那八條 `completed Story is not a Story ID: DBCLI-PLAT-*`
+是 0.3.2 的 Story ID 文法早於這個命名，0.6.0 放寬了。`docs/releases/0.6.0.md`
+點名這個 repo 就是促成那次調查的對象。
+
+**升級只有四個檔。** dry-run 列出的就是三個 `_template/` 與 marker；`AGENTS.md`
+與 guidance 在首次安裝後就是 repository-owned，不在 managed 清單裡。三個 template
+與 v0.3.2 原版逐字相同，沒有本地客製被蓋掉。
+
+marker 釘的是 `v0.6.0` tag（`51ab1f20`），不是 bootstrap 當時所在的 checkout——
+那個位置在 tag 之後兩個文件 commit，marker 指著未上 tag 的 revision 會讓「這是哪一版」
+有兩個答案。
+
+### 為什麼不只是改個數字
+
+Authority、Risk、Task mode、Acceptance Evidence 在 0.6.0 全是 optional，而且**只由
+上游 checker 執行**，那些 checker 住在這個 repo 沒有的 checkout 裡。只推版本號會改變
+「一個 Story 被允許說什麼」，卻不會改變「什麼被檢查」——那正是 DBCLI-013 與 DBCLI-016
+事後各自要收拾的形狀。
+
+沒有選擇在 `scripts/` 裡重寫那些規則。`forgeflow-handoff.ts` 的檔頭明寫著它「刻意不與
+上游 story-check 重疊」，而一份自己不擁有的契約寫兩份實作，兩邊會以沒人控制的節奏分岔，
+副本會是沒人更新的那一份。所以 CI 新增一個 job，clone marker 指定的那個 revision，跑
+上游自己的 `story-check` 與 `handoff-check`。
+
+revision 是檢查的一部分：checkout 在別的 revision 會被拒絕（不同的 ForgeFlow 執行不同的
+契約），沒有 checkout 也會被拒絕而不是跳過。它是 CI job 不是 `make verify` 的 step——
+canonical gate 必須能從這個 repo 單獨一份 clone、離線跑完。
+
+### 21 條舊債：列出來，不是修掉
+
+5 個已交付的 Story 在上游 `story-check` 下有 21 條 FAIL，0.3.2 下就一模一樣，升級沒有
+造成任何一條。從來沒人知道，因為 `make verify` 跑的是自家的 TypeScript 對帳，從來沒跑過
+上游的 checker。
+
+三類措辭問題：trust-boundary 欄位寫成散文、security fixture 儲存格寫成散文而非 backtick
+精確值、一個 Story 的 Classification 與自己的 Superseded Behavior 互相矛盾。
+
+| Story | 條數 | 類型 |
+| --- | --- | --- |
+| DBCLI-PLAT-004 | 1 | trust-boundary |
+| DBCLI-PLAT-005 | 2 | trust-boundary；classification 與 superseded 矛盾 |
+| DBCLI-PLAT-006 | 6 | fixture matrix 第 1–6 列 verification 欄 |
+| DBCLI-PLAT-007 | 9 | fixture matrix 第 1–8 列 source field；trust-boundary |
+| DBCLI-PLAT-012 | 3 | row 10 兩欄；trust-boundary |
+
+沒有在這個 Story 裡修，是人的決定：其中 16 條是矩陣儲存格，真實的值要回到程式碼重新推導，
+而且全部都是在改一份人已經接受過的驗收文本——那是改紀錄，不是排版。它是自己的一個 Story。
+
+在那之前這 21 條被逐條列進 `PREDATING_FINDINGS`，是棘輪不是特赦：exempt 的 Story 多一條
+新的會 fail，修好了卻沒刪 entry 也會 fail，沒有 entry 的 Story 必須全乾淨。清單只准縮短。
+
+### 沒有採用的東西
+
+`story-check --ready` 要求每個 Story 都有 Acceptance Evidence map，現在會回報 71 條。
+那是對「未來每一個 Story」的決定，不是升級的副作用，所以沒有一起打開。上游的
+`templates/story/verification.md` 也沒裝——bootstrap 不管它，而 verification result
+contract 在這裡還沒有消費者。
+
 ## Lifecycle
 
 `current_story` 與 `next_story` 永久是契約的 sentinel。要知道現在該做什麼，問
@@ -669,26 +736,29 @@ workflow:
     - DBCLI-015
     - DBCLI-016
     - DBCLI-017
+    - DBCLI-018
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 980cc078b850f799615dce51b2993141b85c40c7
+  commit: 284b5211a19fa8d0d8dcc85995c3692d429f7809
   dirty_worktree: false
   story_owned_paths:
     - specs/handoff.md
-    - specs/stories/DBCLI-017-portable-verification-attestation/story.md
-    - specs/stories/DBCLI-017-portable-verification-attestation/acceptance.md
-    - docs/adr/0026-a-verification-attestation-is-not-an-evidence-receipt.md
-    - scripts/lib/verification-attestation.ts
-    - scripts/write-attestation.ts
-    - tests/unit/scripts/verification-attestation.test.ts
-    - tests/contract/forgepilot-boundary.test.ts
-    - Makefile
-    - .gitignore
+    - specs/.forgeflow-adoption
+    - specs/stories/README.md
+    - specs/stories/_template/story.md
+    - specs/stories/_template/acceptance.md
+    - specs/stories/DBCLI-018-forgeflow-adoption-upgrade/story.md
+    - specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+    - docs/adr/0027-upstream-forgeflow-checkers-are-run-not-reimplemented.md
+    - scripts/lib/forgeflow-contract.ts
+    - scripts/check-forgeflow-contract.ts
+    - tests/unit/scripts/forgeflow-contract.test.ts
     - .github/workflows/ci.yml
-    - CONTEXT.md
+    - package.json
+    - AGENTS.md
   known_unrelated_paths: []
 
 verification:

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -694,6 +694,12 @@ canonical gate 必須能從這個 repo 單獨一份 clone、離線跑完。
 在那之前這 21 條被逐條列進 `PREDATING_FINDINGS`，是棘輪不是特赦：exempt 的 Story 多一條
 新的會 fail，修好了卻沒刪 entry 也會 fail，沒有 entry 的 Story 必須全乾淨。清單只准縮短。
 
+### baseline 為什麼不是 main
+
+DBCLI-018 疊在 DBCLI-017 上，而 017 還沒合併。baseline 記的是這個 Story 實際從哪裡
+長出來的那個 commit（`1ad46174`），branch 因此是 017 的分支而不是 `main`——那個
+commit 不在 `main` 上，寫 `main` 會讓這兩行合起來指向一個不存在的位置。
+
 ### 沒有採用的東西
 
 `story-check --ready` 要求每個 Story 都有 Acceptance Evidence map，現在會回報 71 條。
@@ -741,8 +747,8 @@ workflow:
 
 baseline:
   repository: CarlLee1983/dbcli
-  branch: main
-  commit: 284b5211a19fa8d0d8dcc85995c3692d429f7809
+  branch: feat/dbcli-017-portable-verification-attestation
+  commit: 1ad461745c2596b773d9e7c41425737789541894
   dirty_worktree: false
   story_owned_paths:
     - specs/handoff.md

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
@@ -1,0 +1,83 @@
+# Acceptance Criteria
+
+Every criterion names the evidence that decides it: a command and the result
+that counts as passing.
+
+## Happy Path
+
+* [ ] The adoption records 0.6.0 at the tagged release.
+      Evidence: `specs/.forgeflow-adoption` reads `version=0.6.0` and
+      `revision=51ab1f20defffc9477c02989989dcda244df791e`, which is
+      `git rev-parse v0.6.0^{commit}` in the ForgeFlow repository.
+* [ ] Every adoption surface agrees.
+      Evidence: `bun run forgeflow:check` → exit `0`, reporting agreement with
+      `specs/stories/README.md` and five other surfaces.
+* [ ] The templates carry the new sections a Story may now declare.
+      Evidence: `specs/stories/_template/story.md` contains `## Authority`,
+      `## Risk`, `## Architecture` and a `Task mode:` bullet;
+      `specs/stories/_template/acceptance.md` contains `## Acceptance Evidence`.
+* [ ] Upstream's checkers pass against this repository.
+      Evidence: with a checkout at the adopted revision,
+      `FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract` → exit `0`,
+      reporting 25 Stories, 21 admitted findings and handoff contract OK.
+* [ ] `handoff-check` now passes where it used to fail.
+      Evidence: upstream `handoff-check` on `specs/handoff.md` reports
+      `HANDOFF_CONTRACT_OK`; under v0.3.2 the same file reported eight
+      `completed Story is not a Story ID: DBCLI-PLAT-*` failures.
+
+## Business Rules
+
+* [ ] The upgrade changed only what upstream manages.
+      Evidence: `./scripts/bootstrap --upgrade --dry-run` from a v0.6.0 checkout
+      lists exactly the three `_template/` files and the marker, and
+      `git diff --stat` for this Story shows no other file changed by bootstrap.
+* [ ] A checkout at another revision is refused.
+      Evidence: `FORGEFLOW_ROOT=<a v0.5.2 checkout> bun run forgeflow:contract`
+      exits non-zero naming both revisions.
+* [ ] No checkout at all is refused, not skipped.
+      Evidence: `bun run forgeflow:contract` with `FORGEFLOW_ROOT` unset exits
+      non-zero and names the commands that produce a usable checkout.
+* [ ] Every one of the 21 pre-existing findings is admitted exactly, by Story.
+      Evidence: `PREDATING_FINDINGS` in
+      `scripts/check-forgeflow-contract.ts` lists 21 findings across
+      `DBCLI-PLAT-004`, `005`, `006`, `007` and `012`, each string identical to
+      what upstream prints.
+* [ ] A new finding in an exempt Story fails; a fixed one fails as a stale
+      entry; a Story with no entry must be clean.
+      Evidence: fixture tests in
+      `tests/unit/scripts/forgeflow-contract.test.ts`.
+* [ ] `make verify` is unchanged.
+      Evidence: `git diff main...HEAD -- Makefile` is empty, and
+      `tests/contract/forgepilot-boundary.test.ts` passes with its
+      `REQUIRED_STEPS` roster unedited.
+
+## Failure Cases
+
+* [ ] A marker recording no revision is refused rather than defaulting.
+      Evidence: the gate exits 1 naming `specs/.forgeflow-adoption`.
+* [ ] A Story directory that upstream reports on but that has no exemption entry
+      fails, with the finding quoted rather than counted.
+      Evidence: fixture test `a finding in a Story with no exemption fails`.
+
+## Regression Requirements
+
+* [ ] `make verify` passes on the delivered commit, run by ForgePilot in a
+      detached worktree of that exact revision, offline and with no ForgeFlow
+      checkout present.
+* [ ] DBCLI-016's refusal rules and DBCLI-017's attestation are untouched.
+      Evidence: `bun run forgeflow:check` and the attestation unit tests pass
+      unchanged.
+* [ ] No Story file, other than this Story's own, is edited.
+      Evidence: `git diff --stat main...HEAD -- specs/stories/` names only
+      `_template/` and `DBCLI-018-*`.
+
+## Verification Notes
+
+The contract gate is deliberately not a `make verify` step: it needs a second
+checkout, and the canonical gate must run from a clone of this repository alone.
+CI runs it as its own job. Confirm from the pull request that the
+`forgeflow-contract` job ran and passed, and record the run URL.
+
+The 21 admitted findings are a debt, not a decision that the rules do not apply.
+The delivery report names them by Story and rule so the follow-up Story starts
+from a list rather than a rediscovery.

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
@@ -66,6 +66,19 @@ that counts as passing.
 
 ## Failure Cases
 
+* [ ] A Story upstream refuses to read is not counted as a clean Story.
+      Evidence: with a Story directory whose `acceptance.md` is empty, upstream
+      exits 2 printing an `ERROR` line and no `FAIL` lines; the gate exits
+      non-zero quoting it. Before this was checked, that Story was counted as
+      satisfying the contract and the total simply went up by one.
+* [ ] A handoff that upstream cannot read is not "handoff contract OK".
+      Evidence: with `specs/handoff.md` emptied, upstream exits 2 with no `FAIL`
+      lines and the gate exits non-zero — the states the handoff contract exists
+      to prevent used to be reported as passing.
+* [ ] A checkout at the adopted revision that cannot run the checker is refused.
+      Evidence: with `scripts/` removed from the checkout, the gate exits
+      non-zero naming the missing `story-check`, rather than reading zero
+      findings for every Story.
 * [ ] A marker recording no revision is refused rather than defaulting.
       Evidence: the gate exits 1 naming `specs/.forgeflow-adoption`.
 * [ ] A Story directory that upstream reports on but that has no exemption entry
@@ -83,6 +96,17 @@ that counts as passing.
 * [ ] No Story file, other than this Story's own, is edited.
       Evidence: `git show <delivering commit> --name-only -- specs/stories/`
       names only `_template/` and `DBCLI-018-*`.
+
+## Known Limits
+
+The Acceptance Evidence map is expressible and unenforced. It is a
+`story-check --ready` check, and this gate runs the default mode; DBCLI-018's
+own Story fails `--ready` on exactly that finding and on checkbox AC
+identifiers. Adopting `--ready` is a decision about every future Story and needs
+a second exemption set for the twenty-five that predate it, so it is out of
+scope here — named rather than left to be discovered. Authority, Risk and Task
+mode are checked in the default mode and so are enforced from this Story
+onward.
 
 ## Verification Notes
 

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
@@ -19,7 +19,8 @@ that counts as passing.
 * [ ] Upstream's checkers pass against this repository.
       Evidence: with a checkout at the adopted revision,
       `FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract` → exit `0`,
-      reporting 25 Stories, 21 admitted findings and handoff contract OK.
+      reporting 26 Stories — the 25 that existed plus this one — 21 admitted
+      findings, and handoff contract OK.
 * [ ] `handoff-check` now passes where it used to fail.
       Evidence: upstream `handoff-check` on `specs/handoff.md` reports
       `HANDOFF_CONTRACT_OK`; under v0.3.2 the same file reported eight
@@ -39,7 +40,7 @@ that counts as passing.
       non-zero and names the commands that produce a usable checkout.
 * [ ] Every one of the 21 pre-existing findings is admitted exactly, by Story.
       Evidence: `PREDATING_FINDINGS` in
-      `scripts/check-forgeflow-contract.ts` lists 21 findings across
+      `scripts/lib/forgeflow-contract.ts` lists 21 findings across
       `DBCLI-PLAT-004`, `005`, `006`, `007` and `012`, each string identical to
       what upstream prints.
 * [ ] A new finding in an exempt Story fails; a fixed one fails as a stale
@@ -54,10 +55,11 @@ that counts as passing.
       fails as a stale entry; this is the other direction, which was a sentence
       in a header that nothing checked.
 * [ ] `make verify` is unchanged by this Story.
-      Evidence: `git show <delivering commit> --name-only` names no `Makefile`,
-      no `tests/contract/`, and no `src/`. Not `git diff main...HEAD`: this
-      branch is stacked on DBCLI-017, whose attestation work does change the
-      `Makefile`, so a range diff would attribute that change here.
+      Evidence: `git diff 284b5211..HEAD --name-only -- Makefile src
+      tests/contract` is empty. The range starts at DBCLI-017's delivered
+      commit, not at `main`: this branch is stacked on it, and its attestation
+      work does change the `Makefile`, so a diff from `main` would attribute
+      that change here.
 * [ ] The offline guarantee is intact.
       Evidence: `bun run forgeflow:check` — the only ForgeFlow step in
       `make verify` — exits `0` with `FORGEFLOW_ROOT` unset, and neither
@@ -93,9 +95,13 @@ that counts as passing.
 * [ ] DBCLI-016's refusal rules and DBCLI-017's attestation are untouched.
       Evidence: `bun run forgeflow:check` and the attestation unit tests pass
       unchanged.
-* [ ] No Story file, other than this Story's own, is edited.
-      Evidence: `git show <delivering commit> --name-only -- specs/stories/`
-      names only `_template/` and `DBCLI-018-*`.
+* [ ] No delivered Story's text is edited.
+      Evidence: `git diff 284b5211..HEAD --name-only -- specs/stories/` names
+      exactly five paths: this Story's two files, the two templates upstream's
+      bootstrap replaced, and `specs/stories/README.md`. The README carries the
+      canonical adoption declaration that `bun run forgeflow:check` compares
+      against the marker, so the upgrade cannot land without it. No file under a
+      delivered Story's directory appears.
 
 ## Known Limits
 

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
@@ -77,6 +77,20 @@ that counts as passing.
       Evidence: with `specs/handoff.md` emptied, upstream exits 2 with no `FAIL`
       lines and the gate exits non-zero — the states the handoff contract exists
       to prevent used to be reported as passing.
+* [ ] A checkout with uncommitted changes is refused.
+      Evidence: edit `scripts/story-check` in the checkout to suppress a finding
+      and the gate exits non-zero quoting the dirty path — `rev-parse HEAD` is
+      unchanged by such an edit, so revision alone would have gone on asserting
+      the adopted rules while running somebody's local ones.
+* [ ] A path git cannot read is refused as that, not as an unset variable.
+      Evidence: `FORGEFLOW_ROOT=/nonexistent` names the path and says it is not
+      a readable git checkout, rather than telling the reader to set a variable
+      they already set.
+* [ ] A Story directory upstream cannot read is not invisible.
+      Evidence: a directory holding only `acceptance.md` makes upstream exit 2;
+      the gate refuses. Discovery is upstream's — one no-argument run from the
+      repository root — so a directory this gate would not have globbed is still
+      seen.
 * [ ] A checkout at the adopted revision that cannot run the checker is refused.
       Evidence: with `scripts/` removed from the checkout, the gate exits
       non-zero naming the missing `story-check`, rather than reading zero

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/acceptance.md
@@ -46,10 +46,23 @@ that counts as passing.
       entry; a Story with no entry must be clean.
       Evidence: fixture tests in
       `tests/unit/scripts/forgeflow-contract.test.ts`.
-* [ ] `make verify` is unchanged.
-      Evidence: `git diff main...HEAD -- Makefile` is empty, and
-      `tests/contract/forgepilot-boundary.test.ts` passes with its
-      `REQUIRED_STEPS` roster unedited.
+* [ ] The list cannot grow without a deliberate edit.
+      Evidence: `ADMITTED_FINDINGS` and `ADMITTED_STORIES` are compared against
+      `PREDATING_FINDINGS` by a test, so adding an entry fails until someone
+      lowers — never raises — those numbers. Verified by adding an entry: the
+      suite goes red. Shrinking is already mechanical, since a fixed finding
+      fails as a stale entry; this is the other direction, which was a sentence
+      in a header that nothing checked.
+* [ ] `make verify` is unchanged by this Story.
+      Evidence: `git show <delivering commit> --name-only` names no `Makefile`,
+      no `tests/contract/`, and no `src/`. Not `git diff main...HEAD`: this
+      branch is stacked on DBCLI-017, whose attestation work does change the
+      `Makefile`, so a range diff would attribute that change here.
+* [ ] The offline guarantee is intact.
+      Evidence: `bun run forgeflow:check` — the only ForgeFlow step in
+      `make verify` — exits `0` with `FORGEFLOW_ROOT` unset, and neither
+      `check-forgeflow-adoption.ts` nor `check-forgeflow-handoff.ts` reads that
+      variable.
 
 ## Failure Cases
 
@@ -68,8 +81,8 @@ that counts as passing.
       Evidence: `bun run forgeflow:check` and the attestation unit tests pass
       unchanged.
 * [ ] No Story file, other than this Story's own, is edited.
-      Evidence: `git diff --stat main...HEAD -- specs/stories/` names only
-      `_template/` and `DBCLI-018-*`.
+      Evidence: `git show <delivering commit> --name-only -- specs/stories/`
+      names only `_template/` and `DBCLI-018-*`.
 
 ## Verification Notes
 

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/story.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/story.md
@@ -1,0 +1,129 @@
+# Story: DBCLI-018 ForgeFlow Adoption Upgrade
+
+## Goal
+
+A Story written in this repository can declare what the agent may do, how risky
+the change is, and what evidence proves each acceptance criterion — and those
+declarations are checked by something, rather than being sections nobody reads.
+
+## Context
+
+The adoption marker recorded ForgeFlow 0.3.2 from revision `7bbdf443`. Upstream
+is 0.6.0. Measured on 2026-09-08, from checkouts of both tags:
+
+* **The upgrade breaks nothing.** Running upstream `story-check` over all 25
+  Story directories gives the identical result under v0.3.2 and v0.6.0: 21
+  findings across 5 Stories, the same 21. No existing Story fails for a reason
+  0.6.0 introduced.
+* **It fixes something.** `handoff-check` goes from `HANDOFF_CONTRACT_INCOMPLETE`
+  to `HANDOFF_CONTRACT_OK`. The eight `completed Story is not a Story ID:
+  DBCLI-PLAT-*` failures were 0.3.2's Story ID grammar predating that naming;
+  0.6.0 widened it. `docs/releases/0.6.0.md` names this repository as the survey
+  that prompted the change.
+* **The upgrade is four files.** `./scripts/bootstrap --upgrade` replaces the
+  three `specs/stories/_template/` files and the marker, and nothing else;
+  `AGENTS.md` and guidance became repository-owned at install. A dry run against
+  this repository listed exactly those four, and the three templates were
+  byte-identical to the v0.3.2 originals, so no local wording was overwritten.
+* **The 21 findings predate everything.** They are three kinds of wording — a
+  trust-boundary field written as prose, a security fixture cell written as
+  prose instead of an exact backticked value, and one Story whose Classification
+  contradicts its own Superseded Behavior. Nothing ever reported them, because
+  `make verify` runs this repository's own TypeScript reconciliation and has
+  never run upstream's checkers.
+
+That last point is the one that decides this Story's shape. Authority, Risk,
+Task mode and the Acceptance Evidence map are all optional at 0.6.0 and all
+enforced by upstream checkers only. Moving the marker without running those
+checkers would change what a Story is permitted to say and nothing about what is
+checked — which is the shape of adoption that DBCLI-013 and DBCLI-016 both had
+to close afterwards.
+
+## Classification
+
+Both declarations are required. `yes` makes the matching section below
+mandatory.
+
+* Security sensitive: no
+* Baseline conformance: no
+
+## Scope
+
+### In Scope
+
+* Upgrading the adoption through upstream's own mechanism, `./scripts/bootstrap
+  --upgrade`, rather than by editing the marker.
+* Pinning the marker to the `v0.6.0` tag rather than to whichever checkout
+  bootstrap happened to run from.
+* Bringing every adoption surface to the new version, which
+  `bun run forgeflow:check` already enforces.
+* A CI job that fetches the adopted revision and runs upstream `story-check` and
+  `handoff-check` against this repository, reconciled against a shrinking list
+  of the findings that predate it.
+* An ADR recording why upstream's checkers are run rather than reimplemented.
+
+### Out of Scope
+
+* Fixing the 21 pre-existing findings. They are admitted exactly, per Story, and
+  belong to their own Story: sixteen of them are matrix cells whose real values
+  have to be re-derived from the code they describe, and all of them are edits
+  to acceptance text a human already accepted.
+* Adding `Authority`, `Risk`, `Task mode`, `Architecture` or an Acceptance
+  Evidence map to any existing Story. The upgrade makes them expressible; it
+  does not retrofit them.
+* `scripts/story-check --ready`, which requires an Acceptance Evidence map for
+  every Story and currently reports 71 findings. Adopting it is a decision about
+  every future Story, not a side effect of an upgrade.
+* Installing upstream's `templates/story/verification.md`. Bootstrap does not
+  manage it, and the verification result contract has no consumer here yet.
+* Any change to `make verify`, its steps, or its offline guarantee.
+* Any change to `src/`, or to what dbcli ships.
+
+## Inputs
+
+* `specs/.forgeflow-adoption`, as the record of which contract applies.
+* A ForgeFlow checkout at that revision, provided by CI through
+  `FORGEFLOW_ROOT`.
+* Every `specs/stories/*/story.md` and `acceptance.md`, and `specs/handoff.md`.
+
+## Outputs
+
+* An adoption marker naming 0.6.0 and the `v0.6.0` tag.
+* Templates carrying the new optional sections, for Stories written next.
+* `bun run forgeflow:contract`, and a CI job that runs it.
+* An exact, per-Story record of the 21 findings this repository has not yet
+  fixed.
+
+## Rules
+
+* R1: The upgrade is performed by upstream's `bootstrap --upgrade`, and the only
+  files it changes are the three templates and the marker.
+* R2: The recorded revision is the one the recorded version names. A marker
+  saying `0.6.0` while pointing at a commit after the tag gives "which release
+  is this" two answers.
+* R3: The contract gate refuses a ForgeFlow checkout whose revision is not the
+  adopted one, and refuses to run with no checkout at all rather than skipping.
+* R4: Every finding upstream reports is either absent or listed exactly. A new
+  finding fails; a listed finding that has been fixed fails as a stale entry; a
+  Story with no entry must be clean.
+* R5: The list may shrink and never grow.
+* R6: `make verify` gains no step, keeps its existing steps in order, and still
+  runs offline from a clone of this repository alone.
+
+## Expected Errors
+
+* A contract check with no `FORGEFLOW_ROOT` refuses, naming the commands that
+  produce a usable checkout.
+* A checkout at another revision refuses, naming both revisions.
+* A Story that acquires a new finding fails with the finding quoted, not with a
+  count.
+
+## Dependencies
+
+* Network access in the CI job that clones ForgeFlow. `make verify` gains none.
+
+## Constraints
+
+* The two existing ForgeFlow gates stay offline and stay inside `make verify`.
+* Upstream's rules are run, not reimplemented: two implementations of one
+  contract diverge on a schedule nobody controls.

--- a/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/story.md
+++ b/specs/stories/DBCLI-018-forgeflow-adoption-upgrade/story.md
@@ -106,9 +106,13 @@ mandatory.
 * R4: Every finding upstream reports is either absent or listed exactly. A new
   finding fails; a listed finding that has been fixed fails as a stale entry; a
   Story with no entry must be clean.
-* R5: The list may shrink and never grow.
+* R5: The list may shrink and never grow. Both directions are checked: a fixed
+  finding fails as a stale entry, and a new entry fails an admitted-count test
+  until someone lowers that count deliberately.
 * R6: `make verify` gains no step, keeps its existing steps in order, and still
-  runs offline from a clone of this repository alone.
+  runs offline from a clone of this repository alone. This Story's own commit
+  touches no `Makefile`; the branch it is stacked on does, so the two must not
+  be read from one range diff.
 
 ## Expected Errors
 

--- a/specs/stories/README.md
+++ b/specs/stories/README.md
@@ -1,9 +1,14 @@
 # ForgeFlow Stories
 
-This repository adopted ForgeFlow 0.3.2 from revision
-`7bbdf443ead484780e23df9abf055095d4c629e2`; `specs/.forgeflow-adoption` is the
+This repository adopted ForgeFlow 0.6.0 from revision
+`51ab1f20defffc9477c02989989dcda244df791e`; `specs/.forgeflow-adoption` is the
 machine-readable record of that. It was first adopted at 0.3.0
-(`afca7600db01279ddfe74ac030bd226444cc8b11`).
+(`afca7600db01279ddfe74ac030bd226444cc8b11`), then 0.3.2, then 0.6.0 via
+`./scripts/bootstrap --upgrade` from a ForgeFlow checkout.
+
+The recorded revision is the `v0.6.0` tag, not the checkout `bootstrap` happened
+to be at — that was two documentation commits later, and a marker naming an
+untagged revision makes "which release is this" a question with two answers.
 
 `make verify` runs `bun run forgeflow:check`, which reconciles the handoff's
 `completed_stories` against the repository. Upstream's `story-check` and

--- a/specs/stories/_template/acceptance.md
+++ b/specs/stories/_template/acceptance.md
@@ -2,19 +2,34 @@
 
 ## Happy Path
 
-* [ ]
+* [ ] AC-001: <acceptance criterion>
 
 ## Business Rules
 
-* [ ]
+* [ ] AC-002: <acceptance criterion>
 
 ## Failure Cases
 
-* [ ]
+* [ ] AC-003: <acceptance criterion>
 
 ## Regression Requirements
 
-* [ ]
+* [ ] AC-004: <acceptance criterion>
+
+## Acceptance Evidence
+
+Required for `scripts/story-check --ready`. Add exactly one row for every
+checkbox AC. `Method` is `test`, `command`, or `human`; every other value is
+one exact non-placeholder value in backticks. The checker validates this map
+only. Run the declared command or test, and leave contextual judgment to Human
+Review.
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | test | `tests/example.sh` | `fixture name` | `expected assertion` |
+| `AC-002` | command | `make verify` | `repository checkout` | `exit 0` |
+| `AC-003` | human | `review record` | `external invariant` | `review observation` |
+| `AC-004` | test | `tests/example.sh` | `regression fixture` | `expected assertion` |
 
 ## Security Fixture Matrix
 
@@ -30,3 +45,15 @@ backticks. The expected result is one of `preserve`, `redact`, `reject`, or
 ## Verification Notes
 
 Any Story-specific verification instructions.
+
+Replace placeholders with observable criteria; keep each AC ID unique. Optional
+`scripts/story-check --ready <story-directory>` checks minimum content and the
+evidence map, not human-approved READY. Criteria may be checked manually or
+automatically.
+
+Example (fenced examples do not count as acceptance criteria):
+
+```markdown
+* [ ] AC-001: An empty order returns a total of zero cents.
+* [ ] AC-002: A negative quantity is rejected with an invalid-quantity error.
+```

--- a/specs/stories/_template/story.md
+++ b/specs/stories/_template/story.md
@@ -15,6 +15,47 @@ mandatory.
 
 * Security sensitive: no
 * Baseline conformance: no
+* Task mode: execution
+
+`Task mode` is optional and defaults to `execution`. Use `architecture` for a
+boundary, ownership, contract, or migration decision; `evidence` for inspection,
+review, or diagnosis that must not change the repository; and `mixed` when the
+Story contains both.
+
+## Authority
+
+Optional. Delete this section to accept the documented defaults for the task
+mode. Every operation is declared as `yes` or `no`, and being able to perform an
+operation is never authorization to perform it.
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: no
+* push: no
+* deploy: no
+
+## Architecture
+
+Optional. `Impact` defaults to `low`; delete this section for a Story that
+carries no architecture weight. `Impact: medium` or `high` must name at least
+one decision or contract. Each `Decision` resolves to a record under
+`specs/decisions/`.
+
+* Impact: low
+* Decision: `ADR-001`
+* Boundary: `BoundaryName`
+* Contract: `BoundaryName public interface remains compatible`
+* Owner: `BoundaryName = owning-domain`
+
+## Risk
+
+Optional. `Level` defaults to `low`; `medium` and `high` must name at least one
+reason. Risk raises inspection and verification depth. It never widens scope.
+
+* Level: low
+* Reason: `signal`
 
 ## Scope
 
@@ -48,6 +89,20 @@ mandatory.
 *
 
 ## Constraints
+
+*
+
+## Guidance
+
+<!-- Optional. Reference relevant engineering principles, decisions, or
+practices. Do not place product requirements here. Omit this section when no
+guidance is relevant. -->
+
+Relevant:
+
+* principle: <id>
+
+Not applicable:
 
 *
 

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -7,8 +7,11 @@
 
 import { describe, expect, test } from 'bun:test'
 import {
+  ADMITTED_FINDINGS,
+  ADMITTED_STORIES,
   checkoutRefusal,
   formatContractFailures,
+  PREDATING_FINDINGS,
   reconcileFindings,
   type Exemptions,
 } from '../../../scripts/lib/forgeflow-contract'
@@ -100,5 +103,30 @@ describe('formatContractFailures', () => {
     expect(report).toContain('DBCLI-016')
     expect(report).toContain(PROSE)
     expect(report).toContain('1 finding(s)')
+  })
+})
+
+describe('the exemption ratchet', () => {
+  test('admits exactly what it says it admits', () => {
+    // The rule is "may shrink and never grow". Shrinking is already mechanical
+    // — a fixed finding fails as a stale entry. This is the other direction:
+    // adding an entry fails here until someone lowers, never raises, these two
+    // numbers, which is the deliberate act the rule asks for. Without it the
+    // ratchet was a sentence in a header that nothing checked.
+    const findings = [...PREDATING_FINDINGS.values()].reduce(
+      (total, list) => total + list.length,
+      0
+    )
+
+    expect(PREDATING_FINDINGS.size).toBe(ADMITTED_STORIES)
+    expect(findings).toBe(ADMITTED_FINDINGS)
+  })
+
+  test('admits no duplicate finding within one Story', () => {
+    // A repeated string would satisfy the count while admitting one fewer real
+    // finding than it appears to.
+    for (const [story, findings] of PREDATING_FINDINGS) {
+      expect(new Set(findings).size, story).toBe(findings.length)
+    }
   })
 })

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Running upstream's checkers is only worth it if the result is reconciled.
+ *
+ * Fixtures, not a repository: the real Story set changes every delivery, and a
+ * test that read it would have to be rewritten to stay green.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  checkoutRefusal,
+  formatContractFailures,
+  reconcileFindings,
+  type Exemptions,
+} from '../../../scripts/lib/forgeflow-contract'
+
+const ADOPTED = '51ab1f20defffc9477c02989989dcda244df791e'
+const PROSE = 'every trust-boundary field must name an exact field, not prose'
+
+const exemptions = (entries: [string, string[]][]): Exemptions => new Map(entries)
+
+describe('checkoutRefusal', () => {
+  test('the adopted revision is accepted', () => {
+    expect(checkoutRefusal(ADOPTED, ADOPTED)).toBeNull()
+  })
+
+  test('another revision is refused, naming both', () => {
+    const refusal = checkoutRefusal(ADOPTED, 'b'.repeat(40))
+
+    // A checkout of some other ForgeFlow enforces some other contract, and an
+    // upgrade that moved the marker without moving the rules would otherwise
+    // look complete.
+    expect(refusal).toContain(ADOPTED)
+    expect(refusal).toContain('b'.repeat(40))
+  })
+
+  test('an absent checkout is refused, not skipped', () => {
+    // A gate that passes wherever its evidence is missing passes in CI and
+    // nowhere else.
+    const refusal = checkoutRefusal(ADOPTED, undefined)
+
+    expect(refusal).toContain('FORGEFLOW_ROOT')
+    expect(refusal).toContain(ADOPTED)
+  })
+})
+
+describe('reconcileFindings', () => {
+  test('a clean Story set passes', () => {
+    expect(reconcileFindings([{ story: 'DBCLI-016', findings: [] }], exemptions([]))).toEqual([])
+  })
+
+  test('a finding in a Story with no exemption fails', () => {
+    const failures = reconcileFindings([{ story: 'DBCLI-016', findings: [PROSE] }], exemptions([]))
+
+    expect(failures).toEqual([{ subject: 'DBCLI-016', reason: PROSE }])
+  })
+
+  test('an admitted finding passes', () => {
+    const failures = reconcileFindings(
+      [{ story: 'DBCLI-PLAT-004', findings: [PROSE] }],
+      exemptions([['DBCLI-PLAT-004', [PROSE]]])
+    )
+
+    expect(failures).toEqual([])
+  })
+
+  test('a new finding in an exempt Story fails', () => {
+    // Counting instead of comparing would let a Story trade one finding for
+    // another and keep its total.
+    const failures = reconcileFindings(
+      [{ story: 'DBCLI-PLAT-004', findings: ['something else entirely'] }],
+      exemptions([['DBCLI-PLAT-004', [PROSE]]])
+    )
+
+    expect(failures).toHaveLength(2)
+    expect(failures[0]!.reason).toMatch(/this finding is new/)
+    expect(failures[1]!.reason).toMatch(/no longer reports/)
+  })
+
+  test('a finding that has been fixed fails as a stale exemption', () => {
+    const failures = reconcileFindings(
+      [{ story: 'DBCLI-PLAT-004', findings: [] }],
+      exemptions([['DBCLI-PLAT-004', [PROSE]]])
+    )
+
+    expect(failures).toHaveLength(1)
+    expect(failures[0]!.reason).toMatch(/delete the exemption entry/)
+  })
+
+  test('an exemption for a Story that no longer exists fails', () => {
+    const failures = reconcileFindings([], exemptions([['DBCLI-GONE', [PROSE]]]))
+
+    expect(failures[0]!.reason).toMatch(/no Story directory/)
+  })
+})
+
+describe('formatContractFailures', () => {
+  test('every failure is named with its subject', () => {
+    const report = formatContractFailures([{ subject: 'DBCLI-016', reason: PROSE }])
+
+    expect(report).toContain('DBCLI-016')
+    expect(report).toContain(PROSE)
+    expect(report).toContain('1 finding(s)')
+  })
+})

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -12,6 +12,7 @@ import {
   ADMITTED_STORIES,
   checkoutRefusal,
   formatContractFailures,
+  parseStoryCheck,
   PREDATING_FINDINGS,
   reconcileFindings,
   type Exemptions,
@@ -22,28 +23,81 @@ const PROSE = 'every trust-boundary field must name an exact field, not prose'
 
 const exemptions = (entries: [string, string[]][]): Exemptions => new Map(entries)
 
+const clean = { root: '/tmp/forgeflow', revision: ADOPTED, status: '' }
+
 describe('checkoutRefusal', () => {
-  test('the adopted revision is accepted', () => {
-    expect(checkoutRefusal(ADOPTED, ADOPTED)).toBeNull()
+  test('a clean checkout at the adopted revision is accepted', () => {
+    expect(checkoutRefusal(ADOPTED, clean)).toBeNull()
   })
 
   test('another revision is refused, naming both', () => {
-    const refusal = checkoutRefusal(ADOPTED, 'b'.repeat(40))
-
     // A checkout of some other ForgeFlow enforces some other contract, and an
     // upgrade that moved the marker without moving the rules would otherwise
     // look complete.
+    const refusal = checkoutRefusal(ADOPTED, { ...clean, revision: 'b'.repeat(40) })
+
     expect(refusal).toContain(ADOPTED)
     expect(refusal).toContain('b'.repeat(40))
   })
 
-  test('an absent checkout is refused, not skipped', () => {
+  test('an unset FORGEFLOW_ROOT is refused, not skipped', () => {
     // A gate that passes wherever its evidence is missing passes in CI and
     // nowhere else.
-    const refusal = checkoutRefusal(ADOPTED, undefined)
+    const refusal = checkoutRefusal(ADOPTED, {
+      root: undefined,
+      revision: undefined,
+      status: undefined,
+    })
 
-    expect(refusal).toContain('FORGEFLOW_ROOT')
-    expect(refusal).toContain(ADOPTED)
+    expect(refusal).toContain('FORGEFLOW_ROOT is not set')
+  })
+
+  test('a path git cannot read is refused as that, not as an unset variable', () => {
+    // Both used to print the same sentence, so a typo in the path sent the
+    // reader to set a variable they had already set.
+    const refusal = checkoutRefusal(ADOPTED, {
+      root: '/nonexistent',
+      revision: undefined,
+      status: undefined,
+    })
+
+    expect(refusal).toContain('/nonexistent')
+    expect(refusal).toContain('not a readable git checkout')
+  })
+
+  test('a dirty checkout is refused, because it is not at any revision', () => {
+    // Editing `scripts/story-check` to stop emitting a finding leaves
+    // `rev-parse HEAD` untouched, so the banner would go on asserting the
+    // adopted revision while the rules being run were somebody's local edit.
+    const refusal = checkoutRefusal(ADOPTED, { ...clean, status: ' M scripts/story-check\n' })
+
+    expect(refusal).toContain('uncommitted changes')
+    expect(refusal).toContain('scripts/story-check')
+  })
+})
+
+describe('parseStoryCheck', () => {
+  const OUTPUT = [
+    'ForgeFlow Story Contract Check',
+    '',
+    'INFO  specs/stories/DBCLI-016-a: Story ID DBCLI-016',
+    'PASS  specs/stories/DBCLI-016-a: classification security=no baseline=no',
+    'INFO  specs/stories/DBCLI-PLAT-004-b: Story ID DBCLI-PLAT-004',
+    `FAIL  specs/stories/DBCLI-PLAT-004-b: ${PROSE}`,
+    '',
+  ].join('\n')
+
+  test('every Story upstream saw is reported, clean or not', () => {
+    // Upstream discovers the directories; globbing for them here was directory
+    // selection reimplemented, and it hid a directory with no `story.md`.
+    expect(parseStoryCheck(OUTPUT)).toEqual([
+      { story: 'DBCLI-016-a', findings: [] },
+      { story: 'DBCLI-PLAT-004-b', findings: [PROSE] },
+    ])
+  })
+
+  test('lines that are neither INFO nor FAIL are ignored', () => {
+    expect(parseStoryCheck('Result: STORY_CONTRACT_OK\nStories checked: 2\n')).toEqual([])
   })
 })
 
@@ -171,5 +225,29 @@ describe('readCheckerRun', () => {
 
   test('findings without a failing exit are refused too', () => {
     expect(typeof readCheckerRun('DBCLI-016', { exitCode: 0, output: 'FAIL  x\n' })).toBe('string')
+  })
+})
+
+describe('findings are compared as multisets', () => {
+  test('two identical findings do not match one exemption entry', () => {
+    // With `includes` in both directions the count would agree while one real
+    // finding went unadmitted.
+    const failures = reconcileFindings(
+      [{ story: 'DBCLI-PLAT-004', findings: [PROSE, PROSE] }],
+      exemptions([['DBCLI-PLAT-004', [PROSE]]])
+    )
+
+    expect(failures).toHaveLength(1)
+    expect(failures[0]!.reason).toMatch(/this finding is new/)
+  })
+
+  test('a duplicated exemption entry is reported stale', () => {
+    const failures = reconcileFindings(
+      [{ story: 'DBCLI-PLAT-004', findings: [PROSE] }],
+      exemptions([['DBCLI-PLAT-004', [PROSE, PROSE]]])
+    )
+
+    expect(failures).toHaveLength(1)
+    expect(failures[0]!.reason).toMatch(/delete the exemption entry/)
   })
 })

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   ADMITTED_FINDINGS,
+  readCheckerRun,
   ADMITTED_STORIES,
   checkoutRefusal,
   formatContractFailures,
@@ -128,5 +129,47 @@ describe('the exemption ratchet', () => {
     for (const [story, findings] of PREDATING_FINDINGS) {
       expect(new Set(findings).size, story).toBe(findings.length)
     }
+  })
+})
+
+describe('readCheckerRun', () => {
+  test('a clean run is no findings', () => {
+    expect(readCheckerRun('DBCLI-016', { exitCode: 0, output: 'PASS  all good\n' })).toEqual([])
+  })
+
+  test('a run with findings returns them', () => {
+    const read = readCheckerRun('DBCLI-016', { exitCode: 1, output: `FAIL  ${PROSE}\n` })
+
+    expect(read).toEqual([`FAIL  ${PROSE}`])
+  })
+
+  test('a Story upstream refused to read is not a clean Story', () => {
+    // The false PASS this function exists to prevent: upstream reports a
+    // missing or unreadable acceptance.md on stderr with an ERROR prefix and
+    // exit 2, printing no FAIL lines, and a reader that only looks for FAIL
+    // counts the Story as satisfying the contract it was never checked against.
+    const read = readCheckerRun('DBCLI-999', {
+      exitCode: 2,
+      output: 'ERROR required Story file is missing or unreadable\n',
+    })
+
+    expect(typeof read).toBe('string')
+    expect(read as string).toContain('DBCLI-999')
+    expect(read as string).toContain('exited 2')
+  })
+
+  test('a checker that could not be spawned is not a clean repository', () => {
+    // `.nothrow()` swallows the spawn failure, and every Story then yields zero
+    // findings — which reads exactly like a repository with nothing wrong.
+    const read = readCheckerRun('DBCLI-016', {
+      exitCode: 1,
+      output: 'bun: command not found: story-check\n',
+    })
+
+    expect(typeof read).toBe('string')
+  })
+
+  test('findings without a failing exit are refused too', () => {
+    expect(typeof readCheckerRun('DBCLI-016', { exitCode: 0, output: 'FAIL  x\n' })).toBe('string')
   })
 })


### PR DESCRIPTION
> 疊在 #176（DBCLI-017）上。#176 合併後這個 PR 會自動改對 `main`。

採用版本從 ForgeFlow 0.3.2 推到 0.6.0，走上游自己的 `./scripts/bootstrap --upgrade`，不是手改版本號；並新增一個 CI job，讓 0.6.0 帶來的能力真的被檢查。

## 動工前量到的三件事

**升級不弄壞任何東西。** 25 個 Story 在 v0.3.2 與 v0.6.0 的 `story-check` 下失敗清單完全相同——21 條、集中在 5 個 Story，0.6.0 沒新增任何一條。

**升級修好一件事。** `handoff-check` 從 `INCOMPLETE` 變成 `OK`：那八條 `completed Story is not a Story ID: DBCLI-PLAT-*` 是 0.3.2 的 Story ID 文法早於這個命名，0.6.0 放寬了。`docs/releases/0.6.0.md` 點名這個 repo 就是促成那次調查的對象。

**升級只有四個檔。** dry-run 與實跑都只動三個 `_template/` 與 marker；`AGENTS.md` 與 guidance 在首次安裝後就是 repository-owned。三個 template 與 v0.3.2 原版逐字相同，沒有本地客製被蓋掉。

marker 釘 `v0.6.0` tag（`51ab1f20`）而不是 bootstrap 當時所在的 checkout——那在 tag 之後兩個文件 commit，marker 指著未上 tag 的 revision 會讓「這是哪一版」有兩個答案。

## 為什麼不只是改個數字

Authority、Risk、Task mode、Acceptance Evidence 全是 optional，而且**只由上游 checker 執行**，那些 checker 住在這個 repo 沒有的 checkout 裡。只推版本號會改變「一個 Story 被允許說什麼」，卻不改變「什麼被檢查」——正是 DBCLI-013 與 DBCLI-016 事後各自要收拾的形狀。

沒有在 `scripts/` 裡重寫那些規則：既有 gate 的檔頭明寫它「刻意不與上游 `story-check` 重疊」，而一份自己不擁有的契約寫兩份實作，副本會是沒人更新的那一份。改成 CI 新增 `forgeflow-contract` job，clone marker 指定的 revision 跑上游自己的 checker。它是 CI job 不是 `make verify` 的 step，因為 canonical gate 必須能從單獨一份 clone 離線跑完——`make verify` 一個字沒動。

## 21 條舊債：列出來，不是修掉

5 個已交付的 Story 在上游 `story-check` 下有 21 條 FAIL，0.3.2 下就一模一樣。從來沒人知道，因為 `make verify` 跑的是自家的 TypeScript 對帳，從來沒跑過上游的 checker。

不在這個 Story 修是人的決定：16 條是矩陣儲存格，真實的值要回程式碼重新推導，而且全部都是在改一份人已經接受過的驗收文本。在那之前它們被**逐條列進棘輪**——exempt 的 Story 多一條新的會 fail，修好了沒刪 entry 也會 fail，沒有 entry 的必須全乾淨，而且 `ADMITTED_FINDINGS = 21` 由測試比對，多加一筆就紅，除非有人把數字往下調。逐 Story 的拆解在 `specs/handoff.md`。

## Review 找到的東西

兩份獨立 review。兩個 CRITICAL、一個 HIGH 值得單獨講：

**上游的 `ERROR` 不印 `FAIL`。** 讀不到 `story.md`／`acceptance.md` 這類操作性失敗，上游印在 stderr、前綴 `ERROR`、exit 2，一條 `FAIL` 都不印。只看 `FAIL` 的讀法看不到問題，於是一個**上游拒絕去讀**的 Story 被算成滿足契約、總數還從 26 變成 27；`specs/handoff.md` 被清空也一樣，會被報成「handoff contract OK」。改成 `readCheckerRun` 明確命名三種結果，其餘一律是 gate 自己的失敗而不是對 Story 的判決。

**髒的 checkout 不在任何 revision 上。** revision 檢查只問 `rev-parse HEAD`，所以把 checkout 裡的 `story-check` 改掉、讓某條 finding 不再出現，`rev-parse` 完全不受影響，banner 還是宣稱「passed against 51ab1f20」。現在 `git status --porcelain` 也必須是空的。

**Story 探索本來是自己 glob**，那是把上游的目錄選擇規則重寫了一遍——而 ADR-0027 整篇的主張就是「跑上游的規則，不重寫」。改成一次無參數執行由上游探索，順帶把 26 次 spawn 降成 1 次，也修好一個真的看不見的情況：只有 `acceptance.md` 沒有 `story.md` 的目錄，上游會 ERROR，glob 根本看不到它。

另外，我自己的 ADR 原本聲稱 Acceptance Evidence 被檢查——**它沒有**。那是 `--ready` 的檢查，而這個 gate 跑預設模式，所以 DBCLI-018 自己的 Story 用 `--ready` 跑就會因為那一條而 fail。ADR 與 acceptance 的 Known Limits 現在分開講「預設模式會檢查的三項」與「不會的那一項」。

## Test plan

- `bun test tests/unit/scripts/forgeflow-contract.test.ts` — 23 pass
- `FORGEFLOW_ROOT=<v0.6.0 checkout> bun run forgeflow:contract` — exit 0，`26 Stories, 21 admitted pre-existing finding(s), handoff contract OK`
- 七條拒絕路徑逐一實測：未設變數／路徑不可讀／非 git 目錄／revision 不符／髒的 checkout／checkout 缺 `scripts/`／Story 只有 `acceptance.md`
- 上游 `handoff-check`：`HANDOFF_CONTRACT_OK`（v0.3.2 下是 8 條 `DBCLI-PLAT-*` 失敗）
- `make verify`：ForgePilot 在 `b1f2f3c34a1430934555fdab6c0e96b002ddb7d9` 的 detached worktree 執行，**PASS**，evidence `EV-014`，與本 PR HEAD 同一個 commit
- typecheck / typecheck:tests / lint / format:check / forgeflow:check 全過

## 需要你決定的兩件事

**`main` 沒有分支保護**（`gh api …/branches/main/protection` 回 *Branch not protected*），所以新的 `forgeflow-contract` job 跟其他所有 job 一樣擋不住 merge。ADR-0027 的立論建立在「CI 會跑它」之上——沒有保護的話，那句話只在有人去看的時候成立。這是 repo 層級的既有狀況，不在本 Story 範圍，也不該由 agent 代為決定。

ADR-0027 是 `status: proposed`。

## 未採用與後續

`story-check --ready` 沒有打開：它回答的是**不同的問題**（交付前的最低內容，獨立的 `STORY_READINESS_INCOMPLETE` 結果），回頭開啟等於用一個當初不存在的標準重新審判 25 個已被接受的 Story，而且會改變未來每一個 Story 的門檻。後續值得開的是「Story readiness 該不該被把關、在哪裡把關」，那是另一個 Story 加另一份 ADR；若它成立，DBCLI-018 自己的 `acceptance.md` 是第一個客戶。

那 21 條舊債同樣需要一個自己的 Story。

Story: DBCLI-018

https://claude.ai/code/session_016ergjTN99kDPMngzfquBBw
