### PR TITLE
fix: [ forgeflow ] 交付說的是「進了 main」，不是「誰做的」

### DIFF
--- a/README.md
+++ b/README.md
@@ -1775,11 +1775,20 @@ is load-bearing rather than decorative.
 
 Every gate here is a variation on one lesson: **a declaration nothing compares
 to anything is not a control.** Delivery claims in the handoff are reconciled
-against commit trailers; a Story's Authority declaration is reconciled against
-the fact of its delivery (ADR-0030); the adopted ForgeFlow version is reconciled
-against every place that restates it. One declaration was wrong in eight
-consecutive Stories without anyone noticing, for the only reason such things
-survive: nothing ever asked whether it was true.
+against commit trailers; the adopted ForgeFlow version is reconciled against
+every place that restates it; the ForgeFlow contract itself is run against a
+pinned upstream revision.
+
+The lesson has a limit, and finding it cost a decision. A Story's `## Authority`
+was briefly reconciled against the fact of its delivery, on the reasoning that
+reaching `main` requires commits on a pushed branch (ADR-0030). It does — but
+`completed_stories` records that a Story was delivered, not **who** performed
+each operation, and the normal flow here is an agent that is granted `modify` and
+a local `commit` handing its branch to a human who pushes and merges. The gate
+refused that flow by name, so the rule was removed (ADR-0031). Whether an
+Authority declaration is true is a question this repository cannot observe and
+Human Review can; a gate that guesses at it is worse than an unchecked
+declaration, because its verdict looks like evidence.
 
 ---
 

--- a/docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md
+++ b/docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md
@@ -1,7 +1,16 @@
 # A permission nobody filled in is not a control
 
-* Status: accepted
+* Status: superseded
 * Date: 2026-09-09
+* Superseded by: ADR-0031
+
+> The decision below — that delivery implies `commit` and `push`, enforced by the
+> handoff gate — is superseded by
+> [ADR-0031](ADR-0031-delivery-does-not-record-who-performed-it.md). Delivery
+> records that a Story reached `main`, not who performed each operation, and an
+> agent that commits locally while a human pushes was refused by name. The
+> measurement below is still current and still accurate; what it was taken to
+> prove is not.
 
 ForgeFlow 0.6.0's `## Authority` section declares, per operation, what a Story is
 permitted to do. AGENTS.md restates the rule that makes it worth having:

--- a/docs/adr/ADR-0031-delivery-does-not-record-who-performed-it.md
+++ b/docs/adr/ADR-0031-delivery-does-not-record-who-performed-it.md
@@ -66,8 +66,13 @@ or a push is not one.
 
 A Story declares what its implementing agent may do, which for an agent that
 hands its branch to a human is `commit: yes, push: no` or `commit: no, push: no`.
-DBCLI-028 is the first Story in this repository to declare `push: no` and mean
-it.
+Such a Story is delivered like any other, and the gate no longer objects.
+
+DBCLI-028 was authored that way and then changed: it was implemented and verified
+under `push: no`, and the human granted `push` to open the pull request, so its
+declaration says `push: yes`. That is the correction mechanism this record names
+working as intended — a permission moves because someone who can grant it granted
+it, not because a branch turned out to be pushed.
 
 Nothing now compares an Authority declaration to anything, which is the state
 ADR-0030 objected to. That objection was right in general and had the wrong

--- a/docs/adr/ADR-0031-delivery-does-not-record-who-performed-it.md
+++ b/docs/adr/ADR-0031-delivery-does-not-record-who-performed-it.md
@@ -1,0 +1,84 @@
+# Delivery does not record who performed it
+
+* Status: accepted
+* Date: 2026-09-09
+* Supersedes: ADR-0030
+
+[ADR-0030](ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md) decided
+that delivery implies `commit` and `push`, and had the handoff gate fail any
+Story in `completed_stories` declaring either as `no`. That rule is removed.
+
+The measurement ADR-0030 rests on is still accurate: eight of eight Stories that
+had ever declared `## Authority` declared `push: no`, three also declared
+`commit: no`, and all eight reached `main` through a merged pull request. What it
+got wrong is what follows from that. `completed_stories` records that a Story was
+delivered. It records nothing about **who** performed each operation, and the
+ordinary division of labour in this repository is precisely the case the rule
+refuses: an agent is granted `modify` and at most a local `commit`, and a human
+commits, pushes, opens the pull request and merges it. The delivery is real and
+the agent's `push: no` was true the whole time.
+
+ADR-0030 wrote its own falsification condition as *delivery stops implying a
+pushed branch*. Delivery does still imply a pushed branch. It never implied the
+**agent** pushed, and that is the step the rule was actually making.
+
+A second symptom points the same way. Upstream ForgeFlow's Execution Contract
+(`protocol/execution.md`, revision `cb4bc97673ad3098a4689a1589e1f2c4b5175c63`,
+the revision `specs/.forgeflow-adoption` pins) defaults every operation but
+`plan` and `modify` to `no`, and states in one sentence that *being able to
+commit, push, deploy, add a dependency, or run a migration is never authorization
+to do it*. So an omitted `push:` says what an explicit `push: no` says. The
+removed rule failed the explicit spelling and passed the omission — one claim,
+two verdicts, with the lenient one available to anyone who deleted a line.
+
+## Decision
+
+**The handoff gate reconciles delivery claims and derives no permission from
+them.** `scripts/lib/forgeflow-handoff.ts` reads no `## Authority` section, and
+`scripts/check-forgeflow-handoff.ts` calls nothing that does. A Story recorded as
+completed while declaring `commit: no` or `push: no` passes: a human performing
+the operation is a supported flow, not a discrepancy.
+
+**Everything else in that gate stays.** Story-directory existence, `Story:`
+trailer evidence, the `DELIVERED_BEFORE_TRAILERS` ratchet, the shallow-clone
+refusal and the lifecycle structure checks are unchanged, and each keeps a test
+that fails if it goes. The lesson DBCLI-027 was right about — a declaration
+nothing compares to anything is not a control — was never a lesson about
+Authority; it is what those rules already do.
+
+**Authority stays upstream's.** Its format, its defaults and which combinations
+are legal are checked by `bun run forgeflow:contract` against the adopted
+revision. Whether a declaration is *true* is Human Review's question, and this
+repository builds no second authorization parser, identity store or approval
+database to answer it.
+
+**The eight rewritten declarations are left as they stand, and what is
+unconfirmed about them is recorded here.** ADR-0030 changed `push: no` to
+`push: yes` in DBCLI-019 to DBCLI-026, and `commit: no` to `commit: yes` in
+DBCLI-019, DBCLI-020 and DBCLI-021, on the inference this record withdraws. No
+approval record was found that states, per operation, what those Stories granted
+their implementing agent. Reverting them would be the same error mirrored —
+inferring a withheld permission from the absence of evidence — so they are not
+reverted. Only an approval record can correct a historical declaration; a merge
+or a push is not one.
+
+## Consequences
+
+A Story declares what its implementing agent may do, which for an agent that
+hands its branch to a human is `commit: yes, push: no` or `commit: no, push: no`.
+DBCLI-028 is the first Story in this repository to declare `push: no` and mean
+it.
+
+Nothing now compares an Authority declaration to anything, which is the state
+ADR-0030 objected to. That objection was right in general and had the wrong
+subject: this repository cannot observe who ran a command, so a gate here can
+only guess, and a gate that guesses is worse than an unchecked declaration
+because its verdict looks like evidence. Human Review is where the question is
+answerable, and the ForgeFlow contract already puts it there.
+
+**Falsified if:** this repository acquires a record that attributes an operation
+to an actor — a signed commit policy, a CI-enforced push identity, or an approval
+log naming who was granted what. Then `scripts/lib/forgeflow-handoff.ts` can
+compare an Authority declaration against something real instead of against the
+fact of delivery, and the question this record closes is open again on evidence
+rather than on inference.

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -26,7 +26,6 @@ import {
   lifecycleBlock,
   readLifecycle,
   reconcile,
-  reconcileDeliveryAuthority,
   shallowCloneRefusal,
   type Exemption,
 } from './lib/forgeflow-handoff'
@@ -112,8 +111,6 @@ const failures = await reconcile({
   exemptions: DELIVERED_BEFORE_TRAILERS,
   commitExists,
 })
-
-failures.push(...reconcileDeliveryAuthority(lifecycle, directories, sources))
 
 if (failures.length > 0) {
   console.error(formatFailures(failures))

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -458,85 +458,29 @@ export function shallowCloneRefusal(isShallowOutput: string): string | null {
 }
 
 /**
- * Permissions a delivered Story necessarily exercised.
+ * Why nothing here reads a Story's `## Authority`.
  *
- * Delivery here means a merged pull request: the work was committed and the
- * branch was pushed. Nothing else on the Authority list is implied — `deploy`,
- * `migration` and `add_dependency` are unconstrained by delivery, and Authority
- * is per-permission by contract.
+ * DBCLI-027 added a rule that failed any Story in `completed_stories` declaring
+ * `commit: no` or `push: no`, reasoning that reaching `main` requires commits on
+ * a pushed branch. The reasoning is sound about the operations and wrong about
+ * who performed them. `completed_stories` records that the Story was delivered;
+ * it records nothing about which hands did what. The ordinary division of labour
+ * in this repository is the counterexample: an agent is granted `modify` and at
+ * most a local `commit`, and a human commits, pushes, opens the pull request and
+ * merges it. Delivery is complete and the agent's `push: no` was true throughout
+ * — and the rule refused exactly that flow.
+ *
+ * It also split one claim into two verdicts. Upstream's Execution Contract
+ * defaults every operation but `plan` and `modify` to `no`, so an omitted
+ * `push:` says what an explicit `push: no` says; the rule failed the explicit
+ * spelling and passed the blank, which made deleting a line the way through.
+ *
+ * So this gate answers one question — does the repository back the delivery
+ * claim — and derives no permission from the answer. Authority's format, its
+ * defaults and which combinations are legal are upstream's checker's business,
+ * run by `bun run forgeflow:contract`; whether a declaration is true is Human
+ * Review's. ADR-0031 supersedes ADR-0030.
  */
-const DELIVERY_IMPLIES: readonly string[] = ['commit', 'push']
-
-/**
- * Read one permission from a Story's `## Authority` section.
- *
- * `undefined` when the Story declares no Authority at all, or declares that
- * section without this permission — the section is optional, and a Story making
- * no claim has nothing to contradict.
- */
-export function readAuthority(source: string, permission: string): 'yes' | 'no' | undefined {
-  const section = source.split(/^## /m).find((part) => part.startsWith('Authority'))
-  if (section === undefined) return undefined
-
-  const pattern = new RegExp(`^\\* ${permission}:\\s*(\\S+)\\s*$`)
-  for (const line of section.split('\n')) {
-    const match = line.match(pattern)
-    if (match === null) continue
-    return match[1] === 'yes' || match[1] === 'no' ? (match[1] as 'yes' | 'no') : undefined
-  }
-
-  return undefined
-}
-
-/**
- * Refuse a delivered Story that says it was not allowed to do what delivering it
- * required.
- *
- * `completed_stories` is the repository's own statement that the Story reached
- * `main`, which it can only have done as commits on a pushed branch. So a
- * completed Story declaring `commit: no` or `push: no` is not recording a
- * permission that was withheld; it is contradicting the handoff two files away.
- *
- * This exists because the declaration was wrong every time it was made. All
- * eight Stories that had ever declared Authority said `push: no` and three also
- * said `commit: no`, while every one of them reached `main` — a template field
- * nobody filled in rather than a decision anybody made. A value that has never
- * once been true is not a control, and what let it survive was that nothing
- * compared it to anything. ADR-0030.
- *
- * Only the two permissions delivery actually implies are checked. Authority is
- * per-permission and nothing implies anything else, so a delivered Story may
- * still truthfully declare `deploy: no`.
- */
-export function reconcileDeliveryAuthority(
-  lifecycle: Lifecycle,
-  directories: ReadonlyMap<string, string>,
-  stories: Iterable<StorySource>
-): Failure[] {
-  const sources = new Map([...stories].map(({ directory, source }) => [directory, source]))
-  const failures: Failure[] = []
-
-  for (const story of lifecycle.completedStories) {
-    const directory = directories.get(story)
-    if (directory === undefined) continue
-
-    const source = sources.get(directory)
-    if (source === undefined) continue
-
-    for (const permission of DELIVERY_IMPLIES) {
-      if (readAuthority(source, permission) !== 'no') continue
-      failures.push({
-        story,
-        reason:
-          `is recorded as completed but its ## Authority declares \`${permission}: no\` — a delivered ` +
-          'Story reached main as commits on a pushed branch, so correct the declaration or stop ' +
-          'recording it as completed',
-      })
-    }
-  }
-
-  return failures
-}
 
 /**
  * Compare every delivery claim against the repository.

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -955,14 +955,45 @@ Authority 記的是核可當下授予了什麼，而改寫已核可 Story 正是
 上游的 checker 只驗值是不是 `yes`／`no`，沒有任何地方問過它是不是真的。一個沒有
 東西去比對的宣告不是控制，措辭再嚴謹都不是。
 
-比對的材料本來就在：`completed_stories` 是這個 repo 自己說某個 Story 進了 main，
-而它只可能是以 commit、經由被 push 的分支進去的。`reconcileDeliveryAuthority`
-現在就檢查這一條，訊息同時指出兩個出口——改宣告，或別再把它記成 completed。
-只檢查 `commit` 與 `push` 兩項：交付不蘊含 `deploy` 或 `migration`，而 Authority
-本來就是逐項授權、彼此不蘊含。決定與失效條件在 ADR-0030。
+比對的材料看起來本來就在：`completed_stories` 是這個 repo 自己說某個 Story 進了
+main，而它只可能是以 commit、經由被 push 的分支進去的。`reconcileDeliveryAuthority`
+當時就檢查這一條。**那一步是錯的，下一節說明並且已經移除。**
 
 順帶對帳出第二件過期：DBCLI-022 到 026 已交付、已合併、已通過 Human Review，卻都
-沒被登進 `completed_stories`。一併補上。
+沒被登進 `completed_stories`。一併補上——這一半站得住，跟 Authority 無關。
+
+### 交付說的是「進了 main」，不是「誰做的」
+
+上一節那條規則活了一天。它擋掉的第一個東西不是漏填的模板，是這個 repo 的正常流程：
+**agent 拿到 `modify`、最多一個本機 `commit`，接手 commit、push、開 PR、合併的是人。**
+交付是完整的，agent 的 `push: no` 從頭到尾都是真的，而 gate 指名拒絕它。
+
+ADR-0030 自己寫的失效條件是「交付不再蘊含被 push 的分支」。交付到今天仍然蘊含一條
+被 push 的分支——它從來沒有蘊含**是 agent** push 的。那一步才是規則真正在做的推論。
+
+第二個症狀指向同一件事：同一個宣告被判兩次不同的結果。上游 0.7.0 的 Execution
+Contract（`protocol/execution.md`，`specs/.forgeflow-adoption` 釘住的 revision）把
+`plan`、`modify` 以外每一項的預設值定為 `no`，並且明說「做得到某件事從來不是被授權
+去做它」。所以省略 `push:` 跟寫 `push: no` 是同一句話；那條規則卻擋顯式的 `no`、
+放行省略的那個——刪掉一行就是穿過去的辦法。
+
+移除的只有那條推論。Story 目錄存在性、`Story:` trailer、`DELIVERED_BEFORE_TRAILERS`
+棘輪、淺複製拒絕、lifecycle 結構檢查全部原封不動，每一條都留著一支會在它消失時變紅
+的測試。DBCLI-027 對的那半句——沒有東西比對過的宣告不是控制——本來就不是在講
+Authority，那是上面那幾條規則已經在做的事。Authority 的格式、預設值與組合合法性由
+`bun run forgeflow:contract` 對著採用的 revision 檢查；它是不是真的，是 Human Review
+的問題。這個 repo 觀察不到指令是誰下的，會猜的 gate 比沒被檢查的宣告更糟，因為它的
+判決長得像證據。
+
+**那八個被改寫的宣告留在原處。** ADR-0030 把 DBCLI-019 到 026 的 `push: no` 改成
+`yes`，其中 019、020、021 的 `commit: no` 也一併改了。查不到任何逐項記錄那八個 Story
+授予了實作 agent 什麼的核可紀錄。改回 `no` 會是同一個錯誤的鏡像——從沒有證據推論
+權限被收回——所以不改。能更正一個歷史宣告的只有核可紀錄，merge 或 push 都不是。
+決定與失效條件在 ADR-0031。
+
+一個順帶的指標修復：上游 `protocol/architecture.md` 明說 `superseded` 的記錄不能當
+依賴，所以 DBCLI-027 的 `Decision:` 改指 ADR-0031，並在該 Story 裡寫明它當初做的
+決定是 ADR-0030。這是指標修復，不是改寫那個 Story 主張過的東西。
 
 ## Lifecycle
 
@@ -1013,9 +1044,16 @@ workflow:
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 87e8c48aa303dbccdc5c36a6aa0cbe0f35fc7995
+  commit: e709ebe1c55924d898d8a524adb486dd4f2e4b41
   dirty_worktree: false
   story_owned_paths:
+    - specs/stories/DBCLI-028-delivery-is-not-authorization/story.md
+    - specs/stories/DBCLI-028-delivery-is-not-authorization/acceptance.md
+    - docs/adr/ADR-0031-delivery-does-not-record-who-performed-it.md
+    - scripts/lib/forgeflow-handoff.ts
+    - scripts/check-forgeflow-handoff.ts
+    - tests/unit/scripts/forgeflow-handoff.test.ts
+    - README.md
     - specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
     - specs/stories/DBCLI-027-authority-that-matches-delivery/acceptance.md
     - docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md

--- a/specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
+++ b/specs/stories/DBCLI-027-authority-that-matches-delivery/story.md
@@ -54,10 +54,15 @@ delivered, merged and approved, and none of them had been added to it.
 ## Architecture
 
 * Impact: medium
-* Decision: `ADR-0030`
+* Decision: `ADR-0031`
 * Boundary: `HandoffContract`
 * Contract: `a delivered Story's Authority agrees with what delivering it required`
 * Owner: `HandoffContract = repository-governance`
+
+The decision this Story made is ADR-0030. It was superseded by ADR-0031
+(DBCLI-028), and upstream rejects a superseded record as a dependency, so the
+reference above points at the record now in force; ADR-0031 carries ADR-0030's
+measurement and links back to it.
 
 ## Risk
 

--- a/specs/stories/DBCLI-028-delivery-is-not-authorization/acceptance.md
+++ b/specs/stories/DBCLI-028-delivery-is-not-authorization/acceptance.md
@@ -1,0 +1,69 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [x] AC-001: A Story recorded as completed, backed by a `Story:` trailer, whose
+      `## Authority` declares `commit: yes` and `push: no` — the agent committed
+      locally and a human pushed — produces no failure.
+* [x] AC-002: The same Story declaring `commit: no` and `push: no` — a human took
+      over both operations — produces no failure.
+
+## Business Rules
+
+* [x] AC-003: The gate reads no permission from any Story: two delivery claims
+      identical except for their Authority text reach the same verdict, so a
+      Story omitting `## Authority` or a permission within it gains nothing an
+      explicit `no` would have cost it.
+* [x] AC-004: Delivery and authorization are separate verdicts: a Story with no
+      trailer and no exemption fails while declaring `commit: yes` and
+      `push: yes`, and a delivered Story passes while declaring both as `no`.
+* [x] AC-005: `scripts/lib/forgeflow-handoff.ts` exports no Authority reader, so
+      no second authorization parser exists in this repository.
+
+## Failure Cases
+
+* [x] AC-006: A Story recorded as completed with no `specs/stories` directory,
+      no trailer, or a `DELIVERED_BEFORE_TRAILERS` commit this repository does
+      not contain still fails by name.
+* [x] AC-007: A shallow clone is still refused rather than silently passed, and
+      a lifecycle block naming a current or next Story is still refused.
+
+## Regression Requirements
+
+* [x] AC-008: `src/` is unchanged.
+* [x] AC-009: `PREDATING_FINDINGS` is still empty and both admitted counts are
+      still zero, checked against the adopted ForgeFlow revision.
+* [x] AC-010: The complete repository verification gate passes.
+
+## Acceptance Evidence
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `a delivered Story a human pushed` | `reconcile returns no failures` |
+| `AC-002` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `a delivered Story a human committed and pushed` | `reconcile returns no failures` |
+| `AC-003` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `three Story sources differing only in Authority` | `identical verdicts` |
+| `AC-004` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `an undelivered Story declaring commit and push yes` | `one unbacked-claim failure` |
+| `AC-005` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `the module namespace` | `no exported name reads Authority` |
+| `AC-006` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `the existing reconcile fixtures` | `each failure names its Story` |
+| `AC-007` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `the existing shallowCloneRefusal and readLifecycle fixtures` | `refusal text and violations unchanged` |
+| `AC-008` | command | `git diff --stat 87e8c48aa303dbccdc5c36a6aa0cbe0f35fc7995 -- src` | `repository checkout` | `empty output` |
+| `AC-009` | command | `bun run forgeflow:contract` | `FORGEFLOW_ROOT set to a clean checkout at cb4bc97673ad3098a4689a1589e1f2c4b5175c63` | `0 admitted pre-existing finding(s)` |
+| `AC-010` | command | `make verify` | `repository checkout` | `exit 0` |
+
+## Verification Notes
+
+```sh
+bun test tests/unit/scripts/forgeflow-handoff.test.ts tests/unit/build/adr-references.test.ts
+bun run forgeflow:check
+FORGEFLOW_ROOT=<clean ForgeFlowV2 checkout> bun run forgeflow:contract
+make verify
+```
+
+`bun run forgeflow:contract` is not part of `make verify`; it needs a clean
+ForgeFlow checkout at the pinned revision and must be run separately.
+
+What human review should weigh is the removal itself. This Story argues that the
+repository cannot tell who performed an operation and should therefore stop
+claiming it can. If there is an approval record that does establish per-operation
+authority for the eight declarations ADR-0030 rewrote, that record — not the
+merge history — is what would correct them.

--- a/specs/stories/DBCLI-028-delivery-is-not-authorization/story.md
+++ b/specs/stories/DBCLI-028-delivery-is-not-authorization/story.md
@@ -1,0 +1,172 @@
+# Story: DBCLI-028 Delivery Is Not Authorization
+
+## Goal
+
+The handoff gate judges whether a delivery claim is backed by the repository, and
+nothing else. Whether the implementing agent was permitted to commit or push is a
+separate question that the fact of delivery cannot answer, so the gate stops
+answering it.
+
+## Context
+
+DBCLI-027 added `reconcileDeliveryAuthority`: a Story in `completed_stories`
+declaring `commit: no` or `push: no` fails `bun run forgeflow:check`, on the
+reasoning that reaching `main` requires commits on a pushed branch. ADR-0030
+recorded it.
+
+The inference is wrong about *who*. `completed_stories` records that the Story
+was delivered; it does not record who performed each operation. The normal
+division of labour in this repository is exactly the counterexample: an agent is
+granted `modify` and at most a local `commit`, and a human takes the branch from
+there — commits it, pushes it, opens the pull request, merges it. Delivery is
+complete and the agent's `push: no` was true the whole time. The gate refuses
+that flow by name.
+
+ADR-0030 wrote its own falsification condition for this: *falsified if delivery
+stops implying a pushed branch*. What it missed is that delivery never implied
+the **agent** pushed. It is falsified now, and by the case its author had in front
+of them.
+
+The second symptom is a split verdict on the same claim. Upstream ForgeFlow
+0.7.0's Execution Contract (`protocol/execution.md`, revision
+`cb4bc97673ad3098a4689a1589e1f2c4b5175c63`) defaults every operation other than
+`plan` and `modify` to `no`, and says so in one sentence: *being able to commit,
+push, deploy, add a dependency, or run a migration is never authorization to do
+it*. So an omitted `push:` is a `no`. `reconcileDeliveryAuthority` fails the
+explicit `no` and passes the omission — two spellings of one declaration, two
+different verdicts, and the lenient one available to anyone who deletes a line.
+
+What survives from DBCLI-027 is its useful half, which was never about Authority:
+a declaration nothing compares to anything is not a control. That is why the
+delivery reconciliation, the trailer evidence, the historical exemption ratchet,
+the shallow-clone refusal and the lifecycle structure checks all stay exactly as
+they are. Authority's format, defaults and combination legality stay upstream's
+job, checked by `bun run forgeflow:contract` against the adopted revision.
+
+The eight declarations DBCLI-027 rewrote from `no` to `yes` are **not reverted**.
+Reverting them would be the same error mirrored: inferring from the absence of
+evidence that permission was withheld. What is recorded instead is that those
+eight values rest on a withdrawn inference and that no approval record confirms
+them. ADR-0031 names them.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: yes
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: no
+* deploy: no
+
+This Story is itself the case it is about: the implementing agent was authorized
+to change these files and commit them locally, and a human takes it from there.
+Its `push: no` is a statement, not a leftover.
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0031`
+* Boundary: `HandoffContract`
+* Contract: `the handoff gate reconciles delivery claims and derives no permission from them`
+* Owner: `HandoffContract = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `governance-control-removal`
+
+A gate is being removed, not added. The risk is that the reasoning removes more
+than the defective rule, so every other rule in the gate keeps a test that fails
+if it goes.
+
+## Scope
+
+### In Scope
+
+* Removing `reconcileDeliveryAuthority`, `DELIVERY_IMPLIES` and `readAuthority`
+  from `scripts/lib/forgeflow-handoff.ts`, and their use in
+  `scripts/check-forgeflow-handoff.ts`.
+* Replacing the tests of the removed rule with tests that hold delivery and
+  authorization apart.
+* ADR-0031, superseding ADR-0030 and keeping its measurement.
+* The README paragraph and the `specs/handoff.md` section that state the removed
+  implication.
+* DBCLI-027's `Decision:` reference. Upstream rejects a `superseded` record as a
+  dependency (`protocol/architecture.md`), so the reference is repointed at
+  ADR-0031, which carries ADR-0030's measurement and links back to it. A pointer
+  repair, not a change to what that Story claimed.
+
+### Out of Scope
+
+* Reverting the eight corrected declarations, or editing any historical
+  Authority declaration without an approval record to correct it against.
+* Any local re-implementation of Authority parsing, defaults or legality; any
+  identity or approval store. Upstream owns the declaration, and human review
+  owns whether it is true.
+* Any change to `src/`, and any release or tag.
+
+## Inputs
+
+* `scripts/lib/forgeflow-handoff.ts`, `scripts/check-forgeflow-handoff.ts`,
+  `tests/unit/scripts/forgeflow-handoff.test.ts`.
+* ADR-0030, `README.md`, `specs/handoff.md`.
+* Upstream `protocol/execution.md` at the revision `specs/.forgeflow-adoption`
+  pins.
+
+## Outputs
+
+* A handoff gate that answers one question and does not derive permissions.
+* A decision record naming the withdrawn inference and what is left unconfirmed.
+
+## Rules
+
+* R1: A Story in `completed_stories` is judged on whether the repository backs
+  the delivery claim. Its `## Authority` cannot change that verdict.
+* R2: A delivered Story declaring `commit: no` or `push: no` passes the gate. A
+  human performing the operation is a permitted flow, not a discrepancy.
+* R3: Omitting `## Authority`, or a permission within it, grants nothing. This
+  gate reads no permission from any Story, so both spellings reach the same
+  place: upstream's default, which is `no`.
+* R4: Delivery reconciliation is unchanged — Story directory existence, `Story:`
+  trailers, the `DELIVERED_BEFORE_TRAILERS` ratchet, the shallow-clone refusal
+  and the lifecycle structure checks all still fail when they failed before.
+* R5: No change to `src/`.
+
+## Expected Errors
+
+* A Story recorded as completed with no trailer and no exemption still fails,
+  whatever its Authority declares.
+* A `DELIVERED_BEFORE_TRAILERS` entry naming a commit this repository does not
+  contain still fails.
+
+## Dependencies
+
+* ADR-0030 — the decision being superseded.
+* ForgeFlow 0.7.0 `protocol/execution.md` — Authority's defaults and the rule
+  that no operation implies another.
+
+## Constraints
+
+* `scripts/lib/forgeflow-handoff.ts` imports nothing and spawns nothing; the
+  removal must not change that.
+* The eight declarations DBCLI-027 rewrote stay as they are, with what is
+  unconfirmed about them written down rather than guessed at in either direction.
+
+## Superseded Behavior
+
+* `tests/unit/scripts/forgeflow-handoff.test.ts` — the `reconcileDeliveryAuthority`
+  suite asserts that a delivered Story declaring `commit: no` or `push: no`
+  produces failures. That is the defect. The suite is replaced by one asserting
+  the opposite, and the two cases it got right — an optional section declares
+  nothing, an undelivered Story is not checked — survive as properties of a gate
+  that reads no Authority at all.
+* `docs/adr/ADR-0030-a-permission-nobody-filled-in-is-not-a-control.md` — its
+  decision that delivery implies `commit` and `push` is superseded by ADR-0031.
+  Its measurement stays current.

--- a/specs/stories/DBCLI-028-delivery-is-not-authorization/story.md
+++ b/specs/stories/DBCLI-028-delivery-is-not-authorization/story.md
@@ -62,12 +62,19 @@ them. ADR-0031 names them.
 * add_dependency: no
 * migration: no
 * commit: yes
-* push: no
+* push: yes
 * deploy: no
 
-This Story is itself the case it is about: the implementing agent was authorized
-to change these files and commit them locally, and a human takes it from there.
-Its `push: no` is a statement, not a leftover.
+This Story is itself the case it is about, and its Authority moved once while it
+was being implemented. It was authored as `commit: yes, push: no` — change these
+files, commit them locally, a human takes the branch from there — and that was
+true through implementation and verification. The human then granted `push` in
+order to open the pull request, so the declaration says `push: yes`.
+
+That grant is the correction mechanism ADR-0031 names: a permission is granted by
+someone who can grant it, and the declaration follows the grant. What it is still
+not is the merge. Had the human pushed the branch themselves, this would read
+`push: no` and the Story would be no less delivered.
 
 ## Architecture
 

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -29,10 +29,8 @@ import {
   formatViolations,
   lifecycleBlock,
   readLifecycle,
-  readAuthority,
   readStoryId,
   reconcile,
-  reconcileDeliveryAuthority,
   shallowCloneRefusal,
   type Exemption,
 } from '../../../scripts/lib/forgeflow-handoff'
@@ -445,68 +443,82 @@ describe('the gate is offline by construction', () => {
   })
 })
 
-describe('reconcileDeliveryAuthority', () => {
+describe('delivery is reconciled; authorization is not derived from it', () => {
+  // The claim `completed_stories` makes is that a Story reached `main`. It does
+  // not say who performed each operation, and in this repository the usual
+  // answer is "not the agent": an agent is granted `modify` and at most a local
+  // `commit`, and a human takes the branch from there. DBCLI-027 read delivery
+  // as proof that the agent was permitted to commit and push, which fails that
+  // flow by name. ADR-0031 withdrew the inference; these tests hold the two
+  // questions apart.
   const AUTHORITY = (commit: string, push: string) =>
-    `# Story: DBCLI-900 T\n\n## Authority\n\n* plan: yes\n* modify: yes\n* commit: ${commit}\n* push: ${push}\n* deploy: no\n\n## Scope\n`
-  const directories = new Map([['DBCLI-900', 'DBCLI-900-t']])
-  const lifecycle = { completedStories: ['DBCLI-900'] }
-  const sourced = (source: string) => [{ directory: 'DBCLI-900-t', source }]
+    `# Story: DBCLI-001 T\n\n## Authority\n\n* plan: yes\n* modify: yes\n* commit: ${commit}\n* push: ${push}\n* deploy: no\n\n## Scope\n`
+  const NO_SECTION = '# Story: DBCLI-001 T\n\n## Scope\n'
+  const delivered = { completedStories: ['DBCLI-001'] }
+  const directory = 'DBCLI-001-contract-absence-and-invalid-drift'
+  const sourced = (source: string) => [{ directory, source }]
 
-  test('reads a declared permission', () => {
-    expect(readAuthority(AUTHORITY('yes', 'no'), 'commit')).toBe('yes')
-    expect(readAuthority(AUTHORITY('yes', 'no'), 'push')).toBe('no')
+  test('a delivered Story whose agent committed locally and left the push to a human', async () => {
+    expect(await reconcile(inputs({ lifecycle: delivered }))).toEqual([])
+    expect(collectStoryIds(sourced(AUTHORITY('yes', 'no'))).get('DBCLI-001')).toBe(directory)
   })
 
-  test('a Story with no Authority section declares nothing', () => {
-    // The section is optional. A Story making no claim has nothing to
-    // contradict, and reporting one would demand a section upstream does not.
-    expect(readAuthority('# Story: DBCLI-900 T\n\n## Scope\n', 'push')).toBeUndefined()
+  test('a delivered Story whose agent did neither, because a human did both', async () => {
+    expect(await reconcile(inputs({ lifecycle: delivered }))).toEqual([])
+    expect(collectStoryIds(sourced(AUTHORITY('no', 'no'))).get('DBCLI-001')).toBe(directory)
   })
 
-  test('a permission absent from a declared section is not a "no"', () => {
-    const partial = '# Story: DBCLI-900 T\n\n## Authority\n\n* plan: yes\n\n## Scope\n'
-
-    expect(readAuthority(partial, 'push')).toBeUndefined()
-    expect(reconcileDeliveryAuthority(lifecycle, directories, sourced(partial))).toEqual([])
-  })
-
-  test('a delivered Story may not declare commit: no or push: no', () => {
-    const failures = reconcileDeliveryAuthority(
-      lifecycle,
-      directories,
-      sourced(AUTHORITY('no', 'no'))
+  test('the Authority text cannot change a delivery verdict', async () => {
+    // Three spellings of the same claim: both permissions granted, both
+    // withheld, and no section at all. A gate that reads none of them cannot
+    // reward the omission — which is the second half of the defect, since
+    // upstream defaults an undeclared operation to `no` and the removed rule
+    // failed the explicit `no` while passing the blank.
+    const verdicts = await Promise.all(
+      [AUTHORITY('yes', 'yes'), AUTHORITY('no', 'no'), NO_SECTION].map(async (source) => ({
+        failures: await reconcile(inputs({ lifecycle: delivered })),
+        index: [...collectStoryIds(sourced(source))],
+      }))
     )
 
-    expect(failures).toHaveLength(2)
-    expect(failures[0]!.reason).toContain('`commit: no`')
-    expect(failures[1]!.reason).toContain('`push: no`')
+    expect(verdicts[1]).toEqual(verdicts[0]!)
+    expect(verdicts[2]).toEqual(verdicts[0]!)
+    expect(verdicts[0]!.failures).toEqual([])
   })
 
-  test('a delivered Story declaring both is clean', () => {
-    expect(
-      reconcileDeliveryAuthority(lifecycle, directories, sourced(AUTHORITY('yes', 'yes')))
-    ).toEqual([])
+  test('an undelivered Story fails however generously it declares Authority', async () => {
+    // The other direction of the same separation: what the gate judges is the
+    // repository's backing for the claim, and a Story granting itself every
+    // permission does not acquire one.
+    const failures = await reconcile(inputs({ lifecycle: delivered, trailers: new Set<string>() }))
+
+    expect(failures.map((failure) => failure.story)).toEqual(['DBCLI-001'])
+    expect(failures[0]!.reason).toMatch(/`Story:` trailer/)
+    expect(collectStoryIds(sourced(AUTHORITY('yes', 'yes'))).get('DBCLI-001')).toBe(directory)
   })
 
-  test('only the two permissions delivery implies are checked', () => {
-    // Authority is per-permission and nothing implies anything else. Delivering
-    // a Story says nothing about whether it was allowed to deploy, so a clean
-    // Story keeps its `deploy: no`.
-    expect(
-      reconcileDeliveryAuthority(lifecycle, directories, sourced(AUTHORITY('yes', 'yes')))
-    ).toEqual([])
-    expect(readAuthority(AUTHORITY('yes', 'yes'), 'deploy')).toBe('no')
+  test('the rules module exposes one delivery verdict and no permission reader', async () => {
+    // Structural, because the defect was structural: the second reconciliation
+    // lived beside the first and a test that only knew about `reconcile` would
+    // have stayed green through all of it. One verdict, and nothing anywhere in
+    // the surface that reads a permission.
+    const rules = await import('../../../scripts/lib/forgeflow-handoff')
+    const exported = Object.keys(rules)
+
+    expect(exported.filter((name) => name.startsWith('reconcile'))).toEqual(['reconcile'])
+    expect(exported.filter((name) => /authority/i.test(name))).toEqual([])
   })
 
-  test('a Story that is not recorded as completed is not checked', () => {
-    // The claim being reconciled is the handoff's, not the Story's. An
-    // in-flight Story has not been delivered and may truthfully say push: no.
-    expect(
-      reconcileDeliveryAuthority(
-        { completedStories: [] },
-        directories,
-        sourced(AUTHORITY('no', 'no'))
-      )
-    ).toEqual([])
+  test('the gate script imports no permission reader either', async () => {
+    // Authority's format, its defaults and which combinations are legal belong
+    // to upstream's checker, run by `bun run forgeflow:contract`. A second
+    // parser here would be a second answer to one question.
+    const source = await Bun.file(
+      new URL('../../../scripts/check-forgeflow-handoff.ts', import.meta.url)
+    ).text()
+    const imported = source.match(/import \{([^}]*)\} from '\.\/lib\/forgeflow-handoff'/)
+
+    expect(imported).not.toBeNull()
+    expect(imported![1]).not.toMatch(/authority/i)
   })
 })


### PR DESCRIPTION
## 為什麼

DBCLI-027 讓 handoff gate 擋下 `completed_stories` 裡宣告 `commit: no` 或 `push: no` 的 Story，推理是進 `main` 只可能以 commit、經由被 push 的分支。那句話對操作是對的，對**誰做的**是錯的。

`completed_stories` 記的是 Story 被交付了，沒有記哪一雙手做了哪一步。而這個 repo 的正常流程正是反例：agent 拿到 `modify`、最多一個本機 `commit`，接手 commit、push、開 PR、合併的是人。交付完整，agent 的 `push: no` 從頭到尾都是真的，gate 卻指名拒絕它。

ADR-0030 自己寫的失效條件是「交付不再蘊含被 push 的分支」。交付今天仍然蘊含一條被 push 的分支——它從來沒有蘊含**是 agent** push 的。那一步才是規則真正在做的推論。

第二個症狀指向同一件事：同一個宣告被判兩次不同結果。上游 0.7.0 的 `protocol/execution.md`（採用標記釘住的 `cb4bc976`）把 `plan`、`modify` 以外每一項的預設值定為 `no`，並明說「做得到某件事從來不是被授權去做它」。所以省略 `push:` 跟寫 `push: no` 是同一句話；那條規則卻擋顯式的 `no`、放行省略的那個——刪掉一行就穿過去了。

## 改了什麼

- 移除 `reconcileDeliveryAuthority`、`readAuthority`、`DELIVERY_IMPLIES` 與 gate 裡的呼叫。
- 保留全部既有防線：Story 目錄存在性、`Story:` trailer、`DELIVERED_BEFORE_TRAILERS` 棘輪、淺複製拒絕、lifecycle 結構檢查，每一條都留著會在它消失時變紅的測試。
- ADR-0031 取代 ADR-0030（量測與脈絡保留，ADR-0030 標成 `superseded` 並加導讀）。上游明說 superseded 記錄不能當依賴，DBCLI-027 的 `Decision:` 因此改指 ADR-0031，並在該 Story 註明它當初做的決定是 ADR-0030。
- README 治理段與 `specs/handoff.md` 對應段落改寫；新增 Story DBCLI-028。
- Authority 的格式、預設值與組合合法性繼續由 `bun run forgeflow:contract` 對採用 revision 檢查；沒有另建授權 parser、身分系統或審批資料庫。

## 那八個歷史宣告

ADR-0030 把 DBCLI-019～026 的 `push: no` 改成 `yes`、019/020/021 的 `commit: no` 也改了。查不到任何逐項記錄那八個 Story 授予實作 agent 什麼的核可紀錄。**不改回 `no`**——那會是同一個錯誤的鏡像，從沒有證據推論權限被收回。改為在 ADR-0031 與 handoff 如實記錄：這八個值建立在已撤回的推論上，且無核可紀錄佐證。能更正歷史宣告的只有核可紀錄，merge 或 push 都不是。

## 測試

`tests/unit/scripts/forgeflow-handoff.test.ts`，49 pass / 0 fail，先紅後綠：

- 人接手 push（`commit: yes, push: no`）與人同時接手 commit 與 push（`no, no`）的兩種交付都不再被擋。
- Authority 三種寫法（都 yes、都 no、整段省略）得到同一個判決——省略換不到上游未授予的權限。
- 沒有 trailer 的 Story 就算自宣 `commit: yes, push: yes` 一樣紅：交付可否確認與操作是否獲准是兩個判決。
- 兩支結構測試釘住這個模組只留一個 `reconcile*`、surface 上沒有讀權限的東西，gate script 也沒 import 任何一個。

## 驗證

| 檢查 | 結果 |
| --- | --- |
| `make verify` | PASS at `b262bcf2ec8ca2e8ffba90927fa738e9367d59c1`（sha256:`2e0ea448…`），6,849 tests / 0 fail |
| `bun run forgeflow:check` | 通過，34 completed Stories |
| `bun run forgeflow:contract` | 通過（`FORGEFLOW_ROOT` = `cb4bc976` 乾淨 checkout），36 Stories、0 admitted findings |

`PREDATING_FINDINGS` 仍為空集合，`ADMITTED_FINDINGS` / `ADMITTED_STORIES` 仍為 0。`forgeflow:contract` 不在 `make verify` 內，另外執行。`src/` 與產品行為零變更，不需新 tag。

## Authority 註記

DBCLI-028 以 `commit: yes, push: no` 起草，並在該授權下完成實作與驗證；人在此時授予 `push` 以便開這個 PR，所以宣告改成 `push: yes`。權限因為有權授予的人授予了它而改變，不是因為分支後來被 push 了——這正是 ADR-0031 指名的更正機制。

尚未通過 Human Review，也未宣告 ForgePilot DONE。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn