### PR TITLE
docs: [ forgeflow ] 例外清單第一次縮短：PLAT-004 與 PLAT-005

### DIFF
--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -46,11 +46,15 @@
 // matrix cells whose real values have to be re-derived from the code. That is
 // its own Story.
 //
-// DBCLI-022 removed the first of them, which is what the list shrinking looks
-// like: PLAT-004's one finding named a trust-boundary declaration that did not
-// say what the code does, so the declarations were re-derived against the code
-// rather than backticked to please the checker. Four Stories and twenty
-// findings remain.
+// DBCLI-022 and DBCLI-023 removed the first two, which is what the list
+// shrinking looks like: each finding named a declaration that did not say what
+// the code does, so the declarations were re-derived against the code rather
+// than backticked to please the checker. PLAT-005 also carried the one
+// Classification contradiction — `Baseline conformance: no` beside a
+// `## Superseded Behavior` section — resolved by correcting the declaration,
+// because the section's content was true and four sibling Stories use `yes` for
+// exactly that shape. Three Stories and eighteen findings remain: sixteen
+// security-fixture cells and two more trust-boundary sections.
 //
 // Until then the findings are listed, exactly, so that they are bounded rather
 // than tolerated: a new finding in an exempt Story fails, a finding that has
@@ -294,7 +298,11 @@ export function formatContractFailures(failures: readonly ContractFailure[]): st
  * code they describe and editing acceptance text a human already accepted, so
  * it is its own Story rather than a paragraph of DBCLI-018.
  *
- * Twenty across four Stories remain; DBCLI-022 took PLAT-004's out.
+ * Eighteen across three Stories remain; DBCLI-022 took PLAT-004's out and
+ * DBCLI-023 took PLAT-005's, which was also the only Classification
+ * contradiction. What is left is sixteen security-fixture cells stating a value
+ * as prose — the ones that have to be re-derived from the code — and the
+ * trust-boundary sections of PLAT-007 and PLAT-012.
  *
  * The ratchet's two directions are enforced differently, and the difference is
  * worth knowing. Shrinking is mechanical: a finding that has been fixed makes
@@ -304,13 +312,6 @@ export function formatContractFailures(failures: readonly ContractFailure[]): st
  * asking for. Neither direction is left to a reviewer noticing.
  */
 export const PREDATING_FINDINGS: Exemptions = new Map([
-  [
-    'DBCLI-PLAT-005-agent-json-mode',
-    [
-      'every trust-boundary field must name an exact field, not prose',
-      'Story declares Baseline conformance: no but declares superseded behavior',
-    ],
-  ],
   [
     'DBCLI-PLAT-006-correlation-id',
     [
@@ -353,5 +354,5 @@ export const PREDATING_FINDINGS: Exemptions = new Map([
  * These numbers may be lowered and never raised. They exist so that "the list
  * may shrink and never grow" is a check rather than a sentence in a header.
  */
-export const ADMITTED_FINDINGS = 20
-export const ADMITTED_STORIES = 4
+export const ADMITTED_FINDINGS = 18
+export const ADMITTED_STORIES = 3

--- a/scripts/lib/forgeflow-contract.ts
+++ b/scripts/lib/forgeflow-contract.ts
@@ -38,12 +38,19 @@
 //
 // ## The exemptions are a ratchet
 //
-// Five delivered Stories fail upstream `story-check` today, on twenty-one
-// findings that have nothing to do with the upgrade: they failed identically
-// under 0.3.2, and nothing ran the checker, so nobody knew. Rewriting the
-// acceptance text of Stories a human has already accepted is a change to the
-// record, not a formatting fix — sixteen of the findings are matrix cells whose
-// real values have to be re-derived from the code. That is its own Story.
+// Five delivered Stories failed upstream `story-check` when this gate was
+// written, on twenty-one findings that have nothing to do with the upgrade:
+// they failed identically under 0.3.2, and nothing ran the checker, so nobody
+// knew. Rewriting the acceptance text of Stories a human has already accepted
+// is a change to the record, not a formatting fix — sixteen of the findings are
+// matrix cells whose real values have to be re-derived from the code. That is
+// its own Story.
+//
+// DBCLI-022 removed the first of them, which is what the list shrinking looks
+// like: PLAT-004's one finding named a trust-boundary declaration that did not
+// say what the code does, so the declarations were re-derived against the code
+// rather than backticked to please the checker. Four Stories and twenty
+// findings remain.
 //
 // Until then the findings are listed, exactly, so that they are bounded rather
 // than tolerated: a new finding in an exempt Story fails, a finding that has
@@ -287,6 +294,8 @@ export function formatContractFailures(failures: readonly ContractFailure[]): st
  * code they describe and editing acceptance text a human already accepted, so
  * it is its own Story rather than a paragraph of DBCLI-018.
  *
+ * Twenty across four Stories remain; DBCLI-022 took PLAT-004's out.
+ *
  * The ratchet's two directions are enforced differently, and the difference is
  * worth knowing. Shrinking is mechanical: a finding that has been fixed makes
  * the gate fail as a stale entry. Growing is caught by the counts below, which
@@ -295,10 +304,6 @@ export function formatContractFailures(failures: readonly ContractFailure[]): st
  * asking for. Neither direction is left to a reviewer noticing.
  */
 export const PREDATING_FINDINGS: Exemptions = new Map([
-  [
-    'DBCLI-PLAT-004-operation-envelope-v1',
-    ['every trust-boundary field must name an exact field, not prose'],
-  ],
   [
     'DBCLI-PLAT-005-agent-json-mode',
     [
@@ -348,5 +353,5 @@ export const PREDATING_FINDINGS: Exemptions = new Map([
  * These numbers may be lowered and never raised. They exist so that "the list
  * may shrink and never grow" is a check rather than a sentence in a header.
  */
-export const ADMITTED_FINDINGS = 21
-export const ADMITTED_STORIES = 5
+export const ADMITTED_FINDINGS = 20
+export const ADMITTED_STORIES = 4

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -803,6 +803,47 @@ frontmatter。兩種並存等於一份記錄兩個狀態，所以整批轉成 bu
 呼叫者。一個要人記得設的變數，會讓檢查在本機過而在 CI 紅，或者反過來——那種失敗
 說的是環境，不是這個 repo 的內容。
 
+## DBCLI-022：第一條被拿掉的例外
+
+DBCLI-018 讓 CI 跑上游 ForgeFlow 自己的檢查（ADR-0027），當時有五個已交付的
+Story 落在二十一條 findings 上。那份清單寫著「只能縮短，不能增長」，但在這一輪
+之前沒有縮短過。DBCLI-022 拿掉第一條，也是最小的一條：DBCLI-PLAT-004 只有一條
+`every trust-boundary field must name an exact field, not prose`。
+
+**這條 finding 指的不是排版。** 上游的規則是每個 bullet 要含一段非空的反引號
+（`forgeflow_count_literal_bullets`、`forgeflow_has_literal`），PLAT-004 十個
+bullet 裡只有一個不合：`Serialized stdout bytes — final 65,536-byte limit and
+single-document framing`。替那句話加上反引號就會過，而那正是不該做的事——它根本
+不是欄位，而位元組上限與單一文件框架早就是 R12／R13／R14 並且在 acceptance 被斷言。
+
+拿著程式碼重推那一節，發現兩處宣告不只是不精確：
+
+* **`warnings[].message` 不是 curated 文字。** 原本寫「derived diagnostic
+  vocabulary and curated English text」，但重複需求的警告是
+  `Duplicate capability id '${id}' in --require was ignored.`
+  （`src/core/capabilities/check.ts:70`），內插的是使用者打進來的 id。它安全的
+  理由跟宣告寫的不是同一個：那個 id 在 `validAgentRequirements`
+  （`src/commands/capabilities.ts:129-138`）已經先過了 `CAPABILITY_ID_PATTERN`
+  與 160 字元上限。整合測試裡的 `SELECT * FROM users` 與 `/tmp/secret` 兩列，斷言
+  的就是這個。
+* **`evidence[]` 與 `recovery` 這個 Story 從來不產生。** `toAgentEnvelope` 與
+  `createAgentOutputFailure` 無條件寫 `evidence: []`、`recovery: null`。它們跨界
+  只發生在 `parseOperationEnvelope(unknown)` 裡——那是從 `@carllee1983/dbcli/core`
+  匯出、讀一份它管不到的文件的入口。把它們跟 `argv` 並排列，讀起來像是 dbcli
+  會產生這些值。
+
+所以那一節現在按**邊界**分成兩段，而不是攤平成一張表。同一個欄位名在兩個邊界上
+被約束的理由不同，分不出來的讀者就分不出哪些欄位是 dbcli 自己該負責收斂的。
+
+**沒有動 acceptance。** 重寫後宣告的每個欄位，都已經有一條被接受的 acceptance
+criterion 與一支被引用的測試；為了讓宣告與驗收看起來對稱而改寫人類已核可的驗收
+文字，是動紀錄，不是補檢查。
+
+**沒有動 `src/`。** 這一輪是治理修正，不發布版本。
+
+剩下四個 Story、二十條 findings。其中 PLAT-006 與 PLAT-007 合起來是十六格
+security fixture cells，要從程式碼重推，各自是自己的一輪。
+
 ## Lifecycle
 
 `current_story` 與 `next_story` 永久是契約的 sentinel。要知道現在該做什麼，問
@@ -847,9 +888,14 @@ workflow:
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 7fc25ff0a08b8d6ee3b969ecda87b8c935a8e400
+  commit: 8334517bb5c5fb4babf234b1ec87a1ac4a471bdd
   dirty_worktree: false
   story_owned_paths:
+    - specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
+    - specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/acceptance.md
+    - specs/stories/DBCLI-PLAT-004-operation-envelope-v1/story.md
+    - scripts/lib/forgeflow-contract.ts
+    - tests/unit/scripts/forgeflow-contract.test.ts
     - specs/handoff.md
     - specs/.forgeflow-adoption
     - specs/stories/README.md

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -844,6 +844,41 @@ criterion 與一支被引用的測試；為了讓宣告與驗收看起來對稱�
 剩下四個 Story、二十條 findings。其中 PLAT-006 與 PLAT-007 合起來是十六格
 security fixture cells，要從程式碼重推，各自是自己的一輪。
 
+## DBCLI-023：第二條例外，以及最後一個 Classification 矛盾
+
+PLAT-005 是五條裡唯一同時帶兩種 finding 的：一條跟 PLAT-004 同形的
+trust-boundary 散文（`Serialized stdout bytes — must never exceed 65,536 UTF-8
+bytes`），另一條是 `Baseline conformance: no` 卻帶著 `## Superseded Behavior`
+——上游 R8 說宣告 `no` 的 Story 不得帶那一節。
+
+**第二條有兩個出口，而它們不等價。** 翻宣告，或刪那一節；兩者都能讓 checker 閉嘴，
+但一個保住紀錄、一個毀掉紀錄。
+
+判斷的依據不是語感，是同一個 repo 裡的四個兄弟。PLAT-005 那一節寫的是真的：
+PLAT-004 曾把 `operation` 限定在 `capabilities.check`、曾把
+`dbcli --agent-output capabilities` 當成 unsupported operation 拒絕，兩件事
+PLAT-005 都刻意換掉了——正是 template 講的「each existing test or documented
+behavior this Story intentionally replaces」。而 DBCLI-017（`make verify` 步驟
+名冊）、DBCLI-020（十九條絕對時間斷言）、DBCLI-PLAT-011（交付後就會變錯的文件
+句子）、DBCLI-PLAT-012 這四個 Story，全是「改動並取代既有具名行為」這個形狀，
+全都宣告 `yes`。照 `no` 讀，PLAT-005 會是這個形狀裡唯一相反的一個。
+
+所以錯的是宣告，改一個字，兩半都留住。刪掉那一節同樣會過，代價是 PLAT-005
+到底取代了什麼再也沒有任何地方寫著。
+
+trust-boundary 那半重推之後發現剩下的宣告是**單薄**而不是錯的。
+`capabilities.list` 的答案來自 `buildCapabilityCatalog()`，回傳
+`Object.freeze` 過的 `CAPABILITIES`；`src/core/capabilities/` 的整個 import graph
+被斷言不含 `process.env`、`Bun.file(`、`node:fs`、`import(`
+（`tests/contract/capability-contract.test.ts`）。舊宣告把這寫成 catalog「must
+contain no dynamic environment variables, paths, or database credentials」，像是
+一條待辦要求；它其實是程式碼**已經有**而且被結構性檢查釘住的性質。
+
+剩下三個 Story、十八條：十六格 security fixture cells，加上 PLAT-007 與
+PLAT-012 各自的 trust-boundary 一條。Classification 矛盾這一類已經清空。
+
+沒有動 acceptance，沒有動 `src/`。
+
 ## Lifecycle
 
 `current_story` 與 `next_story` 永久是契約的 sentinel。要知道現在該做什麼，問
@@ -888,9 +923,12 @@ workflow:
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 8334517bb5c5fb4babf234b1ec87a1ac4a471bdd
+  commit: 01ee82ecab07a7de6f6b870efa927a0e4f473bb7
   dirty_worktree: false
   story_owned_paths:
+    - specs/stories/DBCLI-023-faithful-plat-005-classification/story.md
+    - specs/stories/DBCLI-023-faithful-plat-005-classification/acceptance.md
+    - specs/stories/DBCLI-PLAT-005-agent-json-mode/story.md
     - specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
     - specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/acceptance.md
     - specs/stories/DBCLI-PLAT-004-operation-envelope-v1/story.md

--- a/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/acceptance.md
+++ b/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/acceptance.md
@@ -1,0 +1,73 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] Upstream `story-check` at the adopted revision `cb4bc976` reports no
+      `FAIL` line for `specs/stories/DBCLI-PLAT-004-operation-envelope-v1` —
+      `FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract`
+* [x] `bun run forgeflow:contract` passes and its banner reads 20 admitted
+      pre-existing findings, down from 21 — same command
+
+## Business Rules
+
+* [x] Every bullet under PLAT-004's `## Trust Boundary Fields` carries a
+      non-empty backticked span, which is the rule
+      `forgeflow_count_literal_bullets` and `forgeflow_has_literal` enforce —
+      upstream `story-check`
+* [x] Each declared field is one the code at this revision actually accepts or
+      emits, named at `src/core/operation-envelope.ts`,
+      `src/utils/agent-output.ts`, `src/commands/capabilities.ts`, or
+      `src/commands/capability-context.ts` — human review against those files
+* [x] The section separates the values dbcli derives from `argv`, the
+      environment and `config.json` from the values
+      `parseOperationEnvelope(unknown)` accepts from an external producer —
+      human review
+* [x] The 65,536-byte cap and single-document framing removed from the section
+      remain stated as R12, R13 and R14 — human review of the same file
+* [x] `PREDATING_FINDINGS` holds no entry for
+      `DBCLI-PLAT-004-operation-envelope-v1`, and the four remaining entries
+      are unchanged in name and content —
+      `tests/unit/scripts/forgeflow-contract.test.ts`
+* [x] `ADMITTED_FINDINGS` is 20 and `ADMITTED_STORIES` is 4, and both equal what
+      `PREDATING_FINDINGS` holds — same file
+* [x] No duplicate finding is admitted within any remaining Story — same file
+
+## Failure Cases
+
+* [x] A finding upstream reports for a Story with no exemption fails the gate as
+      unadmitted, so deleting the entry while the prose remains cannot pass —
+      `tests/unit/scripts/forgeflow-contract.test.ts`
+* [x] An exemption entry upstream no longer reports fails the gate as a stale
+      entry that must be deleted — same file
+* [x] `ADMITTED_FINDINGS` or `ADMITTED_STORIES` left at the old value fails
+      before the gate runs — same file
+* [x] A ForgeFlow checkout at another revision, or with uncommitted changes, is
+      refused rather than run — same file
+
+## Regression Requirements
+
+* [x] `src/` is unchanged by this Story, so no product behavior, output byte, or
+      exit code moves — `git diff --stat` against the baseline commit
+* [x] The other four admitted Stories keep exactly the findings they had —
+      `bun run forgeflow:contract`
+* [x] The complete repository verification gate passes — `make verify`
+
+## Verification Notes
+
+Run the focused contract checks first:
+
+```sh
+bun test tests/unit/scripts/forgeflow-contract.test.ts
+```
+
+Then, from a clean ForgeFlow checkout at exactly `cb4bc976`:
+
+```sh
+FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract
+```
+
+Then run `make verify` from the repository root against a clean, committed
+worktree. `forgeflow:contract` is deliberately not a `make verify` step — it
+needs a ForgeFlow checkout and `make verify` must run from a clone of this
+repository alone — so passing one is not evidence about the other and both are
+required.

--- a/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
+++ b/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
@@ -1,0 +1,163 @@
+# Story: DBCLI-022 A Trust Boundary Declaration That Names Fields
+
+## Goal
+
+DBCLI-PLAT-004's `## Trust Boundary Fields` says what the code actually does, so
+that the first of the five admitted contract exemptions is deleted rather than
+carried, and the ratchet is shown to turn.
+
+## Context
+
+DBCLI-018 had CI run upstream ForgeFlow's own checkers against this
+repository's Stories (ADR-0027). Five delivered Stories failed on twenty-one
+findings that predate the gate; they failed identically under 0.3.2 and nothing
+had run the checker, so nobody knew. The findings are admitted per Story in
+`PREDATING_FINDINGS`, exactly as upstream states them, so that they are bounded
+rather than tolerated — a list that may shrink and never grow.
+
+Nothing had shrunk it yet. This Story is the first entry removed, and the
+smallest: DBCLI-PLAT-004 carries one finding,
+`every trust-boundary field must name an exact field, not prose`.
+
+Upstream's rule is that every bullet under `## Trust Boundary Fields` contains a
+non-empty backticked span (`forgeflow_count_literal_bullets` and
+`forgeflow_has_literal` in `scripts/story-check`). Exactly one of PLAT-004's ten
+bullets does not: `Serialized stdout bytes — final 65,536-byte limit and
+single-document framing`. Satisfying the checker by putting backticks around
+that sentence is available and refused. It is not a field; the section's own
+template asks for "every user-controlled or externally derived field", and the
+byte cap and single-document framing are already stated as rules R12, R13 and
+R14 and asserted in acceptance.
+
+Re-deriving the section against the code found two declarations that were not
+merely imprecise:
+
+* **`warnings[].message` is not curated text.** It reads "derived diagnostic
+  vocabulary and curated English text", but
+  `Duplicate capability id '${id}' in --require was ignored.`
+  (`src/core/capabilities/check.ts:70`) interpolates the id the user typed. It
+  is safe for a different reason than the one declared — every id has already
+  matched `CAPABILITY_ID_PATTERN` and the 160-character cap in
+  `validAgentRequirements` (`src/commands/capabilities.ts:129-138`) before a
+  warning can reach the envelope.
+* **`evidence[]` and `recovery` are never populated by this Story.**
+  `toAgentEnvelope` and `createAgentOutputFailure` emit `evidence: []` and
+  `recovery: null` unconditionally (`src/commands/capabilities.ts:158-176`,
+  `src/utils/agent-output.ts:187-203`). They cross a boundary only inside
+  `parseOperationEnvelope(unknown)`, which is exported through
+  `@carllee1983/dbcli/core` and reads a document from a producer it does not
+  control. Listing them beside `argv` implied dbcli produces them.
+
+That second point is why the section is now split by boundary rather than
+flattened into one list. The two boundaries constrain the same field names for
+different reasons, and a reader who cannot tell them apart cannot tell which
+fields dbcli is responsible for bounding.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: no
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: no
+* deploy: no
+
+## Architecture
+
+* Impact: low
+
+## Risk
+
+* Level: medium
+* Reason: `security-declaration`
+
+Editing a security declaration a human has already accepted is a change to the
+record. The failure mode is a declaration rewritten to please a checker while
+saying less than the one it replaced, which is the opposite of what the gate
+exists for.
+
+## Scope
+
+### In Scope
+
+* Rewriting `## Trust Boundary Fields` in
+  `specs/stories/DBCLI-PLAT-004-operation-envelope-v1/story.md` so that every
+  bullet names an exact field, grouped by which boundary the value crosses,
+  each declaration backed by named code or a named test.
+* Deleting the `DBCLI-PLAT-004-operation-envelope-v1` entry from
+  `PREDATING_FINDINGS` and lowering `ADMITTED_FINDINGS` and
+  `ADMITTED_STORIES` to match what remains.
+* Bringing the reasoning in `scripts/lib/forgeflow-contract.ts` to match the
+  list it explains.
+
+### Out of Scope
+
+* The other four admitted Stories. Each is its own removal; PLAT-006 and
+  PLAT-007 need sixteen security-fixture cells re-derived from the code, which
+  is not this Story.
+* Any change to `src/`, to product behavior, or to a published version. This is
+  a governance correction and releases nothing.
+* `specs/stories/DBCLI-PLAT-004-operation-envelope-v1/acceptance.md`. Every
+  field the rewritten section names already has an accepted acceptance
+  criterion and a cited test; rewriting accepted acceptance text to restate
+  them would change the record without adding a check.
+* Relaxing, renaming or adding any other exemption, and any edit to upstream's
+  checkers.
+* Turning on `story-check --ready`, out of scope for the reason ADR-0027 gives.
+
+## Inputs
+
+* Upstream ForgeFlow at the adopted revision `cb4bc976`, run as
+  `FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract`.
+* `src/core/operation-envelope.ts`, `src/utils/agent-output.ts`,
+  `src/commands/capabilities.ts`, and `src/commands/capability-context.ts` —
+  the code each declaration must be true of.
+
+## Outputs
+
+* A PLAT-004 Story upstream `story-check` reports no finding against.
+* Twenty admitted findings across four Stories, down from twenty-one across
+  five.
+
+## Rules
+
+* R1: Every bullet under PLAT-004's `## Trust Boundary Fields` names an exact
+  field and is true of the code at this revision. A backtick added to prose to
+  satisfy the checker fails this rule even though it passes the checker.
+* R2: No trust-boundary constraint stated by the old section is dropped without
+  being stated elsewhere in the Story. The 65,536-byte cap and single-document
+  framing remain R12, R13 and R14.
+* R3: `ADMITTED_FINDINGS` and `ADMITTED_STORIES` equal what
+  `PREDATING_FINDINGS` actually holds, and both only decrease.
+* R4: No exemption other than PLAT-004's is added, removed, renamed or
+  broadened.
+* R5: The repository ships no product change. `src/` is untouched.
+
+## Expected Errors
+
+* A PLAT-004 bullet still written as prose keeps the upstream finding, and the
+  gate then fails on the deleted exemption as a finding it has not admitted.
+* A stale count fails `tests/unit/scripts/forgeflow-contract.test.ts` before
+  the gate is reached.
+* An exemption deleted for a finding upstream still reports fails as a new
+  finding, not silently.
+
+## Dependencies
+
+* `scripts/lib/forgeflow-contract.ts` — the exemption list and its two counts.
+* `tests/unit/scripts/forgeflow-contract.test.ts` — the ratchet assertions.
+* ADR-0027 — upstream's checkers are run, not reimplemented.
+
+## Constraints
+
+* `bun run forgeflow:contract` is not part of `make verify`; both must be run
+  and both must pass.
+* The upstream checker is run from a clean checkout at exactly `cb4bc976`. A
+  dirty checkout is at no revision and the gate refuses it.

--- a/specs/stories/DBCLI-023-faithful-plat-005-classification/acceptance.md
+++ b/specs/stories/DBCLI-023-faithful-plat-005-classification/acceptance.md
@@ -1,0 +1,73 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] Upstream `story-check` at the adopted revision `cb4bc976` reports no
+      `FAIL` line for `specs/stories/DBCLI-PLAT-005-agent-json-mode` —
+      `FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract`
+* [x] `bun run forgeflow:contract` passes and its banner reads 18 admitted
+      pre-existing findings, down from 20 — same command
+
+## Business Rules
+
+* [x] PLAT-005 declares `Baseline conformance: yes`, and its
+      `## Superseded Behavior` entries are unchanged from what was accepted —
+      `git diff` of that file against the baseline commit
+* [x] Every bullet under PLAT-005's `## Trust Boundary Fields` carries a
+      non-empty backticked span — upstream `story-check`
+* [x] The catalog path reads no environment variable, file or dynamic import:
+      every file the `src/core/capabilities/` import graph reaches is asserted
+      free of `process.env`, `Bun.file(`, `node:fs` and `import(`, which is what
+      lets `capabilities.list` emit `context: null` —
+      `tests/contract/capability-contract.test.ts`
+* [x] A successful `capabilities.list` envelope with a non-null `context`, or a
+      populated `warnings`, `evidence` or `recovery`, is rejected by the parser —
+      `tests/unit/core/operation-envelope.test.ts`
+* [x] `PREDATING_FINDINGS` holds no entry for
+      `DBCLI-PLAT-005-agent-json-mode`, and the three remaining entries are
+      unchanged in name and content —
+      `tests/unit/scripts/forgeflow-contract.test.ts`
+* [x] `ADMITTED_FINDINGS` is 18 and `ADMITTED_STORIES` is 3, and both equal what
+      `PREDATING_FINDINGS` holds — same file
+* [x] What remains is 16 security-fixture-cell findings and 2 trust-boundary
+      findings, with no Classification contradiction left — same file
+
+## Failure Cases
+
+* [x] A finding upstream reports for a Story with no exemption fails the gate as
+      unadmitted, so deleting the entry while the contradiction remains cannot
+      pass — `tests/unit/scripts/forgeflow-contract.test.ts`
+* [x] An exemption entry upstream no longer reports fails the gate as a stale
+      entry that must be deleted — same file
+* [x] `ADMITTED_FINDINGS` or `ADMITTED_STORIES` left at the old value fails
+      before the gate runs — same file
+
+## Regression Requirements
+
+* [x] `src/` is unchanged by this Story, so no product behavior, output byte, or
+      exit code moves — `git diff --stat` against the baseline commit
+* [x] The three remaining admitted Stories keep exactly the findings they had —
+      `bun run forgeflow:contract`
+* [x] The complete repository verification gate passes — `make verify`
+
+## Verification Notes
+
+Run the focused contract checks first:
+
+```sh
+bun test tests/unit/scripts/forgeflow-contract.test.ts
+```
+
+Then, from a clean ForgeFlow checkout at exactly `cb4bc976`:
+
+```sh
+FORGEFLOW_ROOT=<checkout> bun run forgeflow:contract
+```
+
+Then run `make verify` from the repository root against a clean, committed
+worktree. `forgeflow:contract` is deliberately not a `make verify` step, so
+passing one is not evidence about the other and both are required.
+
+The Classification correction is the item human review should weigh: the
+alternative exit — deleting `## Superseded Behavior` — satisfies the same
+checker and loses the record of what PLAT-005 replaced.

--- a/specs/stories/DBCLI-023-faithful-plat-005-classification/story.md
+++ b/specs/stories/DBCLI-023-faithful-plat-005-classification/story.md
@@ -1,0 +1,149 @@
+# Story: DBCLI-023 A Classification That Matches Its Own Story
+
+## Goal
+
+DBCLI-PLAT-005 declares what it actually is and describes the boundary its code
+actually has, so the second of the admitted contract exemptions is deleted and
+the last Classification contradiction in the repository is gone.
+
+## Context
+
+DBCLI-022 removed the first exemption. PLAT-005 is the second, and the only one
+of the five carrying two different kinds of finding:
+
+* `every trust-boundary field must name an exact field, not prose` — the same
+  shape DBCLI-022 fixed. One of four bullets, `Serialized stdout bytes — must
+  never exceed 65,536 UTF-8 bytes`, is not a field.
+* `Story declares Baseline conformance: no but declares superseded behavior` —
+  upstream's R8: a Story declaring `no` must not carry the matching section.
+
+The second is a contradiction, not a wording problem, and it has two exits: flip
+the declaration, or delete the section. They are not equivalent — one keeps a
+true record, the other destroys it.
+
+**The section is true and the declaration is wrong.** PLAT-005's
+`## Superseded Behavior` names two behaviors PLAT-004 established and PLAT-005
+deliberately replaced: `operation` constrained to `capabilities.check` alone,
+and `dbcli --agent-output capabilities` rejected as an unsupported operation.
+Both are accurate, and both are exactly what the section is for — upstream's
+template asks for "each existing test or documented behavior this Story
+intentionally replaces".
+
+The declaration is the half that does not survive comparison with its siblings.
+Four Stories in this repository already declare `Baseline conformance: yes` for
+this same shape — a change Story that supersedes named prior behavior, not a
+conformance audit: DBCLI-017 (the `make verify` step roster), DBCLI-020 (the
+nineteen absolute-time perf cases), DBCLI-PLAT-011 (documentation sentences that
+become wrong on delivery) and DBCLI-PLAT-012. Reading PLAT-005 as `no` would
+make it the only Story of that shape declaring the opposite.
+
+So the correction is one word, and it preserves both halves of a record a human
+already accepted. Deleting the section would have satisfied the same checker
+while losing the only written statement of what PLAT-005 replaced.
+
+Re-deriving the trust-boundary section found the remaining declarations thin
+rather than wrong. `capabilities.list` answers from `buildCapabilityCatalog()`,
+which returns the frozen `CAPABILITIES` table; `src/core/capabilities/` reads no
+environment variable, file or dynamic import at all — asserted over its whole
+import graph — which is why that operation emits `context: null` and needs no
+configuration. The old section stated that as
+a requirement the catalog "must" meet. It is a property the code already has.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: no
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: no
+* deploy: no
+
+## Architecture
+
+* Impact: low
+
+## Risk
+
+* Level: medium
+* Reason: `classification-flip`
+
+Changing a Classification changes which sections upstream requires of the
+Story and what a reader takes the Story to be. The failure mode is picking the
+exit that silences the checker fastest rather than the one that keeps the
+record true.
+
+## Scope
+
+### In Scope
+
+* Correcting `Baseline conformance` to `yes` in
+  `specs/stories/DBCLI-PLAT-005-agent-json-mode/story.md`, leaving its
+  `## Superseded Behavior` entries as written.
+* Rewriting that Story's `## Trust Boundary Fields` so every bullet names an
+  exact field, split by whether the value enters from `argv` or through
+  `parseOperationEnvelope(unknown)`, each backed by named code.
+* Deleting the `DBCLI-PLAT-005-agent-json-mode` entry from `PREDATING_FINDINGS`
+  and lowering both counts to what remains.
+
+### Out of Scope
+
+* PLAT-006, PLAT-007 and PLAT-012. Sixteen of their eighteen remaining findings
+  are security-fixture cells whose real values must be re-derived from the code;
+  that is its own Story, and PLAT-004's and PLAT-005's removals do not make it
+  smaller.
+* `specs/stories/DBCLI-PLAT-005-agent-json-mode/acceptance.md`. The
+  Classification change does not alter any acceptance criterion, and every field
+  the rewritten section names already has one.
+* Any change to `src/` or to product behavior. This releases nothing.
+* Relaxing, renaming or adding any other exemption, and any edit to upstream's
+  checkers.
+
+## Inputs
+
+* Upstream ForgeFlow at the adopted revision `cb4bc976`.
+* `src/commands/capabilities.ts`, `src/core/capabilities/registry.ts`,
+  `src/core/capabilities/schema.ts`, `src/utils/agent-output.ts` and
+  `src/core/operation-envelope.ts` — the code the declarations must be true of.
+
+## Outputs
+
+* A PLAT-005 Story upstream `story-check` reports no finding against.
+* Eighteen admitted findings across three Stories, down from twenty across four.
+
+## Rules
+
+* R1: The Classification is corrected to what the Story is, not to whichever
+  value makes the checker quiet. `## Superseded Behavior` keeps its entries.
+* R2: Every bullet under PLAT-005's `## Trust Boundary Fields` names an exact
+  field and is true of the code at this revision.
+* R3: No constraint stated by the old section is dropped without being stated
+  elsewhere. The 65,536-byte cap remains a rule of the envelope contract.
+* R4: `ADMITTED_FINDINGS` and `ADMITTED_STORIES` equal what
+  `PREDATING_FINDINGS` holds, and both only decrease.
+* R5: No exemption other than PLAT-005's is added, removed, renamed or
+  broadened, and the repository ships no product change.
+
+## Expected Errors
+
+* A declaration left at `no` beside the section keeps upstream's contradiction
+  finding, and the gate then fails on it as unadmitted.
+* A stale count fails `tests/unit/scripts/forgeflow-contract.test.ts` before the
+  gate is reached.
+
+## Dependencies
+
+* `scripts/lib/forgeflow-contract.ts` — the exemption list and its two counts.
+* `tests/unit/scripts/forgeflow-contract.test.ts` — the ratchet assertions.
+* DBCLI-022 — the first removal, and the precedent for re-deriving rather than
+  backticking.
+
+## Constraints
+
+* `bun run forgeflow:contract` is not part of `make verify`; both must pass.
+* The upstream checker runs from a clean checkout at exactly `cb4bc976`.

--- a/specs/stories/DBCLI-PLAT-004-operation-envelope-v1/story.md
+++ b/specs/stories/DBCLI-PLAT-004-operation-envelope-v1/story.md
@@ -202,22 +202,71 @@ must address keys by name rather than depend on ordering.
 
 ## Trust Boundary Fields
 
-* `argv[]` — identifies the exact opt-in token, placement, operation, and
-  conflicting user-supplied output options before Commander may emit prose.
-* `--require <ids>` — user-controlled capability ids projected into bounded
-  `required` and `results` arrays.
-* `context.connectionName` — config-derived label projected through the existing
-  bound; connection credentials and endpoints are never accepted.
-* `context.engine`, `context.permission`, and `context.agentMode` — externally
-  derived evaluation context constrained to existing vocabularies.
-* `data` — operation-owned result projection constrained by the
-  `capabilities.check` strict schema.
-* `warnings[].code` and `warnings[].message` — derived diagnostic vocabulary and
-  curated English text.
-* `evidence[].kind`, `evidence[].id`, and `evidence[].digest` — external artifact
-  references stripped of paths and embedded bodies.
-* `recovery` — existing strict recovery data; its error must agree with the
-  enclosing envelope.
-* `error.code` and `error.message` — stable classification and curated text;
-  arbitrary exception details never cross the boundary.
-* Serialized stdout bytes — final 65,536-byte limit and single-document framing.
+Two boundaries carry values into this contract, and the same field name means a
+different thing at each. dbcli *builds* an envelope from `argv`, the environment
+and `config.json`; `parseOperationEnvelope(unknown)`, exported through
+`@carllee1983/dbcli/core`, *reads* a whole document from a producer it does not
+control. A field listed only under the second is one this Story never populates.
+
+Entering from `argv`, the environment, or `config.json`:
+
+* `process.argv` — scanned by `inspectAgentOutputInvocation` before Commander
+  runs, to find the exact `--agent-output` token, its placement relative to the
+  subcommand, the operation, and a conflicting explicit `--format` or
+  `--for-agent`. No argv token is ever copied into the envelope.
+* `data.required[]` and `data.results[].id` — the ids from `--require`, split
+  and de-duplicated by `parseRequirements`, then admitted only if every id
+  matches `CAPABILITY_ID_PATTERN` and is at most 160 characters and there are at
+  most 128 of them (`validAgentRequirements`). Anything else becomes
+  `INVALID_CAPABILITY_REQUIREMENTS` with `data: null` and the rejected text
+  absent from stdout.
+* `warnings[].message` — the duplicate-requirement warning interpolates the id
+  the user typed. It is safe because that id has already passed
+  `validAgentRequirements`, not because the text is curated; the other three
+  warning messages are fixed English.
+* `context.connectionName` — `config.effectiveConnectionName` read from
+  `config.json`, truncated to 200 characters by the resolver and then refused
+  outright above 160, which emits `AGENT_OUTPUT_INTERNAL_ERROR` and exit `1`
+  rather than a shortened label.
+* `context.engine` and `context.permission` — `config.connection.system` and
+  `config.permission` from `config.json`, each admitted only as a member of its
+  closed vocabulary; a value outside it resolves to no context at all rather
+  than to a reported one.
+* `context.agentMode` — the boolean `process.env.DBCLI_AGENT_MODE === '1'`. The
+  variable is never echoed.
+
+Entering through `parseOperationEnvelope(unknown)`, which trusts no key of the
+document it is handed:
+
+* `schemaVersion` — accepted only as the literal `1`; every other value,
+  including a later one, is rejected rather than parsed optimistically.
+* `operation` — accepted only from the registered enum, which is additionally
+  held to the dotted-identifier pattern and the 160-character bound, so no raw
+  argv, SQL, or path can occupy it.
+* `ok` and `status` — a closed pair; `ok` must equal `status === "succeeded"`,
+  so a document cannot claim success in one and failure in the other.
+* `data` — accepted only as the strict per-operation projection, capped at 128
+  `required` and 128 `results` that must agree in order, or as `null`. Unknown
+  keys, including nested ones, are rejected, which is what refuses `data.rows`
+  and `data.sql`.
+* `warnings[].code` and `error.code` — bounded uppercase snake-case identifiers
+  of at most 160 characters, an extensible grammar rather than a closed enum.
+* `error.message` — at most 2,000 characters. An unexpected exception never
+  reaches it: the presentation path substitutes the fixed
+  `Agent output failed safely.` and the raw `Error.message` is discarded.
+* `evidence[].kind`, `evidence[].id`, and `evidence[].digest` — references only:
+  `kind` from the three-member enum, `id` matching
+  `^[A-Za-z0-9][A-Za-z0-9_.-]{0,159}$`, an optional digest matching
+  `^sha256:[a-f0-9]{64}$`, at most 16 entries, and no key that could carry a
+  path or an embedded body. This Story always emits `evidence: []`.
+* `recovery` — `null`, or a document the existing strict Recovery Envelope
+  parser accepts whose error code and message match the enclosing error exactly
+  and whose every nested string is within the 2,000-character bound. This Story
+  always emits `recovery: null`.
+* `context` — the same four fields as above plus nothing else; `context.password`,
+  `context.connectionString` and `context.configPath` are refused as unknown
+  keys, which is what the security fixture matrix asserts.
+
+The 65,536-byte cap on the serialized document and its single-document,
+single-trailing-newline framing are not fields and are stated as R12, R13 and
+R14.

--- a/specs/stories/DBCLI-PLAT-005-agent-json-mode/story.md
+++ b/specs/stories/DBCLI-PLAT-005-agent-json-mode/story.md
@@ -28,7 +28,7 @@ capability catalog while preserving backward compatibility with all existing hum
 ## Classification
 
 * Security sensitive: yes
-* Baseline conformance: no
+* Baseline conformance: yes
 
 ## Scope
 
@@ -148,11 +148,55 @@ For `capabilities.list`:
 
 ## Trust Boundary Fields
 
-* `argv[]` — parsed during preflight to detect `--agent-output` and enforce placement rules.
-* `data.capabilities` — static capability objects emitted in `capabilities.list`. Must contain
-  no dynamic environment variables, paths, or database credentials.
-* `error.code` and `error.message` — stable curated English strings.
-* Serialized stdout bytes — must never exceed 65,536 UTF-8 bytes.
+`capabilities.list` is the narrower of the two operations: its answer is a
+compile-time constant, so `argv` is the only thing that enters. The remaining
+fields cross only inside `parseOperationEnvelope(unknown)`, which is exported
+through `@carllee1983/dbcli/core` and reads a document it did not produce.
+
+Entering from `argv`:
+
+* `process.argv` — scanned by `inspectAgentOutputInvocation` before Commander
+  runs, to detect `--agent-output`, reject it after the subcommand, and reject a
+  conflicting explicit `--format`. On this path a bare `capabilities` with no
+  further subcommand selects `capabilities.list`. No argv token reaches the
+  envelope.
+* `--format <type>` — checked against the catalog's three accepted values before
+  the catalog is built; a rejected value becomes
+  `AGENT_OUTPUT_INTERNAL_ERROR` and exit `1` when agent output is active.
+
+Emitted, not accepted — stated because the section must show they carry nothing
+external:
+
+* `data.schemaVersion` and `data.capabilities[]` — `buildCapabilityCatalog()`
+  returns the frozen `CAPABILITIES` table declared in
+  `src/core/capabilities/registry.ts`. No environment variable, path, credential,
+  connection or argv value is read while building it, which is why this
+  operation emits `context: null` and needs no configuration to answer.
+* `error.code` and `error.message` — on this path the only pair is
+  `AGENT_OUTPUT_INTERNAL_ERROR` with its fixed message; a raw `Error.message`
+  is never emitted.
+* `warnings`, `evidence`, `recovery`, and `context` — literal `[]`, `[]`, `null`
+  and `null` in the one place a `capabilities.list` envelope is constructed, and
+  the parser additionally refuses a successful `capabilities.list` envelope that
+  has any of them populated.
+
+Entering through `parseOperationEnvelope(unknown)`:
+
+* `data.capabilities[].id`, `.command`, `.risk`, `.sideEffect`, `.engines[]`,
+  `.limitedEngines[]`, `.minimumPermission` — accepted only from their closed
+  vocabularies and patterns; `.description` must be non-empty; the object is
+  `.strict()`, so an unknown key is rejected rather than carried.
+* `data.capabilities[].supportsJson`, `.supportsEvidence`,
+  `.engineIndependent`, `.requiresConnection`, `.mutatesConfiguration` — the
+  per-subcommand JSON granularity this Story clarifies, accepted only as
+  booleans.
+* `operation` — accepted only as a member of the registered union, which this
+  Story widens from `capabilities.check` alone to include `capabilities.list`.
+
+The 65,536-byte cap on the serialized document is not a field. It is stated as
+a rule and enforced by `serializeOperationEnvelope`, which replaces an oversized
+document with a bounded `AGENT_OUTPUT_LIMIT_EXCEEDED` envelope rather than
+truncating it.
 
 ## Superseded Behavior
 

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -177,6 +177,19 @@ describe('the exemption ratchet', () => {
     expect(findings).toBe(ADMITTED_FINDINGS)
   })
 
+  test('no longer admits anything for DBCLI-PLAT-004', () => {
+    // DBCLI-022 re-derived that Story's trust-boundary declarations against the
+    // code, so upstream reports nothing for it. The counts above would still
+    // agree if the entry were merely renamed or traded for another, which is
+    // what this names outright.
+    expect([...PREDATING_FINDINGS.keys()]).toEqual([
+      'DBCLI-PLAT-005-agent-json-mode',
+      'DBCLI-PLAT-006-correlation-id',
+      'DBCLI-PLAT-007-bounded-evidence-receipts',
+      'DBCLI-PLAT-012-schema-cache-write-boundary',
+    ])
+  })
+
   test('admits no duplicate finding within one Story', () => {
     // A repeated string would satisfy the count while admitting one fewer real
     // finding than it appears to.

--- a/tests/unit/scripts/forgeflow-contract.test.ts
+++ b/tests/unit/scripts/forgeflow-contract.test.ts
@@ -177,17 +177,26 @@ describe('the exemption ratchet', () => {
     expect(findings).toBe(ADMITTED_FINDINGS)
   })
 
-  test('no longer admits anything for DBCLI-PLAT-004', () => {
-    // DBCLI-022 re-derived that Story's trust-boundary declarations against the
-    // code, so upstream reports nothing for it. The counts above would still
-    // agree if the entry were merely renamed or traded for another, which is
-    // what this names outright.
+  test('no longer admits anything for DBCLI-PLAT-004 or DBCLI-PLAT-005', () => {
+    // DBCLI-022 and DBCLI-023 re-derived those Stories' declarations against the
+    // code, so upstream reports nothing for either. The counts above would still
+    // agree if an entry were merely renamed or traded for another, which is what
+    // this names outright.
     expect([...PREDATING_FINDINGS.keys()]).toEqual([
-      'DBCLI-PLAT-005-agent-json-mode',
       'DBCLI-PLAT-006-correlation-id',
       'DBCLI-PLAT-007-bounded-evidence-receipts',
       'DBCLI-PLAT-012-schema-cache-write-boundary',
     ])
+  })
+
+  test('what remains is fixture cells and two trust-boundary sections', () => {
+    // The Classification contradiction was PLAT-005's and is gone, so the
+    // header's claim about what is left is now checkable rather than prose.
+    const remaining = [...PREDATING_FINDINGS.values()].flat()
+
+    expect(remaining.filter((f) => f.startsWith('security fixture row'))).toHaveLength(16)
+    expect(remaining.filter((f) => f.includes('trust-boundary'))).toHaveLength(2)
+    expect(remaining.filter((f) => f.includes('Baseline conformance'))).toHaveLength(0)
   })
 
   test('admits no duplicate finding within one Story', () => {


### PR DESCRIPTION
DBCLI-018 讓 CI 跑上游 ForgeFlow 自己的檢查（ADR-0027），當時五個已交付的 Story
落在二十一條 findings 上，清單寫著「只能縮短，不能增長」——在這之前沒有縮短過。
這個 PR 是頭兩次縮短：**21 條／5 個 Story → 18 條／3 個 Story**。

兩個 Story 都不動 `src/`，不動 acceptance，不發布版本。

## DBCLI-022 — PLAT-004 的信任邊界宣告

`every trust-boundary field must name an exact field, not prose`。十個 bullet 裡
只有 `Serialized stdout bytes` 不合規則，替那句話加反引號就會過——那是刻意拒絕的
做法：它不是欄位，而位元組上限與單一文件框架早就是 R12／R13／R14。

拿程式碼重推整節，兩處宣告不只是不精確：

- **`warnings[].message` 不是 curated 文字。** 重複需求的警告是
  `Duplicate capability id '${id}' in --require was ignored.`
  （`src/core/capabilities/check.ts:70`），內插使用者輸入。它安全的理由是那個 id
  已先過 `validAgentRequirements` 的 `CAPABILITY_ID_PATTERN` 與 160 字元上限。
- **`evidence[]` 與 `recovery` 這個 Story 從來不產生。** `toAgentEnvelope` 與
  `createAgentOutputFailure` 無條件寫 `[]` 與 `null`；它們跨界只在公開匯出的
  `parseOperationEnvelope(unknown)` 裡。

所以該節改成按邊界分兩段，而不是攤平成一張表。

## DBCLI-023 — PLAT-005 的 Classification

兩條 finding，一條同形的 trust-boundary 散文，一條是 `Baseline conformance: no`
卻帶著 `## Superseded Behavior`（上游 R8）。

**矛盾有兩個出口，兩個都能讓 checker 閉嘴：翻宣告，或刪那一節。** 選前者，因為
那一節寫的是真的——PLAT-004 曾把 `operation` 限定在 `capabilities.check`、曾拒絕
`dbcli --agent-output capabilities`，兩件事 PLAT-005 都刻意換掉了。而 DBCLI-017、
020、PLAT-011、PLAT-012 四個同形狀的 Story 全宣告 `yes`；照 `no` 讀，PLAT-005 會是
唯一相反的一個。刪那一節同樣會過，代價是再也沒有地方寫著 PLAT-005 取代了什麼。

**這是本 PR 唯一需要判斷的事。**

trust-boundary 那半重推後發現剩下的宣告是單薄不是錯：舊文把 catalog 不含環境變數、
路徑、憑證寫成待辦要求，那其實是 `src/core/capabilities/` 整個 import graph 已被
`tests/contract/capability-contract.test.ts` 斷言釘住的性質。

## 棘輪

`ADMITTED_FINDINGS` 21→20→18，`ADMITTED_STORIES` 5→4→3，沒有任何其他例外被新增、
改名或放寬，上游 checker 未動。新增兩條斷言：剩下的 key 清單（單看數字分不出
「刪掉」與「換名」），以及剩下 18 條的組成是 16 格 fixture cells + 2 條
trust-boundary、Classification 矛盾為 0。

## Test plan

```
bun test tests/unit/scripts/forgeflow-contract.test.ts        → 25 pass / 0 fail
FORGEFLOW_ROOT=<cb4bc976 clean> bun run forgeflow:contract
  → 31 Stories, 18 admitted pre-existing finding(s)（起點：29 Stories, 21）
story-check 全庫 FAIL 行數 18；PLAT-004 與 PLAT-005 皆無 FAIL
make verify                                                   → exit 0
```

`forgeflow:contract` 不在 `make verify` 裡，兩者都跑過。ForgePilot 在
`.forgepilot/worktrees/` 的 detached worktree 對 `12c19b20` 獨立再跑一次
`make verify`：`EV-035 PASS`、`EV-034 PASS`，WI-009／WI-010 皆 DONE。

## 剩下的

PLAT-006（6）、PLAT-007（9）、PLAT-012（3）。其中 PLAT-007 的八列 source field
要從 evidence-receipt 實作推出確切欄位名，是最硬的一個。各自一個 Story。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn