### PR TITLE
feat: [ forgeflow ] 有交付紀錄卻沒登進清單，現在會紅

### DIFF
--- a/docs/adr/ADR-0032-a-delivery-records-itself.md
+++ b/docs/adr/ADR-0032-a-delivery-records-itself.md
@@ -1,0 +1,75 @@
+# A delivery records itself
+
+* Status: accepted
+* Date: 2026-09-09
+
+`specs/handoff.md`'s `completed_stories` was reconciled in one direction: every
+recorded Story must have a `Story:` commit trailer or a
+`DELIVERED_BEFORE_TRAILERS` entry. That direction cannot catch an omission, so
+the list could only rot toward being incomplete — and did, twice.
+
+* DBCLI-027 found DBCLI-022 to DBCLI-026 delivered, merged and approved, with
+  none of them recorded.
+* Reconciling DBCLI-028's own delivery found that DBCLI-027 had left **itself**
+  out of the same list it had just repaired.
+
+Both were found because a human happened to look. Neither entry was ever false;
+nothing had asked for them, which is this repository's recurring failure shape
+seen from the side that has no gate.
+
+## Decision
+
+**The reconciliation runs in both directions.** A Story whose `Story:` trailer
+is reachable from `HEAD`, and which has a `specs/stories` directory, must appear
+in `completed_stories`. Absent, it fails `bun run forgeflow:check` by name.
+
+**One history for both directions.** The forward rule read trailers from
+`git log --all`; the reverse rule cannot, because an unmerged branch's trailers
+would demand handoff entries for Stories this tree has not delivered. Both now
+read `git log HEAD` — the checkout in hand, which is the same set locally and in
+CI, where `pull_request` checks out the merge commit. Two scopes for one
+comparison would rebuild the split verdict ADR-0031 removed.
+
+**The entry is written in the change that delivers the Story**, not after the
+merge. That is the whole point of the timing: the trailer and the entry arrive
+in the same commit or the same pull request, so every commit carrying a trailer
+is green, and the recording cannot be the step that gets forgotten — it is the
+step that makes the gate pass.
+
+The cost is that the handoff states a delivery slightly before the merge makes
+it true. That is bounded and self-correcting: an unmerged branch's entry dies
+with the branch, and the forward rule still demands the trailer that the entry
+claims. Recording after the merge is the alternative, and it is what produced
+both omissions; it also leaves `main` red between the merge and the follow-up.
+
+**A trailer naming a Story with no `specs/stories` directory is not reported.**
+`DBCLI-PLAT-008`, `DBCLI-PLAT-009` and `DBCLI-PLAT-010` were accepted against
+issues rather than Stories. Demanding a handoff entry for a Story this
+repository does not contain would be inventing one rather than reconciling one.
+
+## Consequences
+
+Delivering a Story now has one more mechanical step, and it is enforced rather
+than remembered. Work that predates this record is unaffected: the reverse rule
+is green on `main` at `2594c2c6` with no edit to `completed_stories`, which is
+the check that it describes what this repository has actually done rather than
+what it wishes it had.
+
+There is one uncomfortable window, and it is worth naming rather than
+discovering: between writing the entry and making the commit that carries the
+trailer, the working tree fails the forward rule — the handoff records a Story
+no commit has claimed yet. It closes when the commit lands. The alternative
+order fails the other way, so one of the two is red for as long as it takes to
+commit, and this is the one where the fix is the next thing you were going to
+do anyway.
+
+The shallow-clone refusal becomes load-bearing for a second reason. Without
+trailers, the forward rule failed every recorded Story; the reverse rule would
+now report every Story in the repository instead. Both are the same wrong answer
+from missing evidence, and the refusal still comes first.
+
+**Falsified if:** Stories stop being delivered as commits carrying `Story:`
+trailers — a different delivery record, or a repository where the trailer is no
+longer the evidence — then the reverse rule in
+`scripts/lib/forgeflow-handoff.ts` is demanding entries against a signal that no
+longer means delivery, and must be re-pointed at whatever does.

--- a/scripts/check-forgeflow-handoff.ts
+++ b/scripts/check-forgeflow-handoff.ts
@@ -52,9 +52,17 @@ const DELIVERED_BEFORE_TRAILERS: ReadonlyMap<string, Exemption> = new Map([
   ],
 ])
 
-/** Story IDs that have a `Story: <ID>` trailer somewhere in history. */
+/**
+ * Story IDs carrying a `Story: <ID>` trailer reachable from `HEAD`.
+ *
+ * `HEAD`, not `--all`: the reconciliation runs in both directions now, and the
+ * reverse one would read an unmerged branch's trailers as deliveries this tree
+ * has to have recorded. One scope for both directions, and it is the history of
+ * the checkout in hand — the same set locally and in CI, where `pull_request`
+ * checks out the merge commit.
+ */
 async function storiesWithTrailers(): Promise<Set<string>> {
-  const log = await $`git log --all --format=%b`.text()
+  const log = await $`git log HEAD --format=%b`.text()
   return new Set([...log.matchAll(/^Story:\s*(\S+)\s*$/gm)].map(([, id]) => id as string))
 }
 

--- a/scripts/lib/forgeflow-handoff.ts
+++ b/scripts/lib/forgeflow-handoff.ts
@@ -483,12 +483,34 @@ export function shallowCloneRefusal(isShallowOutput: string): string | null {
  */
 
 /**
- * Compare every delivery claim against the repository.
+ * Compare every delivery claim against the repository, and back.
  *
  * `DELIVERED_BEFORE_TRAILERS` is a ratchet, not an amnesty: it may shrink and
  * never grow. A new Story must carry a trailer, an entry whose commit stopped
  * existing fails, and so does an entry for a Story that has since acquired a
  * trailer — a stale exemption is drift of exactly the kind this gate catches.
+ *
+ * ## Both directions, because one of them cannot catch an omission
+ *
+ * For ten revisions this asked only whether every recorded Story had evidence.
+ * A list checked in that direction alone can only rot toward being incomplete,
+ * and it did, twice: DBCLI-027 found DBCLI-022 to DBCLI-026 delivered, merged
+ * and approved with none of them recorded, and reconciling DBCLI-028's delivery
+ * then found DBCLI-027 had left itself out of the same list it had just
+ * repaired. Both were found by a human noticing. The entries were never false —
+ * nothing had asked for them. ADR-0032.
+ *
+ * `trailers` is one set for both directions: the Story IDs whose trailers are
+ * reachable from `HEAD`. It used to be read from `git log --all`, which the
+ * reverse rule cannot use — an unmerged branch would demand handoff entries for
+ * Stories this tree has not delivered — and two scopes for one comparison is
+ * the split verdict ADR-0031 removed, one level down. So both read the history
+ * of the checkout in hand, which is the same history locally and in CI.
+ *
+ * A trailer naming a Story with no `specs/stories` directory is not reported.
+ * `DBCLI-PLAT-008` and its neighbours were accepted against issues; demanding a
+ * handoff entry for a Story this repository does not contain would be inventing
+ * one rather than reconciling one.
  */
 export async function reconcile({
   lifecycle,
@@ -546,6 +568,18 @@ export async function reconcile({
         reason: 'has a DELIVERED_BEFORE_TRAILERS entry but is not recorded as completed',
       })
     }
+  }
+
+  const recorded = new Set(completedStories)
+
+  for (const story of trailers) {
+    if (recorded.has(story) || !directories.has(story)) continue
+    failures.push({
+      story,
+      reason:
+        'carries a `Story:` trailer in this history but is not recorded in completed_stories — ' +
+        'add it in the change that delivers it',
+    })
   }
 
   return failures

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1047,6 +1047,7 @@ workflow:
     - DBCLI-026
     - DBCLI-027
     - DBCLI-028
+    - DBCLI-029
   status: done
 
 baseline:

--- a/specs/stories/DBCLI-029-record-what-history-claims/acceptance.md
+++ b/specs/stories/DBCLI-029-record-what-history-claims/acceptance.md
@@ -1,0 +1,63 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [ ] AC-001: A Story whose `Story:` trailer is reachable from `HEAD` and which
+      has a `specs/stories` directory, but which `completed_stories` does not
+      record, fails by name with a message saying to record it.
+* [ ] AC-002: `bun run forgeflow:check` passes on this branch with no edit to
+      `completed_stories` beyond DBCLI-029's own entry.
+
+## Business Rules
+
+* [ ] AC-003: A trailer naming a Story with no `specs/stories` directory is not
+      reported, so the issue-accepted `DBCLI-PLAT-008` does not demand an entry.
+* [ ] AC-004: Both directions read one set of trailers, so a Story recorded and
+      delivered, and a Story delivered and unrecorded, are decided against the
+      same history.
+* [ ] AC-005: A Story with a directory and no trailer anywhere is not reported
+      by the reverse rule — an authored, undelivered Story is not a delivery.
+
+## Failure Cases
+
+* [ ] AC-006: The forward rules still fail: a recorded Story with no trailer and
+      no exemption, a stale exemption, an exemption naming an absent commit, and
+      a recorded Story with no directory.
+* [ ] AC-007: A shallow clone is refused before either direction runs.
+
+## Regression Requirements
+
+* [ ] AC-008: `src/` is unchanged.
+* [ ] AC-009: `PREDATING_FINDINGS` is still empty and both admitted counts are
+      still zero.
+* [ ] AC-010: The complete repository verification gate passes.
+
+## Acceptance Evidence
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `a trailer for a Story absent from completed_stories` | `one failure naming the Story` |
+| `AC-002` | command | `bun run forgeflow:check` | `this branch` | `reconciliation passed` |
+| `AC-003` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `a trailer whose Story has no directory` | `no failure` |
+| `AC-004` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `one trailer set, both directions` | `both verdicts from the same input` |
+| `AC-005` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `a Story directory with no trailer` | `no reverse failure` |
+| `AC-006` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `the existing reconcile fixtures` | `each failure names its Story` |
+| `AC-007` | test | `tests/unit/scripts/forgeflow-handoff.test.ts` | `git rev-parse --is-shallow-repository answering true` | `refusal naming --unshallow` |
+| `AC-008` | command | `git diff --stat 2594c2c6 -- src` | `repository checkout` | `empty output` |
+| `AC-009` | command | `bun run forgeflow:contract` | `FORGEFLOW_ROOT at cb4bc976` | `0 admitted pre-existing finding(s)` |
+| `AC-010` | command | `make verify` | `repository checkout` | `exit 0` |
+
+## Verification Notes
+
+```sh
+bun test tests/unit/scripts/forgeflow-handoff.test.ts
+bun run forgeflow:check
+FORGEFLOW_ROOT=<clean ForgeFlowV2 checkout> bun run forgeflow:contract
+make verify
+```
+
+What human review should weigh is the timing in ADR-0032: the entry is written
+in the change that delivers the Story, so the gate is green at every commit that
+carries the trailer. The alternative — recording after the merge — is what left
+two Stories unrecorded, and it makes `main` red between the merge and the
+follow-up.

--- a/specs/stories/DBCLI-029-record-what-history-claims/story.md
+++ b/specs/stories/DBCLI-029-record-what-history-claims/story.md
@@ -1,0 +1,128 @@
+# Story: DBCLI-029 Record What History Already Claims
+
+## Goal
+
+A Story whose delivery this checkout's own history claims is recorded in
+`specs/handoff.md`, because the gate now asks the question in both directions
+instead of only the one that cannot catch an omission.
+
+## Context
+
+The handoff gate reconciles `completed_stories` against `Story:` commit
+trailers, and it has only ever asked one of the two questions that comparison
+makes available: *does every recorded Story have evidence?* The other one —
+*does every delivered Story get recorded?* — has never been asked, and a list
+that is only checked in that direction can only rot toward being incomplete.
+
+It has rotted twice, and both times a human happened to look. DBCLI-027 found
+DBCLI-022 to DBCLI-026 delivered, merged and approved with none of them
+recorded. Reconciling DBCLI-028's own delivery then found that DBCLI-027 had
+left *itself* out of the same list it had just repaired. Two occurrences, two
+accidental discoveries, zero gate involvement.
+
+This is the lesson the surrounding gates already encode, applied to the half of
+the comparison that was left out: a claim nothing compares to anything survives
+by inertia. The missing entries were never false — they were unasked.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: no
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: yes
+* deploy: no
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0032`
+* Boundary: `HandoffContract`
+* Contract: `the handoff and this checkout's delivery history state the same set of Stories`
+* Owner: `HandoffContract = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `governance-gate-change`
+
+The rule fails work that was previously green, and it fails it on `main` if the
+recording is left for later. That timing is the decision, and ADR-0032 records
+why it is drawn where it is.
+
+## Scope
+
+### In Scope
+
+* A reverse reconciliation in `scripts/lib/forgeflow-handoff.ts`: a Story whose
+  `Story:` trailer is reachable from `HEAD` and which has a `specs/stories`
+  directory, but which `completed_stories` does not record, is a failure naming
+  the Story and the fix.
+* One history scope for both directions. The forward rule reads trailers from
+  `git log --all` and the reverse rule cannot — an unmerged branch would demand
+  entries for Stories this tree has not delivered — so both move to `HEAD`.
+* ADR-0032, and the `specs/stories/README.md` or `AGENTS.md` sentence that tells
+  the next author when to write the entry.
+
+### Out of Scope
+
+* Stories delivered without a `specs/stories` directory. `DBCLI-PLAT-008`,
+  `DBCLI-PLAT-009` and `DBCLI-PLAT-010` were accepted against issues, and
+  demanding a handoff entry for a Story this repository does not contain would
+  be inventing a Story rather than reconciling one.
+* `DELIVERED_BEFORE_TRAILERS`, which stays a shrink-only ratchet.
+* Any change to `src/`, and any release.
+
+## Inputs
+
+* `scripts/lib/forgeflow-handoff.ts`, `scripts/check-forgeflow-handoff.ts`,
+  `tests/unit/scripts/forgeflow-handoff.test.ts`.
+* `specs/handoff.md` — `completed_stories`.
+
+## Outputs
+
+* A gate that fails an unrecorded delivery by name.
+* A decision record stating when the entry is written and why not later.
+
+## Rules
+
+* R1: A Story with a `Story:` trailer reachable from `HEAD` and a
+  `specs/stories` directory, absent from `completed_stories`, fails
+  `bun run forgeflow:check`.
+* R2: A trailer naming a Story with no `specs/stories` directory is not
+  reported. The gate reconciles the handoff against this repository's Stories,
+  and a Story it does not contain is not one of them.
+* R3: Both directions read one history — commits reachable from `HEAD`. A rule
+  whose verdict differs between a local branch and the same branch in CI is the
+  defect DBCLI-028 removed, one level down.
+* R4: The existing forward rules are unchanged in substance: a recorded Story
+  still needs a trailer or a `DELIVERED_BEFORE_TRAILERS` entry, a stale
+  exemption still fails, and an exemption naming an absent commit still fails.
+* R5: The shallow-clone refusal still guards both directions; with no trailers
+  readable, the reverse rule would report every Story in the repository.
+* R6: No change to `src/`.
+
+## Expected Errors
+
+* A Story delivered on this branch and not recorded fails, naming the Story and
+  saying to add it to `completed_stories`.
+* A shallow clone is refused before either direction runs.
+
+## Dependencies
+
+* ADR-0032 — when the entry is written.
+* ADR-0031 — the gate reconciles delivery and derives nothing else from it.
+
+## Constraints
+
+* `scripts/lib/forgeflow-handoff.ts` imports nothing and spawns nothing.
+* The reverse rule must be green on `main` at `2594c2c6` without editing
+  `completed_stories`, or it is asserting something this repository has not
+  actually done.

--- a/specs/stories/README.md
+++ b/specs/stories/README.md
@@ -11,10 +11,17 @@ to be at — a marker naming an untagged revision makes "which release is this" 
 question with two answers.
 
 `make verify` runs `bun run forgeflow:check`, which reconciles the handoff's
-`completed_stories` against the repository. Upstream's `story-check` and
+`completed_stories` against the repository, in both directions: every recorded
+Story needs a `Story:` commit trailer, and every Story whose trailer this
+checkout's history carries needs an entry. Upstream's `story-check` and
 `handoff-check` are static structure checks that live in a ForgeFlow checkout
 and are documented as never deciding whether a declaration is truthful; this
 repository's check covers that separate layer and duplicates neither.
+
+**Add the `completed_stories` entry in the change that delivers the Story**, in
+the same commit as the trailer or the same pull request. Recording it after the
+merge is what left DBCLI-022 to DBCLI-027 unrecorded, and it turns `main` red in
+between. ADR-0032.
 
 Create a Story by copying the template:
 

--- a/tests/unit/scripts/forgeflow-handoff.test.ts
+++ b/tests/unit/scripts/forgeflow-handoff.test.ts
@@ -71,12 +71,22 @@ const NO_EXEMPTIONS: ReadonlyMap<string, Exemption> = new Map()
 const present = async () => true
 const absent = async () => false
 
-/** The default reconciliation: everything backed, nothing exempt. */
+/**
+ * The default reconciliation: everything backed and everything delivered
+ * recorded, nothing exempt.
+ *
+ * The trailer set matches `completed_stories` exactly. It used to carry a third
+ * ID the handoff did not record, which was harmless while the gate only asked
+ * whether recorded Stories had evidence and became a failure in every test the
+ * moment it also asked whether delivered Stories were recorded. A default
+ * fixture has to be clean in both directions, or every test that uses it is
+ * asserting against a handoff that is already broken.
+ */
 function inputs(overrides: Partial<Parameters<typeof reconcile>[0]> = {}) {
   return {
     lifecycle: readLifecycle(BODY).lifecycle,
     directories: DIRECTORIES,
-    trailers: new Set(['DBCLI-001', 'DBCLI-PLAT-001', 'DBCLI-PLAT-013']),
+    trailers: new Set(['DBCLI-001', 'DBCLI-PLAT-001']),
     exemptions: NO_EXEMPTIONS,
     commitExists: present,
     ...overrides,
@@ -314,6 +324,7 @@ describe('reconcile', () => {
     const failures = await reconcile(
       inputs({
         lifecycle: { completedStories: ['DBCLI-001'] },
+        trailers: new Set(['DBCLI-001']),
       })
     )
     expect(failures).toEqual([])
@@ -323,6 +334,7 @@ describe('reconcile', () => {
     const failures = await reconcile(
       inputs({
         lifecycle: { completedStories: ['DBCLI-PLAT-001'] },
+        trailers: new Set(['DBCLI-PLAT-001']),
       })
     )
     expect(failures).toEqual([])
@@ -334,7 +346,7 @@ describe('reconcile', () => {
 
   test('a completed Story with no directory fails closed', async () => {
     const failures = await reconcile(
-      inputs({ lifecycle: { completedStories: ['DBCLI-PLAT-004'] } })
+      inputs({ lifecycle: { completedStories: ['DBCLI-PLAT-004'] }, trailers: new Set<string>() })
     )
     expect(failures).toHaveLength(1)
     expect(failures[0]!.story).toBe('DBCLI-PLAT-004')
@@ -388,6 +400,87 @@ describe('reconcile', () => {
       })
     )
     expect(failures.map((failure) => failure.story)).toContain('DBCLI-777')
+  })
+})
+
+describe('a delivery this history claims is recorded', () => {
+  // The forward direction — every recorded Story has evidence — has never been
+  // able to catch an omission, and the list rotted twice: DBCLI-027 found
+  // DBCLI-022 to DBCLI-026 delivered and unrecorded, and reconciling DBCLI-028
+  // found DBCLI-027 had left itself out of the same list. Both were noticed by
+  // a human. ADR-0032.
+  test('a Story delivered in this history and not recorded fails by name', async () => {
+    const failures = await reconcile(
+      inputs({
+        lifecycle: { completedStories: ['DBCLI-001'] },
+        trailers: new Set(['DBCLI-001', 'DBCLI-PLAT-013']),
+      })
+    )
+
+    expect(failures.map((failure) => failure.story)).toEqual(['DBCLI-PLAT-013'])
+    expect(failures[0]!.reason).toMatch(/completed_stories/)
+  })
+
+  test('a trailer for a Story this repository does not contain is not reported', async () => {
+    // DBCLI-PLAT-008 was accepted against an issue and has no Story directory.
+    // Demanding a handoff entry for it would invent a Story rather than
+    // reconcile one.
+    const failures = await reconcile(
+      inputs({ trailers: new Set([...inputs().trailers, 'DBCLI-PLAT-008']) })
+    )
+
+    expect(failures).toEqual([])
+  })
+
+  test('an authored Story nobody has delivered is not a delivery', async () => {
+    // A directory with no trailer is work in progress. Only the trailer says
+    // the work was delivered, which is the same evidence the forward rule reads,
+    // so `DBCLI-PLAT-013` — indexed, never delivered — is reported by neither.
+    const failures = await reconcile(
+      inputs({
+        lifecycle: { completedStories: ['DBCLI-001'] },
+        trailers: new Set(['DBCLI-001']),
+      })
+    )
+
+    expect(failures).toEqual([])
+  })
+
+  test('both directions decide against one set of trailers', async () => {
+    // One history, read once. A rule whose verdict differs between a local
+    // branch and the same branch in CI is the split DBCLI-028 removed, and two
+    // scopes here would rebuild it: `--all` cannot drive the reverse rule,
+    // because an unmerged branch would demand entries for Stories this tree has
+    // not delivered.
+    const failures = await reconcile(
+      inputs({
+        lifecycle: { completedStories: ['DBCLI-001', 'DBCLI-PLAT-001'] },
+        trailers: new Set(['DBCLI-PLAT-001', 'DBCLI-PLAT-013']),
+      })
+    )
+
+    expect(failures.map((failure) => failure.story).sort()).toEqual(['DBCLI-001', 'DBCLI-PLAT-013'])
+    expect(failures.find((failure) => failure.story === 'DBCLI-001')!.reason).toMatch(
+      /`Story:` trailer/
+    )
+    expect(failures.find((failure) => failure.story === 'DBCLI-PLAT-013')!.reason).toMatch(
+      /completed_stories/
+    )
+  })
+
+  test('a Story recorded under an exemption is not demanded twice', async () => {
+    // The exemption backs a Story delivered before trailers existed. It has no
+    // trailer, so the reverse rule has nothing to say about it, and saying
+    // something would contradict the forward rule that just accepted it.
+    const failures = await reconcile(
+      inputs({
+        lifecycle: { completedStories: ['DBCLI-001'] },
+        trailers: new Set<string>(),
+        exemptions: new Map([['DBCLI-001', { commit: 'abc123', evidence: 'two named tests' }]]),
+      })
+    )
+
+    expect(failures).toEqual([])
   })
 })
 
@@ -455,16 +548,17 @@ describe('delivery is reconciled; authorization is not derived from it', () => {
     `# Story: DBCLI-001 T\n\n## Authority\n\n* plan: yes\n* modify: yes\n* commit: ${commit}\n* push: ${push}\n* deploy: no\n\n## Scope\n`
   const NO_SECTION = '# Story: DBCLI-001 T\n\n## Scope\n'
   const delivered = { completedStories: ['DBCLI-001'] }
+  const trailers = new Set(['DBCLI-001'])
   const directory = 'DBCLI-001-contract-absence-and-invalid-drift'
   const sourced = (source: string) => [{ directory, source }]
 
   test('a delivered Story whose agent committed locally and left the push to a human', async () => {
-    expect(await reconcile(inputs({ lifecycle: delivered }))).toEqual([])
+    expect(await reconcile(inputs({ lifecycle: delivered, trailers }))).toEqual([])
     expect(collectStoryIds(sourced(AUTHORITY('yes', 'no'))).get('DBCLI-001')).toBe(directory)
   })
 
   test('a delivered Story whose agent did neither, because a human did both', async () => {
-    expect(await reconcile(inputs({ lifecycle: delivered }))).toEqual([])
+    expect(await reconcile(inputs({ lifecycle: delivered, trailers }))).toEqual([])
     expect(collectStoryIds(sourced(AUTHORITY('no', 'no'))).get('DBCLI-001')).toBe(directory)
   })
 
@@ -476,7 +570,7 @@ describe('delivery is reconciled; authorization is not derived from it', () => {
     // failed the explicit `no` while passing the blank.
     const verdicts = await Promise.all(
       [AUTHORITY('yes', 'yes'), AUTHORITY('no', 'no'), NO_SECTION].map(async (source) => ({
-        failures: await reconcile(inputs({ lifecycle: delivered })),
+        failures: await reconcile(inputs({ lifecycle: delivered, trailers })),
         index: [...collectStoryIds(sourced(source))],
       }))
     )


### PR DESCRIPTION
## 為什麼

handoff gate 十個 revision 以來只問一個方向：**清單裡的每一筆有沒有證據**。那個方向抓不到「漏登」，所以這份清單只會往不完整的方向壞——而且已經壞了兩次：

- DBCLI-027 發現 DBCLI-022～026 已交付、已合併、已核可，卻一筆都沒登記。
- 對帳 DBCLI-028 的交付時又發現 DBCLI-027 把**自己**漏在它剛修好的那份清單外面。

兩次都是人偶然看到的。那些條目從來不是假的，是沒有東西要求過它們——這個 repo 反覆學到的同一課，從沒有 gate 的那一側看過去。

## 改了什麼

- **反向規則**：`Story:` trailer 在這個 checkout 的歷史裡、且有 `specs/stories` 目錄的 Story，必須出現在 `completed_stories`，否則指名報錯並說怎麼修。
- **兩個方向讀同一份歷史**。forward 原本讀 `git log --all`，reverse 不能用它——未合併的分支會要求這棵樹替它沒交付的 Story 登記。兩者改讀 `git log HEAD`：手上這個 checkout 的歷史，本機與 CI（`pull_request` 檢出 merge commit）是同一個集合。一個比較有兩種範圍，就是 ADR-0031 剛拆掉的分裂判決低一層。
- **沒有 Story 目錄的 trailer 不報**：`DBCLI-PLAT-008`／`009`／`010` 當初以 issue 驗收，要求替這個 repo 沒有的 Story 登記等於憑空造一個 Story。
- 測試 fixture 校正：預設 fixture 原本帶著一個 handoff 沒記錄的 trailer，只問單一方向時無害，一問另一個方向就讓每支用到它的測試變紅。預設 fixture 必須兩個方向都乾淨。

## 決定：登記寫在交付那個變更裡（ADR-0032）

不是合併之後。trailer 與條目同時到達，帶 trailer 的每個 commit 都是綠的，登記不再是會被忘記的那一步——它是讓 gate 通過的那一步。

代價寫在 ADR 裡，兩個都誠實記著：handoff 會在合併前一步就宣稱交付（未合併的分支條目跟著分支一起死，forward 規則仍然要求它宣稱的 trailer）；還有一個紅燈窗口——寫了條目、還沒 commit 出 trailer 的那段時間 forward 規則會紅，commit 落地就關掉。另一個順序則是反方向紅，而這個順序的修法正好是你本來就要做的下一件事。

反過來說，合併後才登記正是產生上面兩次漏登的做法，而且它會讓 `main` 在合併與補登之間紅著。

## 驗證

| 檢查 | 結果 |
| --- | --- |
| `make verify` | PASS at `4a7c2e2c3cca8cc0613a6aa87830f27219615a7f`（sha256:`dc4a9102…`） |
| `bun test tests/unit/scripts/forgeflow-handoff.test.ts` | 54 pass / 0 fail |
| `bun run forgeflow:check` | 通過，37 completed Stories |
| `bun run forgeflow:contract` | 通過（`FORGEFLOW_ROOT` = `cb4bc976`），37 Stories、0 admitted findings |

反向規則在 `main`（`2594c2c6`）上**不需要動 `completed_stories` 就是綠的**——這是它描述的是這個 repo 真的做過的事，而不是它希望自己做過的事。`PREDATING_FINDINGS` 仍為空集合，`src/` 零變更，不需新 tag。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn