### PR TITLE
feat: [ forgeflow ] 沒有東西比對過的宣告不是控制

### DIFF
--- a/docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md
+++ b/docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md
@@ -1,0 +1,62 @@
+# A permission nobody filled in is not a control
+
+* Status: accepted
+* Date: 2026-09-09
+
+ForgeFlow 0.6.0's `## Authority` section declares, per operation, what a Story is
+permitted to do. AGENTS.md restates the rule that makes it worth having:
+Authority is per-permission and nothing implies anything else — `modify` does not
+grant `commit`, and `commit` does not grant `push`.
+
+Measured on 2026-09-09 across every Story in this repository that had ever
+declared the section:
+
+* eight Stories declared `## Authority`;
+* **eight of eight declared `push: no`**;
+* three of those also declared `commit: no`;
+* all eight reached `main` through a merged pull request — as commits, on a
+  pushed branch.
+
+A declaration that was false every time it was made is not recording a decision.
+It is the template's default, copied and never filled in. What let it survive
+eight Stories is that nothing compared it to anything: upstream's checker
+validates that the values are `yes` or `no`, and no checker anywhere asked
+whether they were true.
+
+## Decision
+
+**Delivery implies `commit` and `push`, and the handoff gate enforces it.**
+`specs/handoff.md`'s `completed_stories` is this repository's own statement that
+a Story reached `main`. A Story listed there whose Authority declares
+`commit: no` or `push: no` fails `bun run forgeflow:check`, with the message
+naming both exits: correct the declaration, or stop recording the Story as
+completed.
+
+**Only those two.** `deploy`, `migration`, `add_dependency`, `plan` and `modify`
+are unconstrained by delivery, and a delivered Story may still truthfully declare
+`deploy: no`. Extending the check to them would be inventing implications the
+contract explicitly denies.
+
+**The eight existing declarations are corrected rather than explained.** The
+usual rule here is that a record a human approved is not rewritten to tidy it up
+— DBCLI-021 refused exactly that. This is not that case: `push: no` was never a
+statement anyone made about those Stories, so correcting it destroys no decision.
+The discrepancy was first recorded in prose in `specs/handoff.md` and left
+unfixed on that reasoning; the 8-of-8 measurement is what changed the answer.
+
+## Consequences
+
+A Story authored today declares `commit: yes` and `push: yes` when it is expected
+to be delivered as a pull request, which is every Story in this repository so far.
+One that genuinely must not push — an inspection or review Story that changes
+nothing — declares `push: no` and simply is not recorded as completed while that
+holds, which is the same thing the gate is saying.
+
+The gate is offline and reads two files. It needs no git history, so it behaves
+the same in a shallow CI clone as it does locally — the failure mode that the
+sibling trailer reconciliation has to guard against explicitly.
+
+**Falsified if:** delivery stops implying a pushed branch — if Stories reach
+`main` by some route that does not require `commit` and `push` — then
+`reconcileDeliveryAuthority` in `scripts/lib/forgeflow-handoff.ts` is asserting
+an implication that no longer holds and must be narrowed or removed.

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -26,6 +26,7 @@ import {
   lifecycleBlock,
   readLifecycle,
   reconcile,
+  reconcileDeliveryAuthority,
   shallowCloneRefusal,
   type Exemption,
 } from './lib/forgeflow-handoff'
@@ -101,13 +102,18 @@ if (violations.length > 0) {
   process.exit(1)
 }
 
+const sources = await storySources()
+const directories = collectStoryIds(sources)
+
 const failures = await reconcile({
   lifecycle,
-  directories: collectStoryIds(await storySources()),
+  directories,
   trailers: await storiesWithTrailers(),
   exemptions: DELIVERED_BEFORE_TRAILERS,
   commitExists,
 })
+
+failures.push(...reconcileDeliveryAuthority(lifecycle, directories, sources))
 
 if (failures.length > 0) {
   console.error(formatFailures(failures))

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -458,6 +458,87 @@ export function shallowCloneRefusal(isShallowOutput: string): string | null {
 }
 
 /**
+ * Permissions a delivered Story necessarily exercised.
+ *
+ * Delivery here means a merged pull request: the work was committed and the
+ * branch was pushed. Nothing else on the Authority list is implied — `deploy`,
+ * `migration` and `add_dependency` are unconstrained by delivery, and Authority
+ * is per-permission by contract.
+ */
+const DELIVERY_IMPLIES: readonly string[] = ['commit', 'push']
+
+/**
+ * Read one permission from a Story's `## Authority` section.
+ *
+ * `undefined` when the Story declares no Authority at all, or declares that
+ * section without this permission — the section is optional, and a Story making
+ * no claim has nothing to contradict.
+ */
+export function readAuthority(source: string, permission: string): 'yes' | 'no' | undefined {
+  const section = source.split(/^## /m).find((part) => part.startsWith('Authority'))
+  if (section === undefined) return undefined
+
+  const pattern = new RegExp(`^\\* ${permission}:\\s*(\\S+)\\s*$`)
+  for (const line of section.split('\n')) {
+    const match = line.match(pattern)
+    if (match === null) continue
+    return match[1] === 'yes' || match[1] === 'no' ? (match[1] as 'yes' | 'no') : undefined
+  }
+
+  return undefined
+}
+
+/**
+ * Refuse a delivered Story that says it was not allowed to do what delivering it
+ * required.
+ *
+ * `completed_stories` is the repository's own statement that the Story reached
+ * `main`, which it can only have done as commits on a pushed branch. So a
+ * completed Story declaring `commit: no` or `push: no` is not recording a
+ * permission that was withheld; it is contradicting the handoff two files away.
+ *
+ * This exists because the declaration was wrong every time it was made. All
+ * eight Stories that had ever declared Authority said `push: no` and three also
+ * said `commit: no`, while every one of them reached `main` — a template field
+ * nobody filled in rather than a decision anybody made. A value that has never
+ * once been true is not a control, and what let it survive was that nothing
+ * compared it to anything. ADR-0030.
+ *
+ * Only the two permissions delivery actually implies are checked. Authority is
+ * per-permission and nothing implies anything else, so a delivered Story may
+ * still truthfully declare `deploy: no`.
+ */
+export function reconcileDeliveryAuthority(
+  lifecycle: Lifecycle,
+  directories: ReadonlyMap<string, string>,
+  stories: Iterable<StorySource>
+): Failure[] {
+  const sources = new Map([...stories].map(({ directory, source }) => [directory, source]))
+  const failures: Failure[] = []
+
+  for (const story of lifecycle.completedStories) {
+    const directory = directories.get(story)
+    if (directory === undefined) continue
+
+    const source = sources.get(directory)
+    if (source === undefined) continue
+
+    for (const permission of DELIVERY_IMPLIES) {
+      if (readAuthority(source, permission) !== 'no') continue
+      failures.push({
+        story,
+        reason:
+          `is recorded as completed but its ## Authority declares \`${permission}: no\` — a delivered ` +
+          'Story reached main as commits on a pushed branch, so correct the declaration or stop ' +
+          'recording it as completed',
+      })
+    }
+  }
+
+  return failures
+}
+
+/**
  * Compare every delivery claim against the repository.
  *
  * `DELIVERED_BEFORE_TRAILERS` is a ratchet, not an amnesty: it may shrink and

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -938,12 +938,31 @@ row 10 的 persisted locations 原本寫 `stderr, audit entry`，那是**替代�
 `PREDATING_FINDINGS` 與兩個計數留著。空的意思是棘輪到底了：任何一條 finding 現在
 都會讓 gate 紅，而要加回一條就得**調低**——不能調高——那兩個數字。
 
-### 一個沒有修的落差
+### 那個落差修掉了，理由跟原本的判斷相反
 
-DBCLI-022／023 的 `## Authority` 都宣告 `push: no`，實際上那個分支被 push 了，因為
-人類當場授權。沒有回頭改那兩份 Story：Authority 記的是核可當下授予了什麼，不是後
-來發生了什麼，而改寫已核可 Story 的內文正是 DBCLI-021 自己 Out of Scope 拒絕的事。
-記在這裡，讓落差有地方可查。
+上一節原本記著：DBCLI-022／023 宣告 `push: no` 而分支被 push 了，不回頭改，因為
+Authority 記的是核可當下授予了什麼，而改寫已核可 Story 正是 DBCLI-021 拒絕的事。
+
+**量一下就翻案了。** 這個 repo 裡所有曾經宣告 `## Authority` 的 Story 共八個，
+**八個全部**寫 `push: no`，而八個全部都經由合併的 PR 進了 main；其中三個還寫
+`commit: no`，而它們帶著自己 `Story:` trailer 的 commit 就在 main 上。
+
+八分之八不是決定的紀錄，是模板預設值被抄了八次沒填。改它不會毀掉任何決定，因為
+從來沒有人做過那個陳述。原本的推理對「已核可的紀錄不要動」是對的，錯在把這件事
+歸成那一類。
+
+真正有用的是另一半：**它能活過八個 Story，是因為沒有東西拿它跟任何東西比對。**
+上游的 checker 只驗值是不是 `yes`／`no`，沒有任何地方問過它是不是真的。一個沒有
+東西去比對的宣告不是控制，措辭再嚴謹都不是。
+
+比對的材料本來就在：`completed_stories` 是這個 repo 自己說某個 Story 進了 main，
+而它只可能是以 commit、經由被 push 的分支進去的。`reconcileDeliveryAuthority`
+現在就檢查這一條，訊息同時指出兩個出口——改宣告，或別再把它記成 completed。
+只檢查 `commit` 與 `push` 兩項：交付不蘊含 `deploy` 或 `migration`，而 Authority
+本來就是逐項授權、彼此不蘊含。決定與失效條件在 ADR-0030。
+
+順帶對帳出第二件過期：DBCLI-022 到 026 已交付、已合併、已通過 Human Review，卻都
+沒被登進 `completed_stories`。一併補上。
 
 ## Lifecycle
 
@@ -984,14 +1003,25 @@ workflow:
     - DBCLI-019
     - DBCLI-020
     - DBCLI-021
+    - DBCLI-022
+    - DBCLI-023
+    - DBCLI-024
+    - DBCLI-025
+    - DBCLI-026
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 38f6241e0d5bc620ed4cae918ebf3fee05a73b57
+  commit: 87e8c48aa303dbccdc5c36a6aa0cbe0f35fc7995
   dirty_worktree: false
   story_owned_paths:
+    - specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
+    - specs/stories/DBCLI-027-authority-that-matches-delivery/acceptance.md
+    - docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md
+    - scripts/lib/forgeflow-handoff.ts
+    - scripts/check-forgeflow-handoff.ts
+    - tests/unit/scripts/forgeflow-handoff.test.ts
     - specs/stories/DBCLI-024-plat-012-cache-write-failure-field/story.md
     - specs/stories/DBCLI-024-plat-012-cache-write-failure-field/acceptance.md
     - specs/stories/DBCLI-025-plat-006-verification-that-exists/story.md

--- a/specs/stories/DBCLI-019-load-independent-perf-verdict/story.md
+++ b/specs/stories/DBCLI-019-load-independent-perf-verdict/story.md
@@ -74,8 +74,8 @@ mandatory.
 * modify: yes
 * add_dependency: no
 * migration: no
-* commit: no
-* push: no
+* commit: yes
+* push: yes
 * deploy: no
 
 ## Risk

--- a/specs/stories/DBCLI-020-perf-gates-without-a-clock/story.md
+++ b/specs/stories/DBCLI-020-perf-gates-without-a-clock/story.md
@@ -71,8 +71,8 @@ about benchmark gates.
 * modify: yes
 * add_dependency: no
 * migration: no
-* commit: no
-* push: no
+* commit: yes
+* push: yes
 * deploy: no
 
 ## Risk

--- a/specs/stories/DBCLI-021-resolvable-decision-records/story.md
+++ b/specs/stories/DBCLI-021-resolvable-decision-records/story.md
@@ -50,8 +50,8 @@ out `specs/decisions/` in the first place.
 * modify: yes
 * add_dependency: no
 * migration: no
-* commit: no
-* push: no
+* commit: yes
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
+++ b/specs/stories/DBCLI-022-faithful-plat-004-trust-boundary/story.md
@@ -66,7 +66,7 @@ fields dbcli is responsible for bounding.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-023-faithful-plat-005-classification/story.md
+++ b/specs/stories/DBCLI-023-faithful-plat-005-classification/story.md
@@ -61,7 +61,7 @@ a requirement the catalog "must" meet. It is a property the code already has.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-024-plat-012-cache-write-failure-field/story.md
+++ b/specs/stories/DBCLI-024-plat-012-cache-write-failure-field/story.md
@@ -53,7 +53,7 @@ risk instead of the guard.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-025-plat-006-verification-that-exists/story.md
+++ b/specs/stories/DBCLI-025-plat-006-verification-that-exists/story.md
@@ -57,7 +57,7 @@ fixture rows assert nothing" are the same line in the checker's output.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-026-plat-007-receipt-source-fields/story.md
+++ b/specs/stories/DBCLI-026-plat-007-receipt-source-fields/story.md
@@ -62,7 +62,7 @@ in.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
 ## Architecture

--- a/specs/stories/DBCLI-027-authority-that-matches-delivery/acceptance.md
+++ b/specs/stories/DBCLI-027-authority-that-matches-delivery/acceptance.md
@@ -1,0 +1,55 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] `bun run forgeflow:check` passes, reconciling 34 completed Stories —
+      `bun run forgeflow:check`
+* [x] No Story declaring `## Authority` declares `commit: no` or `push: no` —
+      `grep -c '^\* \(commit\|push\): no' specs/stories/DBCLI-*/story.md`
+
+## Business Rules
+
+* [x] A completed Story declaring `commit: no` and `push: no` produces exactly
+      two failures, one naming each permission —
+      `tests/unit/scripts/forgeflow-handoff.test.ts`
+* [x] A Story with no `## Authority` section declares nothing and is not
+      reported — same file
+* [x] A permission absent from a declared section is not read as `no` — same file
+* [x] A Story absent from `completed_stories` is not checked, so an in-flight
+      Story may truthfully declare `push: no` — same file
+* [x] `deploy: no` on a delivered Story is left alone; only `commit` and `push`
+      are checked — same file
+* [x] DBCLI-022 to DBCLI-026 are recorded in `completed_stories`, each backed by
+      its own `Story:` commit trailer — `bun run forgeflow:check`
+
+## Failure Cases
+
+* [x] Before this Story's corrections, the gate reported DBCLI-019, DBCLI-020 and
+      DBCLI-021 by name for `commit: no` — reproduced in-session against the
+      pre-correction tree
+* [x] The gate reads `specs/handoff.md` and the Story files only, spawning no
+      git command, so a shallow clone cannot change its verdict — human review of
+      `scripts/lib/forgeflow-handoff.ts`
+
+## Regression Requirements
+
+* [x] `src/` is unchanged — `git diff --stat` against the baseline commit
+* [x] The existing handoff reconciliation is unchanged: delivery claims are still
+      checked against `Story:` trailers and `DELIVERED_BEFORE_TRAILERS` —
+      `tests/unit/scripts/forgeflow-handoff.test.ts`
+* [x] `docs/adr/` still declares no record as `proposed` —
+      `tests/unit/build/adr-references.test.ts`
+* [x] The complete repository verification gate passes — `make verify`
+
+## Verification Notes
+
+```sh
+bun test tests/unit/scripts/forgeflow-handoff.test.ts tests/unit/build/adr-references.test.ts
+bun run forgeflow:check
+```
+
+The correction of eight approved declarations is what human review should weigh.
+It rests on the measurement in ADR-0030 — eight of eight declared `push: no`
+while all eight were delivered — and not on the declarations being untidy. If
+that measurement is wrong, the edit is the quiet record change this repository
+normally refuses.

--- a/specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
+++ b/specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
@@ -1,0 +1,133 @@
+# Story: DBCLI-027 An Authority Declaration Something Checks
+
+## Goal
+
+A Story's `## Authority` says what was actually permitted, because a gate
+compares it to the repository's own record of delivery instead of leaving it to
+a reader who has never once caught it.
+
+## Context
+
+DBCLI-022 and DBCLI-023 declared `push: no` and their branch was pushed. That
+was recorded in `specs/handoff.md` as a known discrepancy and deliberately not
+fixed, on the reasoning that Authority records what was granted at approval and
+rewriting an approved Story is what DBCLI-021 refused to do.
+
+Measuring it changed the answer. Every Story in this repository that has ever
+declared `## Authority` — eight of them — declares `push: no`, and all eight
+reached `main` through a merged pull request. Three also declare `commit: no`,
+with their commits sitting on `main` carrying their own `Story:` trailers.
+
+**Eight out of eight is not a record of a decision.** It is the template's
+default, copied and never filled in, and correcting it destroys nothing because
+nobody ever made the statement. The earlier reasoning was right about approved
+records and wrong about which kind of thing this was.
+
+What let it survive eight Stories is the more useful half: upstream's checker
+validates that Authority's values are `yes` or `no`, and nothing anywhere asked
+whether they were true. A declaration nothing compares to anything is not a
+control, however carefully it is worded.
+
+The comparison is available and cheap. `completed_stories` in `specs/handoff.md`
+is this repository's own statement that a Story reached `main`, which it can only
+have done as commits on a pushed branch.
+
+While reconciling that list, a second staleness: DBCLI-022 to DBCLI-026 were
+delivered, merged and approved, and none of them had been added to it.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: no
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: yes
+* deploy: no
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0030`
+* Boundary: `HandoffContract`
+* Contract: `a delivered Story's Authority agrees with what delivering it required`
+* Owner: `HandoffContract = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `retro-edit-of-approved-records`
+
+Correcting a declaration in eight Stories a human has already approved is the
+move this repository normally refuses. It is justified here by a measurement,
+not by tidiness, and if the measurement is wrong the edit is exactly the kind of
+quiet record change the rule exists to prevent.
+
+## Scope
+
+### In Scope
+
+* `reconcileDeliveryAuthority` in `scripts/lib/forgeflow-handoff.ts`, failing any
+  Story in `completed_stories` whose Authority declares `commit: no` or
+  `push: no`, wired into `bun run forgeflow:check`.
+* Correcting the eight existing declarations.
+* Adding DBCLI-022 to DBCLI-026 to `completed_stories`.
+* ADR-0030, and replacing the handoff paragraph that recorded the discrepancy as
+  accepted with what was done about it.
+
+### Out of Scope
+
+* The other five Authority permissions. Delivery implies `commit` and `push` and
+  nothing else; checking `deploy` or `migration` against delivery would invent
+  implications the contract explicitly denies.
+* `specs/stories/_template/story.md`. It is an adoption surface reconciled
+  against upstream, and its `push: no` is upstream's default, not a claim about a
+  delivered Story.
+* Any change to `src/`, and any release.
+
+## Inputs
+
+* The eight Story directories declaring `## Authority`.
+* `specs/handoff.md` — `completed_stories`.
+
+## Outputs
+
+* A gate that fails on the discrepancy this Story is fixing.
+* Eight declarations that agree with what delivering them required.
+
+## Rules
+
+* R1: A Story in `completed_stories` declaring `commit: no` or `push: no` fails
+  `bun run forgeflow:check`, and the message names both exits — correct the
+  declaration, or stop recording it as completed.
+* R2: A Story with no `## Authority` section, or one omitting a permission,
+  declares nothing and is not reported. The section is optional upstream.
+* R3: A Story not recorded as completed is not checked. The claim being
+  reconciled is the handoff's, not the Story's.
+* R4: Only `commit` and `push` are checked.
+* R5: The gate stays offline and reads no git history, so a shallow CI clone
+  behaves as a local one does.
+* R6: No change to `src/`.
+
+## Expected Errors
+
+* A delivered Story left at `push: no` fails the handoff gate by name.
+* A Story added to `completed_stories` before its Authority is corrected fails
+  the same way.
+
+## Dependencies
+
+* `scripts/lib/forgeflow-handoff.ts` and `scripts/check-forgeflow-handoff.ts`.
+* ADR-0030 — the decision and its falsification condition.
+
+## Constraints
+
+* The check reads two files and spawns nothing; the sibling trailer
+  reconciliation needs git and has to guard against shallow clones, and this one
+  must not inherit that.

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -29,8 +29,10 @@ import {
   formatViolations,
   lifecycleBlock,
   readLifecycle,
+  readAuthority,
   readStoryId,
   reconcile,
+  reconcileDeliveryAuthority,
   shallowCloneRefusal,
   type Exemption,
 } from '../../../scripts/lib/forgeflow-handoff'
@@ -440,5 +442,71 @@ describe('the gate is offline by construction', () => {
     ).text()
     expect(source).not.toMatch(/^\s*import\s/m)
     expect(source).not.toMatch(/\bfetch\s*\(|\brequire\s*\(/)
+  })
+})
+
+describe('reconcileDeliveryAuthority', () => {
+  const AUTHORITY = (commit: string, push: string) =>
+    `# Story: DBCLI-900 T\n\n## Authority\n\n* plan: yes\n* modify: yes\n* commit: ${commit}\n* push: ${push}\n* deploy: no\n\n## Scope\n`
+  const directories = new Map([['DBCLI-900', 'DBCLI-900-t']])
+  const lifecycle = { completedStories: ['DBCLI-900'] }
+  const sourced = (source: string) => [{ directory: 'DBCLI-900-t', source }]
+
+  test('reads a declared permission', () => {
+    expect(readAuthority(AUTHORITY('yes', 'no'), 'commit')).toBe('yes')
+    expect(readAuthority(AUTHORITY('yes', 'no'), 'push')).toBe('no')
+  })
+
+  test('a Story with no Authority section declares nothing', () => {
+    // The section is optional. A Story making no claim has nothing to
+    // contradict, and reporting one would demand a section upstream does not.
+    expect(readAuthority('# Story: DBCLI-900 T\n\n## Scope\n', 'push')).toBeUndefined()
+  })
+
+  test('a permission absent from a declared section is not a "no"', () => {
+    const partial = '# Story: DBCLI-900 T\n\n## Authority\n\n* plan: yes\n\n## Scope\n'
+
+    expect(readAuthority(partial, 'push')).toBeUndefined()
+    expect(reconcileDeliveryAuthority(lifecycle, directories, sourced(partial))).toEqual([])
+  })
+
+  test('a delivered Story may not declare commit: no or push: no', () => {
+    const failures = reconcileDeliveryAuthority(
+      lifecycle,
+      directories,
+      sourced(AUTHORITY('no', 'no'))
+    )
+
+    expect(failures).toHaveLength(2)
+    expect(failures[0]!.reason).toContain('`commit: no`')
+    expect(failures[1]!.reason).toContain('`push: no`')
+  })
+
+  test('a delivered Story declaring both is clean', () => {
+    expect(
+      reconcileDeliveryAuthority(lifecycle, directories, sourced(AUTHORITY('yes', 'yes')))
+    ).toEqual([])
+  })
+
+  test('only the two permissions delivery implies are checked', () => {
+    // Authority is per-permission and nothing implies anything else. Delivering
+    // a Story says nothing about whether it was allowed to deploy, so a clean
+    // Story keeps its `deploy: no`.
+    expect(
+      reconcileDeliveryAuthority(lifecycle, directories, sourced(AUTHORITY('yes', 'yes')))
+    ).toEqual([])
+    expect(readAuthority(AUTHORITY('yes', 'yes'), 'deploy')).toBe('no')
+  })
+
+  test('a Story that is not recorded as completed is not checked', () => {
+    // The claim being reconciled is the handoff's, not the Story's. An
+    // in-flight Story has not been delivered and may truthfully say push: no.
+    expect(
+      reconcileDeliveryAuthority(
+        { completedStories: [] },
+        directories,
+        sourced(AUTHORITY('no', 'no'))
+      )
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
接續 #184。修掉那份 PR 裡自己記下的「已知落差」—— 並且推翻當時不修的理由。

## 為什麼翻案

#184 的 handoff 寫著：DBCLI-022／023 宣告 `push: no` 而分支被 push 了，不回頭改，
因為 Authority 記的是核可當下授予了什麼，而改寫已核可 Story 正是 DBCLI-021 拒絕
的事。

量了之後翻案。這個 repo 裡所有曾宣告 `## Authority` 的 Story 共八個：

* **八個全部**宣告 `push: no`；
* 其中三個（019／020／021）另外宣告 `commit: no`；
* 八個全部經由合併的 PR 進了 `main` —— 以 commit、在被 push 的分支上。

**八分之八不是決定的紀錄，是模板預設值被抄了八次沒填。** 改它不毀掉任何決定，因為
從來沒有人做過那個陳述。原本的推理對「已核可的紀錄不要動」是對的，錯在把這件事歸
成那一類。

## 真正的問題不是那八個字

它能活過八個 Story，是因為**沒有東西拿它跟任何東西比對**。上游的 checker 只驗
Authority 的值是不是 `yes`／`no`，沒有任何地方問過它是不是真的。一個沒有東西去
比對的宣告不是控制，措辭再嚴謹都不是。

所以這個 PR 不是只改那八個字 —— 那樣下次還會再犯。

## `reconcileDeliveryAuthority`

比對材料本來就在：`completed_stories` 是這個 repo 自己說某個 Story 進了 `main`，
而它只可能以 commit、經由被 push 的分支進去。列在那裡卻宣告 `commit: no` 或
`push: no` 的 Story，`bun run forgeflow:check` 就紅，訊息同時指出兩個出口 ——
改宣告，或別再把它記成 completed。

**只檢查這兩項。** 交付不蘊含 `deploy`、`migration` 或 `add_dependency`，而
Authority 依契約就是逐項授權、彼此不蘊含；多檢查等於發明契約明確否認的蘊含關係。
一個已交付的 Story 仍可以誠實地宣告 `deploy: no`。

**離線。** 只讀 `specs/handoff.md` 與各 Story 檔案，不呼叫 git。兄弟那條 trailer
對帳需要 git history、必須明確防淺複製；這一條不繼承那個失效模式。

## 順帶對帳出的第二件過期

DBCLI-022 到 026 已交付、已合併、已通過 Human Review，卻都沒被登進
`completed_stories`。一併補上 —— 34 completed Stories。

## 要審的重點

那八個已核可宣告的 retro-edit。它靠的是 ADR-0030 裡 8/8 的量測，不是「看起來不
整齊」。**量測若是錯的，這個編輯就正是這個 repo 平常拒絕的那種悄悄改紀錄** ——
這一點寫在 Story 的 `Risk` 與 acceptance 的 Verification Notes 裡。

ADR-0030 帶失效條件：若交付不再蘊含被 push 的分支，這個檢查就在斷言一個不成立的
蘊含，必須收窄或移除。

## Test plan

```
bun test tests/unit/scripts/forgeflow-handoff.test.ts   → 50 pass（新增 7 條）
bun test tests/unit/build/adr-references.test.ts        → 4 pass
bun run forgeflow:check                                  → 34 completed Stories
FORGEFLOW_ROOT=<cb4bc976 clean> bun run forgeflow:contract
  → 35 Stories, 0 admitted pre-existing finding(s)
make verify                                              → exit 0
```

修正前先跑過一次確認 gate 真的會紅：它按名字報出 DBCLI-019／020／021 的
`commit: no`。ForgePilot 在 detached worktree 對 `68f649f7` 獨立跑 `make verify`：
`EV-044 PASS`，WI-014 DONE。

`git diff --name-only main...HEAD -- src/` 為空。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn