### PR TITLE
feat: [ verification ] FAIL 說出它停在哪一步

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,18 @@
 # resolved from PATH. `--frozen-lockfile` fails rather than resolving a set that
 # `bun.lock` does not pin.
 #
-# The steps run inside one subshell so that a FAIL is recorded too. `make` stops
-# at the first failing step, so an attestation written as a final line would only
-# ever describe a passing run — the case nobody needs evidence for. The subshell
-# captures the status, the attestation is written either way, and the recipe
-# re-exits with the captured status.
+# The steps are one recipe line so that a FAIL is recorded too. `make` stops at
+# the first failing *line*, so an attestation written as a final line would only
+# ever describe a passing run — the case nobody needs evidence for. Joined by
+# `&&`, the chain stops at the first failure, `status=$$?` captures it, the
+# attestation is written either way, and the recipe re-exits with that status.
+#
+# DBCLI-030 removed the parentheses that used to group the chain. They never
+# made it stop — `&&` does — but they made it a subshell, and `step` died with
+# it, so every FAIL attestation could say only that something failed. Each step
+# now names itself first, and the name that survives is the step the run stopped
+# at. Nothing crosses `begin` and `finish` through a file, which is DBCLI-017's
+# rule and the reason this is a variable rather than a marker file.
 #
 # The recipe stays POSIX. GNU Make ignores the environment's `SHELL` and runs
 # `/bin/sh`, which is dash on the Ubuntu runner this gate's `integration` job
@@ -20,13 +27,14 @@
 # It passed locally only because macOS `/bin/sh` is bash. Nothing here pipes
 # anything, so `pipefail` was a fatal no-op.
 #
-# One thing was lost and is not being quietly accepted: each step used to be its
-# own recipe line, so make echoed it and a CI log showed which of the 24 checks
-# was running and which one failed. Joined and prefixed with `@`, it does not.
-# Debugging now leans on the failing tool's own output, which is fine for
-# `bun run test` and thin for `docs:check`. Restoring it properly means echoing
-# each step with its own timing, which is DBCLI-019's subject; it is recorded
-# here so that Story inherits a known cost rather than rediscovering it.
+# One thing was lost and is only half recovered: each step used to be its own
+# recipe line, so make echoed it and a CI log showed which of the checks was
+# running and which one failed. Joined and prefixed with `@`, it does not.
+# DBCLI-030 recovered the half that matters after the fact — the attestation
+# names the failing step — and left the half that matters during the run, a live
+# log saying which step is executing and how long it took. That still means
+# echoing each step with its own timing, and it is recorded here rather than
+# rediscovered.
 #
 # Neither attestation phase can decide the verdict, which is the point of the
 # `|| run=''` and the `|| true`: `begin` failing leaves `run` empty so `finish`
@@ -37,31 +45,30 @@
 # DBCLI-017, and `scripts/write-attestation.ts` for what the record says.
 verify:
 	@run=$$(bun run scripts/write-attestation.ts begin) || run=''; \
-	( \
-		bun install --frozen-lockfile && \
-		bun run services:check && \
-		bun run audit && \
-		bun run format:check && \
-		bun run agent-core:check && \
-		bun run core-stdout:check && \
-		bun run typecheck && \
-		bun run typecheck:tests && \
-		bun run lint && \
-		SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test && \
-		bun run build && \
-		bun run build:determinism && \
-		bun run dev -- --help && \
-		bun run dev -- --version && \
-		./dist/cli.mjs --help && \
-		./dist/cli.mjs --version && \
-		bun run test:perf && \
-		bun run platform:check && \
-		bun run plugin:check && \
-		bun run manifest:check && \
-		bun run docs:check && \
-		bun run contract:check && \
-		bun run plan:check && \
-		bun run forgeflow:check \
-	); status=$$?; \
-	bun run scripts/write-attestation.ts finish $$status $$run || true; \
+	step='bun install --frozen-lockfile' && bun install --frozen-lockfile && \
+	step='bun run services:check' && bun run services:check && \
+	step='bun run audit' && bun run audit && \
+	step='bun run format:check' && bun run format:check && \
+	step='bun run agent-core:check' && bun run agent-core:check && \
+	step='bun run core-stdout:check' && bun run core-stdout:check && \
+	step='bun run typecheck' && bun run typecheck && \
+	step='bun run typecheck:tests' && bun run typecheck:tests && \
+	step='bun run lint' && bun run lint && \
+	step='SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test' && SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test && \
+	step='bun run build' && bun run build && \
+	step='bun run build:determinism' && bun run build:determinism && \
+	step='bun run dev -- --help' && bun run dev -- --help && \
+	step='bun run dev -- --version' && bun run dev -- --version && \
+	step='./dist/cli.mjs --help' && ./dist/cli.mjs --help && \
+	step='./dist/cli.mjs --version' && ./dist/cli.mjs --version && \
+	step='bun run test:perf' && bun run test:perf && \
+	step='bun run platform:check' && bun run platform:check && \
+	step='bun run plugin:check' && bun run plugin:check && \
+	step='bun run manifest:check' && bun run manifest:check && \
+	step='bun run docs:check' && bun run docs:check && \
+	step='bun run contract:check' && bun run contract:check && \
+	step='bun run plan:check' && bun run plan:check && \
+	step='bun run forgeflow:check' && bun run forgeflow:check; \
+	status=$$?; \
+	bun run scripts/write-attestation.ts finish $$status $$run "$$step" || true; \
 	exit $$status

--- a/docs/adr/ADR-0033-a-fail-names-the-step-it-stopped-at.md
+++ b/docs/adr/ADR-0033-a-fail-names-the-step-it-stopped-at.md
@@ -1,0 +1,65 @@
+# A FAIL names the step it stopped at
+
+* Status: accepted
+* Date: 2026-09-10
+
+The Verification Attestation recorded `result`, `exit_code` and the revision. It
+did not record what went wrong, so every FAIL looked like every other FAIL.
+
+Two evidence records at the same revision made that concrete. ForgePilot wrote
+`EV-048 FAIL at d387498b` and, minutes later, `EV-049 PASS at d387498b`. Nothing
+had changed in the repository: six test containers had exited hours earlier, and
+`services:check` — the third of twenty-three steps — refused before a single
+test ran. Both records are true, the evidence store keeps both, and neither says
+that one of them is about the machine and the other is about the code.
+
+An evidence store whose failures cannot be told apart trains its readers to skip
+them, and a record nobody reads is the failure this repository keeps paying for
+in different costumes.
+
+## Decision
+
+**A FAIL attestation carries `failed_step`, naming the step the run stopped at.
+A PASS carries no such field**, because nothing failed and the recipe's variable
+on a passing run holds the last step, which would read as the step that failed.
+`schema_version` moves to `2`: a field's existence and its requiredness both
+changed.
+
+**The name travels through the recipe's own shell, never a file.** DBCLI-017
+refused to hand state between `begin` and `finish` through a `run.json`, because
+a file left behind by a killed run gets adopted by the next `finish` and produces
+one document describing two runs. A step marker file would reintroduce exactly
+that. The revision already travels as shell words; the step now travels beside
+it.
+
+**The parentheses around the step chain are removed.** They never made the chain
+stop — `&&` does, and `make` stops at a failing *line*, which is why the steps
+are one line — but they made it a subshell, so the variable naming the running
+step died before the attestation was written. Removing the grouping keeps both
+properties DBCLI-017 added them for: a FAIL is still recorded, and the
+attestation still cannot change a verdict.
+
+**Every step names itself, and a contract test compares the two halves.** A
+marker that names a different command would send a reader to a step that ran
+fine, which is worse than having no field at all. The roster stays a literal
+list, and the only `;` permitted among the steps is the one that ends the chain.
+
+## Consequences
+
+`bun run scripts/write-attestation.ts finish` takes five arguments instead of
+four. The argument count is checked, as it already was, because a shifted
+argument list produces an error naming the wrong problem.
+
+The field says *where* the run stopped, not *why*. `services:check` failing still
+needs its own output to say which container was down. That is the right split:
+the attestation is a bounded record of one run's verdict, and a log is a log.
+
+What this does not fix is the run-time half. A CI log still does not say which
+step is executing, because the steps are one `@`-prefixed line; the Makefile
+records that as an outstanding cost rather than pretending it is gone.
+
+**Falsified if:** the recipe stops running its steps as one `&&` chain in one
+shell — parallel steps, a step runner, a generated recipe — then the surviving
+`step` variable no longer names the step that stopped the run, and
+`failed_step` in `scripts/lib/verification-attestation.ts` would be recording
+whichever step happened to be assigned last.

--- a/scripts/lib/verification-attestation.ts
+++ b/scripts/lib/verification-attestation.ts
@@ -46,9 +46,9 @@ import { createHash } from 'node:crypto'
  * The artifact format version, which is not the package version.
  *
  * It moves when a field, its requiredness, or the meaning of a value changes.
- * DBCLI-019's per-step detail is the next thing expected to move it.
+ * Version 2 added `failed_step`, present exactly on the FAIL path.
  */
-export const ATTESTATION_SCHEMA_VERSION = 1
+export const ATTESTATION_SCHEMA_VERSION = 2
 
 export type AttestationResult = 'PASS' | 'FAIL'
 
@@ -79,6 +79,22 @@ export interface Attestation {
   readonly finished_at: string
   readonly duration_ms: number
   readonly environment: AttestationEnvironment
+  /**
+   * The step the run stopped at, on the FAIL path and only there.
+   *
+   * A FAIL used to be one word for two different facts. `EV-048 FAIL` was six
+   * stopped containers refused by `services:check`, the third of twenty-three
+   * steps; `EV-049 PASS` at the same revision was the same code once they were
+   * up. Both records are true and the evidence store keeps both, and nothing in
+   * either said that one was about the machine. A record that compresses "this
+   * commit is broken" and "this machine was not ready" into one word trains its
+   * readers to skip it.
+   *
+   * Absent on PASS. The recipe's variable holds the last step it *started*,
+   * which on a passing run is the last step, and recording that would read as
+   * the step that failed.
+   */
+  readonly failed_step?: string
   readonly attestation_hash: string
 }
 
@@ -90,6 +106,8 @@ export interface AttestationInput {
   readonly startedAt: string
   readonly finishedAt: string
   readonly environment: AttestationEnvironment
+  /** Required when `exitCode` is non-zero, refused when it is zero. */
+  readonly failedStep?: string
 }
 
 /** Key order is part of the format: two serialisations of one run must match. */
@@ -104,6 +122,7 @@ const FIELDS = [
   'finished_at',
   'duration_ms',
   'environment',
+  'failed_step',
   'attestation_hash',
 ] as const
 
@@ -113,6 +132,18 @@ const REVISION = /^[0-9a-f]{40}$/
 const INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 const SAFE_TEXT = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,63}$/
 const COMMAND = /^[a-z][a-z0-9 :-]{0,63}$/
+
+/**
+ * A step as the recipe spells it: `bun run docs:check`, `./dist/cli.mjs --help`,
+ * an inline `NAME=value` prefix.
+ *
+ * Bounded like every other text field here, and for the same reason: the value
+ * is produced by this repository's own Makefile, so the pattern is not defence
+ * against an attacker but against a shell variable that held something other
+ * than a step name. A `;` cannot appear, which is what a smuggled second
+ * command would need.
+ */
+const STEP = /^[A-Za-z0-9./][A-Za-z0-9 _./:=-]{0,127}$/
 
 /** One day. Long enough for any real gate, short enough to catch a bad clock. */
 const MAX_DURATION_MS = 24 * 60 * 60 * 1000
@@ -215,6 +246,15 @@ export function buildAttestation(input: AttestationInput): Attestation {
     refuse('exit_code', `must be an integer in 0..255, got ${JSON.stringify(input.exitCode)}`)
   }
 
+  // The pairing is the point of the field. A FAIL with no step is the record
+  // this Story exists to stop producing, and a PASS with one names a step that
+  // did not fail.
+  const failed =
+    input.exitCode === 0 ? undefined : requireMatch(input.failedStep, STEP, 'failed_step')
+  if (input.exitCode === 0 && input.failedStep !== undefined) {
+    refuse('failed_step', 'is stated on a passing run, where no step failed')
+  }
+
   const duration = Date.parse(finishedAt) - Date.parse(startedAt)
   if (duration < 0) refuse('finished_at', `is before started_at, so the run has no duration`)
 
@@ -238,6 +278,7 @@ export function buildAttestation(input: AttestationInput): Attestation {
     finished_at: finishedAt,
     duration_ms: duration,
     environment: checkEnvironment(input.environment),
+    ...(failed === undefined ? {} : { failed_step: failed }),
   }
 
   const digest = createHash('sha256').update(hashableBytes(body), 'utf8').digest('hex')
@@ -275,6 +316,10 @@ export function parseAttestation(text: string): Attestation {
   }
 
   for (const field of FIELDS) {
+    // `failed_step` is required exactly where it is meaningful. Requiring it
+    // everywhere would refuse every passing attestation; requiring it nowhere
+    // would read a FAIL that has lost its step as a FAIL that never had one.
+    if (field === 'failed_step' && record.exit_code === 0) continue
     if (!(field in record)) refuse(field, 'is missing')
   }
   for (const field of Object.keys(record)) {
@@ -308,6 +353,7 @@ export function parseAttestation(text: string): Attestation {
     startedAt: record.started_at as string,
     finishedAt: record.finished_at as string,
     environment: environment as AttestationEnvironment,
+    failedStep: record.failed_step as string | undefined,
   })
 
   // Rebuilding and comparing is the whole check: every derived field — the

--- a/scripts/write-attestation.ts
+++ b/scripts/write-attestation.ts
@@ -83,7 +83,8 @@ async function finish(
   exitCode: number,
   revision: string | undefined,
   worktree: string | undefined,
-  startedAt: string | undefined
+  startedAt: string | undefined,
+  step: string | undefined
 ): Promise<void> {
   if (revision === undefined || worktree === undefined || startedAt === undefined) {
     throw new Error(
@@ -103,6 +104,10 @@ async function finish(
     startedAt,
     finishedAt: instant(),
     environment: environment(),
+    // The recipe's variable holds the step it last *started*, so it names the
+    // failing step only when something failed. On a passing run it is the last
+    // step, and recording that would read as the step that stopped the run.
+    failedStep: exitCode === 0 ? undefined : step,
   })
 
   await mkdir(outputDirectory, { recursive: true })
@@ -124,21 +129,21 @@ try {
     // extra word was accepted in silence, and a word prepended — one line of
     // unexpected stdout, a future banner — shifted everything and produced an
     // error naming the wrong problem.
-    if (rest.length !== 4) {
+    if (rest.length !== 5) {
       throw new Error(
-        `finish takes <status> <revision> <clean|dirty> <started-at>, got ${rest.length} argument(s): ${JSON.stringify(rest)}`
+        `finish takes <status> <revision> <clean|dirty> <started-at> <step>, got ${rest.length} argument(s): ${JSON.stringify(rest)}`
       )
     }
 
-    const [status, revision, worktree, startedAt] = rest
+    const [status, revision, worktree, startedAt, step] = rest
     const exitCode = Number.parseInt(status ?? '', 10)
     if (!Number.isInteger(exitCode)) {
       throw new Error(`finish needs the run's exit status, got ${JSON.stringify(status)}`)
     }
-    await finish(exitCode, revision, worktree, startedAt)
+    await finish(exitCode, revision, worktree, startedAt, step)
   } else {
     throw new Error(
-      `unknown phase ${JSON.stringify(phase)}; expected 'begin' or 'finish <status> <revision> <clean|dirty> <started-at>'`
+      `unknown phase ${JSON.stringify(phase)}; expected 'begin' or 'finish <status> <revision> <clean|dirty> <started-at> <step>'`
     )
   }
 } catch (cause) {

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1048,12 +1048,13 @@ workflow:
     - DBCLI-027
     - DBCLI-028
     - DBCLI-029
+    - DBCLI-030
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: 1f855384089b21392d4742b8cbe385f15f0f6b53
+  commit: d387498bb32e8e2e18ca5f0289db9a08cdc73bb1
   dirty_worktree: false
   story_owned_paths:
     - specs/stories/DBCLI-028-delivery-is-not-authorization/story.md

--- a/specs/stories/DBCLI-030-an-attestation-that-names-the-step/acceptance.md
+++ b/specs/stories/DBCLI-030-an-attestation-that-names-the-step/acceptance.md
@@ -1,0 +1,67 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [ ] AC-001: A failing `make verify` writes an attestation whose `failed_step`
+      names the step that failed.
+* [ ] AC-002: A passing `make verify` writes an attestation with no
+      `failed_step` field.
+
+## Business Rules
+
+* [ ] AC-003: The step name reaches `finish` through the recipe's own shell; no
+      file carries state between `begin` and `finish`.
+* [ ] AC-004: Every step in the recipe is preceded by its `step=` marker, and a
+      step without one fails the contract test.
+* [ ] AC-005: The step roster is unchanged in content and order, and every step
+      is still blocking.
+* [ ] AC-006: The recipe stays POSIX and contains no `pipefail`.
+
+## Failure Cases
+
+* [ ] AC-007: `finish` given the wrong number of arguments refuses and names
+      what it expected.
+* [ ] AC-008: A failure to write the attestation still costs a record and never
+      a verdict — the recipe re-exits with the run's own status.
+
+## Regression Requirements
+
+* [ ] AC-009: `src/` is unchanged.
+* [ ] AC-010: `bun run forgeflow:check` and `bun run forgeflow:contract` pass,
+      with `PREDATING_FINDINGS` still empty.
+* [ ] AC-011: The complete repository verification gate passes.
+
+## Acceptance Evidence
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | test | `tests/unit/scripts/verification-attestation.test.ts` | `a non-zero exit status and a step name` | `failed_step names the step` |
+| `AC-002` | test | `tests/unit/scripts/verification-attestation.test.ts` | `a zero exit status` | `no failed_step key` |
+| `AC-003` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe` | `finish is handed the step, and no step file is written` |
+| `AC-004` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe` | `every step carries a marker naming it` |
+| `AC-005` | test | `tests/contract/forgepilot-boundary.test.ts` | `the pinned roster` | `same steps, same order, all blocking` |
+| `AC-006` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe text` | `no pipefail` |
+| `AC-007` | test | `tests/unit/scripts/verification-attestation.test.ts` | `finish with four arguments` | `refusal naming five` |
+| `AC-008` | test | `tests/contract/forgepilot-boundary.test.ts` | `the epilogue` | `the recipe re-exits with the captured status` |
+| `AC-009` | command | `git diff --stat d387498b -- src` | `repository checkout` | `empty output` |
+| `AC-010` | command | `bun run forgeflow:check` | `this branch` | `reconciliation passed` |
+| `AC-011` | command | `make verify` | `repository checkout` | `exit 0` |
+
+## Verification Notes
+
+```sh
+bun test tests/contract/forgepilot-boundary.test.ts tests/unit/scripts/verification-attestation.test.ts
+bun run forgeflow:check
+FORGEFLOW_ROOT=<clean ForgeFlowV2 checkout> bun run forgeflow:contract
+make verify
+```
+
+A real FAIL is reproduced in-session by stopping the test services and running
+`make verify`, then reading `.verification/attestation.json` — the exact
+situation that produced `EV-048` with nothing in it naming `services:check`.
+
+What human review should weigh is removing the subshell grouping from the
+recipe that decides every verdict. The grouping never made the chain stop —
+`&&` does — and it is what discards the step name. The properties it was added
+for, a recorded FAIL and an attestation that cannot change a verdict, are
+asserted literally by the contract test and are unchanged.

--- a/specs/stories/DBCLI-030-an-attestation-that-names-the-step/story.md
+++ b/specs/stories/DBCLI-030-an-attestation-that-names-the-step/story.md
@@ -1,0 +1,147 @@
+# Story: DBCLI-030 An Attestation That Names The Step
+
+## Goal
+
+A FAIL attestation says which step failed, so a recorded failure can be told
+apart from a different recorded failure without opening a log.
+
+## Context
+
+`.verification/attestation.json` records `result`, `exit_code` and the revision.
+It does not record what went wrong, so every FAIL looks like every other FAIL.
+
+That became concrete while reconciling DBCLI-029. ForgePilot recorded
+`EV-048 FAIL at d387498b`; the cause was six test containers that had exited
+hours earlier, and `services:check` — the third of twenty-three steps — refused
+before a single test ran. The commit was fine, and `EV-049 PASS` at the same
+revision proved it once the containers were up. Both records are true and the
+evidence store keeps both, which is correct. What it cannot do is say that one
+of them is about the machine and the other is about the code.
+
+An evidence record that compresses "this commit is broken" and "this machine was
+not ready" into the same word trains its readers to skip it, and a record nobody
+reads is the failure mode this repository has now paid for three times in a
+different costume.
+
+The step name is available: the recipe knows which step it is running. It is
+lost because the steps run inside a subshell, so the variable holding it dies
+before the attestation is written. The subshell is not what makes the chain
+stop — `&&` does, and `make` stops at a failing *line*, which is why the steps
+were joined into one. Removing the grouping keeps both properties and lets the
+name out.
+
+DBCLI-017 refused to pass state between the two phases through a file: a
+`run.json` left by a killed run would be adopted by the next `finish` and
+produce one document describing two runs. That reasoning is untouched here and
+is the reason this Story does not add a step file.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: yes
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: yes
+* deploy: no
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0033`
+* Boundary: `VerificationAttestation`
+* Contract: `a FAIL attestation names the step that failed, and no state crosses phases through a file`
+* Owner: `VerificationAttestation = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `verification-harness`
+
+The change is to the recipe that decides every verdict this repository issues.
+A mistake here does not produce a wrong record; it produces no verification.
+
+## Scope
+
+### In Scope
+
+* `Makefile`: each step preceded by `step=<name>` on the same `&&` chain, the
+  subshell grouping removed so the variable survives, and the name handed to
+  `write-attestation.ts finish`.
+* `scripts/write-attestation.ts` and `scripts/lib/verification-attestation.ts`:
+  a `failed_step` field, written on FAIL and absent on PASS.
+* `tests/contract/forgepilot-boundary.test.ts`: the roster stays literal and
+  gains the marker for each step, and the prologue and epilogue comparisons
+  follow the recipe.
+* ADR-0033.
+
+### Out of Scope
+
+* Per-step timing. The Makefile records it as DBCLI-019's inherited cost; naming
+  the failing step does not need it, and adding it here would put two changes in
+  one recipe.
+* Starting the test services from `make verify`. That would make Docker a
+  dependency of the canonical gate, which DBCLI-014 deliberately avoided, and
+  the services are shared by port so two runs would collide. `services:check`
+  already refuses rather than passing, which is the behaviour worth keeping.
+* Any change to `src/`, and any release.
+
+## Inputs
+
+* `Makefile`, `scripts/write-attestation.ts`,
+  `scripts/lib/verification-attestation.ts`,
+  `tests/contract/forgepilot-boundary.test.ts`,
+  `tests/unit/scripts/verification-attestation.test.ts`.
+
+## Outputs
+
+* A FAIL attestation naming its step.
+* A contract test that fails if a step is added without a marker.
+
+## Rules
+
+* R1: A FAIL attestation carries `failed_step` naming the step that failed.
+* R2: A PASS attestation carries no `failed_step`. Nothing failed, and a field
+  naming the last step would read as one.
+* R3: No state crosses `begin` and `finish` through a file. The name travels
+  through the recipe's own shell, as the revision already does.
+* R4: Every step is preceded by its marker, and the contract test fails on a
+  step that has none — an unmarked step would be attributed to the step above it,
+  which is worse than no field at all.
+* R5: The step roster is unchanged in content and order, and every step is still
+  blocking.
+* R6: The recipe stays POSIX and free of `pipefail`.
+* R7: The attestation still never decides the verdict: a failure to write one
+  costs a record, never a result.
+* R8: No change to `src/`.
+
+## Expected Errors
+
+* `finish` given the wrong number of arguments names what it expected, as it
+  already does.
+* A step added to the Makefile without a marker fails the contract test.
+
+## Dependencies
+
+* ADR-0033 — the decision and its falsification condition.
+* DBCLI-017 — the two-phase attestation and why no file crosses the phases.
+
+## Constraints
+
+* The recipe must keep recording a FAIL. A change that only records passing runs
+  removes the evidence this Story is trying to improve.
+
+## Superseded Behavior
+
+* `tests/contract/forgepilot-boundary.test.ts` — `PROLOGUE`, `EPILOGUE` and the
+  recipe parser pin the subshell grouping and the bare step strings. The
+  grouping is what discards the step name, so those literals change deliberately
+  and the roster gains a marker per step.
+* `tests/unit/scripts/verification-attestation.test.ts` — the serialised-shape
+  assertions gain the `failed_step` field on the FAIL path.

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -21,6 +21,13 @@ const readRoot = (relative: string): Promise<string> => readFile(join(ROOT, rela
  * recorded as well as a passing one. That is the argued-for change the comment
  * above demands: the roster below is unchanged, every step is still blocking,
  * and what the recipe gained is the ability to say that it stopped.
+ *
+ * DBCLI-030 removed the grouping and gave each step a `step=` marker naming it.
+ * The grouping never made the chain stop — `&&` does, and `make` stops at a
+ * failing line, which is why the steps are one line — but it did discard the
+ * variable holding the running step's name, so every FAIL attestation said only
+ * that something failed. The roster below is again unchanged; what the recipe
+ * gained is the ability to say *which* step stopped it. ADR-0033.
  */
 const REQUIRED_STEPS = [
   'bun run services:check',
@@ -60,11 +67,11 @@ const REQUIRED_STEPS = [
  * `verify:` target further down that make would run instead. Each of them
  * changes one of these lines, so each of them now fails.
  */
-const PROLOGUE = ["@run=$$(bun run scripts/write-attestation.ts begin) || run='';", '('] as const
+const PROLOGUE = ["@run=$$(bun run scripts/write-attestation.ts begin) || run='';"] as const
 
 const EPILOGUE = [
-  '); status=$$?;',
-  'bun run scripts/write-attestation.ts finish $$status $$run || true;',
+  'status=$$?;',
+  'bun run scripts/write-attestation.ts finish $$status $$run "$$step" || true;',
   'exit $$status',
 ] as const
 
@@ -108,17 +115,37 @@ const parseVerifyRecipe = (makefile: string): Recipe => {
     if (text.length > 0 && !text.startsWith('#')) recipe.push(text)
   }
 
-  const opening = recipe.indexOf('(')
-  const closing = recipe.findIndex((line) => line.startsWith(');'))
+  const opening = recipe.findIndex((line) => line.startsWith('step='))
+  const closing = recipe.findIndex((line) => line.startsWith('status='))
   expect(opening).toBeGreaterThanOrEqual(0)
   expect(closing).toBeGreaterThan(opening)
 
-  const steps = recipe.slice(opening + 1, closing).map((line) => {
-    expect(line).not.toMatch(/\|\|\s*true|^-|;/)
-    return line.replace(/\s*&&$/, '')
+  // Each step line is `step='<name>' && <command>`, and the two halves are
+  // compared. A step whose marker names a different command would put the wrong
+  // step in a FAIL attestation, which is worse than the field not existing: it
+  // sends the reader to a step that ran fine.
+  //
+  // Every line but the last ends in `&&`, which is what keeps it blocking; the
+  // last ends the chain with `;` so that `status=$?` runs whatever happened.
+  // That one `;` is the only one allowed anywhere in the steps — chaining a
+  // second command onto a step with `;` would run it unconditionally and hide
+  // its status, which is the shape this roster exists to refuse.
+  const stepLines = recipe.slice(opening, closing)
+  const steps = stepLines.map((line, index) => {
+    const last = index === stepLines.length - 1
+    expect(line).not.toMatch(/\|\|\s*true|^-/)
+    expect(line.endsWith(last ? ';' : '&&')).toBe(true)
+
+    const body = line.replace(last ? /;$/ : /\s*&&$/, '').trim()
+    expect(body).not.toContain(';')
+
+    const marked = body.match(/^step='([^']*)' && (.+)$/)
+    expect(marked, `step line is not marked: ${JSON.stringify(line)}`).not.toBeNull()
+    expect(marked![1]).toBe(marked![2] as string)
+    return marked![2] as string
   })
 
-  return { prologue: recipe.slice(0, opening + 1), steps, epilogue: recipe.slice(closing) }
+  return { prologue: recipe.slice(0, opening), steps, epilogue: recipe.slice(closing) }
 }
 
 const verifyRecipe = async (): Promise<Recipe> => parseVerifyRecipe(await readRoot('Makefile'))

--- a/tests/unit/scripts/verification-attestation.test.ts
+++ b/tests/unit/scripts/verification-attestation.test.ts
@@ -19,6 +19,9 @@ import {
 
 const REVISION = '980cc078b850f799615dce51b2993141b85c40c7'
 
+/** A real step, spelled as the recipe spells it. */
+const FAILED_STEP = 'bun run services:check'
+
 const INPUT: AttestationInput = {
   revision: REVISION,
   dirtyWorktree: false,
@@ -42,7 +45,7 @@ describe('buildAttestation', () => {
   })
 
   test('a non-zero exit is a FAIL, and the code is kept', () => {
-    const attestation = buildAttestation({ ...INPUT, exitCode: 2 })
+    const attestation = buildAttestation({ ...INPUT, exitCode: 2, failedStep: FAILED_STEP })
 
     expect(attestation.result).toBe('FAIL')
     expect(attestation.exit_code).toBe(2)
@@ -60,7 +63,17 @@ describe('buildAttestation', () => {
 
     expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(buildAttestation(INPUT).attestation_hash).toBe(hash)
-    expect(buildAttestation({ ...INPUT, exitCode: 1 }).attestation_hash).not.toBe(hash)
+    expect(
+      buildAttestation({ ...INPUT, exitCode: 1, failedStep: FAILED_STEP }).attestation_hash
+    ).not.toBe(hash)
+
+    // The step is inside the hash, not beside it: two FAILs that stopped at
+    // different steps are different documents.
+    expect(
+      buildAttestation({ ...INPUT, exitCode: 1, failedStep: 'bun run lint' }).attestation_hash
+    ).not.toBe(
+      buildAttestation({ ...INPUT, exitCode: 1, failedStep: FAILED_STEP }).attestation_hash
+    )
   })
 
   test('nothing the repository cannot verify for itself gets in', () => {
@@ -83,6 +96,46 @@ describe('buildAttestation', () => {
       'attestation_hash',
     ])
     expect(Object.keys(buildAttestation(INPUT).environment)).toEqual(['os', 'arch', 'bun', 'ci'])
+  })
+
+  test('a FAIL names the step that failed', () => {
+    // EV-048 recorded a FAIL whose cause was six stopped containers, and EV-049
+    // recorded a PASS at the same revision once they were up. Both are true and
+    // both are kept; what the format could not do was say that one of them is
+    // about the machine and the other would have been about the code. ADR-0033.
+    const attestation = buildAttestation({ ...INPUT, exitCode: 1, failedStep: FAILED_STEP })
+
+    expect(attestation.result).toBe('FAIL')
+    expect(attestation.failed_step).toBe(FAILED_STEP)
+    expect(Object.keys(attestation)).toContain('failed_step')
+  })
+
+  test('a PASS carries no failed step, because nothing failed', () => {
+    // The recipe's variable holds the last step it started, which on a passing
+    // run is the last step. Recording it would read as the step that failed.
+    const attestation = buildAttestation(INPUT)
+
+    expect(attestation.failed_step).toBeUndefined()
+    expect(Object.keys(attestation)).not.toContain('failed_step')
+    expect(serialiseAttestation(attestation)).not.toContain('failed_step')
+  })
+
+  test('a FAIL with no step, and a PASS with one, are both refused', () => {
+    // Neither is a document this repository can produce, and a producer that
+    // accepts both records whichever mistake it was handed.
+    expect(() => buildAttestation({ ...INPUT, exitCode: 1 })).toThrow(/failed_step/)
+    expect(() => buildAttestation({ ...INPUT, failedStep: FAILED_STEP })).toThrow(/failed_step/)
+  })
+
+  test('a step that is not a step this recipe runs is refused', () => {
+    const refused = (step: string) =>
+      expect(() => buildAttestation({ ...INPUT, exitCode: 1, failedStep: step })).toThrow(
+        /failed_step/
+      )
+
+    refused('')
+    refused('bun run test; rm -rf /')
+    refused(`bun run ${'x'.repeat(200)}`)
   })
 
   test('a revision that is not a full commit SHA is refused', () => {
@@ -134,11 +187,26 @@ describe('parseAttestation', () => {
 
   test('a schema version it does not know is refused, not partially read', () => {
     const text = serialiseAttestation(buildAttestation(INPUT)).replace(
-      '"schema_version": 1',
-      '"schema_version": 2'
+      `"schema_version": ${ATTESTATION_SCHEMA_VERSION}`,
+      `"schema_version": ${ATTESTATION_SCHEMA_VERSION + 1}`
     )
 
     expect(() => parseAttestation(text)).toThrow(/schema_version/)
+  })
+
+  test('a FAIL round-trips with the step it named', () => {
+    const attestation = buildAttestation({ ...INPUT, exitCode: 1, failedStep: FAILED_STEP })
+
+    expect(parseAttestation(serialiseAttestation(attestation))).toEqual(attestation)
+  })
+
+  test('a FAIL document with no step is refused rather than read as unknown', () => {
+    const document = JSON.parse(
+      serialiseAttestation(buildAttestation({ ...INPUT, exitCode: 1, failedStep: FAILED_STEP }))
+    ) as Record<string, unknown>
+    delete document.failed_step
+
+    expect(() => parseAttestation(JSON.stringify(document))).toThrow(/failed_step/)
   })
 
   test('a missing required field is refused, naming the field', () => {


### PR DESCRIPTION
## 為什麼

`.verification/attestation.json` 只記 `result`、`exit_code` 與 revision，不記出了什麼事，所以每一筆 FAIL 長得都一樣。

對帳 DBCLI-029 時這件事變具體了：ForgePilot 記下 `EV-048 FAIL at d387498b`，幾分鐘後記下 `EV-049 PASS at d387498b`。中間 repository 一個字沒改——是六個測試容器幾小時前就退出，`services:check`（23 步裡的第 3 步）在任何測試跑起來之前就拒絕作答。兩筆都是真的，evidence store 兩筆都該留，但沒有一筆說得出「其中一個是機器的事，另一個才會是程式碼的事」。

分不出彼此的失敗紀錄會訓練讀的人跳過它，而沒人讀的紀錄正是這個 repo 反覆在付的那筆學費，只是換了戲服。

## 改了什麼

- **FAIL 帶 `failed_step`，PASS 不帶。** recipe 的變數在通過的那一輪持有的是最後一步，記下來會被讀成「停在那一步」。`schema_version` 進到 2（欄位的存在與必要性都變了），`failed_step` 進 hash——兩筆停在不同步驟的 FAIL 是不同的文件。
- **步驟名走 recipe 自己的 shell，不走檔案。** DBCLI-017 明文拒絕用 `run.json` 在兩個階段之間傳狀態（被殺掉的那輪留下的檔案會被下一次 `finish` 認領，產出一份描述兩輪的文件）；step marker 檔案會把那個問題原樣搬回來。
- **拿掉步驟鏈外面那對括號。** 它從來不是讓鏈停下來的東西——`&&` 才是，而 `make` 停在失敗的「那一行」，所以步驟本來就併成一行——但它讓那段成為 subshell，持有步驟名的變數因此在 attestation 寫出去之前就死了。DBCLI-017 加它時要的兩個性質（FAIL 照樣被記錄、attestation 照樣不能改變判決）由 contract test 逐字釘著，都還在。
- **每個步驟自己報名**，contract test 比對 marker 與指令兩半：marker 名字跟指令不一致，會把讀的人送去一個跑得好好的步驟，那比沒有這個欄位更糟。roster 內容與順序不變，步驟之間唯一允許的 `;` 是結束整條鏈的那一個。

## 實測復現

停掉六個容器跑 `make verify`：

```json
{ "schema_version": 2, "result": "FAIL", "exit_code": 1, "failed_step": "bun run services:check" }
```

正是 EV-048 當時說不出口的那句話。

## 明確不做的事

- **per-step 計時**：Makefile 把它記成 DBCLI-019 繼承下來的已知成本。命名失敗步驟不需要它，兩件事塞進同一條 recipe 會讓審查變難。
- **由 `make verify` 自己起測試服務**：那會讓 Docker 變成 canonical gate 的相依（DBCLI-014 刻意避開），而且服務走 host port，兩個併行的 worktree 會互撞。`services:check` 現在是 fail-closed 並指名原因，這個行為值得保留。

## 驗證

| 檢查 | 結果 |
| --- | --- |
| `make verify` | PASS at `61bf4eae097c5d42a13eae5e5ffd23f94ca53580`（sha256:`69cb64ea…`） |
| `bun test`（兩支受影響的 suite） | 40 pass / 0 fail |
| `bun run forgeflow:check` | 通過，38 completed Stories |
| `bun run forgeflow:contract` | 通過（`FORGEFLOW_ROOT` = `cb4bc976`），38 Stories、0 admitted findings |

`PREDATING_FINDINGS` 仍為空集合，`src/` 零變更，不需新 tag。

決定與失效條件在 ADR-0033。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn