### PR TITLE
feat: [ verification ] verify log 說出自己跑到哪一步、花了多久

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,18 @@
 # It passed locally only because macOS `/bin/sh` is bash. Nothing here pipes
 # anything, so `pipefail` was a fatal no-op.
 #
-# One thing was lost and is only half recovered: each step used to be its own
-# recipe line, so make echoed it and a CI log showed which of the checks was
-# running and which one failed. Joined and prefixed with `@`, it does not.
-# DBCLI-030 recovered the half that matters after the fact — the attestation
-# names the failing step — and left the half that matters during the run, a live
-# log saying which step is executing and how long it took. That still means
-# echoing each step with its own timing, and it is recorded here rather than
-# rediscovered.
+# What joining the steps cost is now paid in full. Each step used to be its own
+# recipe line, so make echoed it and a log showed which check was running and
+# which one failed; joined and prefixed with `@`, it did not. DBCLI-030 recovered
+# the half read afterwards — the attestation names the failing step — and
+# DBCLI-031 the half read during: `run` prints each step's number and name before
+# it runs and its elapsed seconds and status after.
+#
+# `run` executes `eval "$$step"`, so a step's label and its command are one
+# string rather than two copies that can disagree. The input is the single-quoted
+# literal on the line above, pinned character-for-character by
+# `tests/contract/forgepilot-boundary.test.ts`, which also refuses a `;` anywhere
+# in a step. ADR-0034.
 #
 # Neither attestation phase can decide the verdict, which is the point of the
 # `|| run=''` and the `|| true`: `begin` failing leaves `run` empty so `finish`
@@ -44,31 +48,36 @@
 # cannot leave state for the next run to pick up and describe as its own.
 # DBCLI-017, and `scripts/write-attestation.ts` for what the record says.
 verify:
-	@run=$$(bun run scripts/write-attestation.ts begin) || run=''; \
-	step='bun install --frozen-lockfile' && bun install --frozen-lockfile && \
-	step='bun run services:check' && bun run services:check && \
-	step='bun run audit' && bun run audit && \
-	step='bun run format:check' && bun run format:check && \
-	step='bun run agent-core:check' && bun run agent-core:check && \
-	step='bun run core-stdout:check' && bun run core-stdout:check && \
-	step='bun run typecheck' && bun run typecheck && \
-	step='bun run typecheck:tests' && bun run typecheck:tests && \
-	step='bun run lint' && bun run lint && \
-	step='SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test' && SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test && \
-	step='bun run build' && bun run build && \
-	step='bun run build:determinism' && bun run build:determinism && \
-	step='bun run dev -- --help' && bun run dev -- --help && \
-	step='bun run dev -- --version' && bun run dev -- --version && \
-	step='./dist/cli.mjs --help' && ./dist/cli.mjs --help && \
-	step='./dist/cli.mjs --version' && ./dist/cli.mjs --version && \
-	step='bun run test:perf' && bun run test:perf && \
-	step='bun run platform:check' && bun run platform:check && \
-	step='bun run plugin:check' && bun run plugin:check && \
-	step='bun run manifest:check' && bun run manifest:check && \
-	step='bun run docs:check' && bun run docs:check && \
-	step='bun run contract:check' && bun run contract:check && \
-	step='bun run plan:check' && bun run plan:check && \
-	step='bun run forgeflow:check' && bun run forgeflow:check; \
+	@started=$$(bun run scripts/write-attestation.ts begin) || started=''; \
+	run() { count=$$((count+1)); at=$$(date +%s); \
+		printf '==> [%s] %s\n' "$$count" "$$step"; \
+		eval "$$step"; code=$$?; \
+		printf '<== [%s] %s %ss exit %s\n' "$$count" "$$step" "$$(($$(date +%s)-at))" "$$code"; \
+		return $$code; }; \
+	step='bun install --frozen-lockfile' && run && \
+	step='bun run services:check' && run && \
+	step='bun run audit' && run && \
+	step='bun run format:check' && run && \
+	step='bun run agent-core:check' && run && \
+	step='bun run core-stdout:check' && run && \
+	step='bun run typecheck' && run && \
+	step='bun run typecheck:tests' && run && \
+	step='bun run lint' && run && \
+	step='SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test' && run && \
+	step='bun run build' && run && \
+	step='bun run build:determinism' && run && \
+	step='bun run dev -- --help' && run && \
+	step='bun run dev -- --version' && run && \
+	step='./dist/cli.mjs --help' && run && \
+	step='./dist/cli.mjs --version' && run && \
+	step='bun run test:perf' && run && \
+	step='bun run platform:check' && run && \
+	step='bun run plugin:check' && run && \
+	step='bun run manifest:check' && run && \
+	step='bun run docs:check' && run && \
+	step='bun run contract:check' && run && \
+	step='bun run plan:check' && run && \
+	step='bun run forgeflow:check' && run; \
 	status=$$?; \
-	bun run scripts/write-attestation.ts finish $$status $$run "$$step" || true; \
+	bun run scripts/write-attestation.ts finish $$status $$started "$$step" || true; \
 	exit $$status

--- a/docs/adr/ADR-0034-a-step-label-and-its-command-are-one-string.md
+++ b/docs/adr/ADR-0034-a-step-label-and-its-command-are-one-string.md
@@ -1,0 +1,65 @@
+# A step's label and its command are one string
+
+* Status: accepted
+* Date: 2026-09-10
+
+`make verify` runs twenty-four steps as one `@`-prefixed recipe line, which is
+what makes a failing run recordable — `make` stops at a failing *line*, so steps
+on separate lines could only ever produce an attestation for a passing run. The
+cost, written into the Makefile when it was paid rather than discovered later,
+is that a running gate says nothing about where it is.
+
+ADR-0033 paid the half you read afterwards: a FAIL attestation names the step it
+stopped at. This is the half you read during — which step is running, and how
+long each one took.
+
+## Decision
+
+**Each step announces itself.** A `run` shell function prints the step's number
+and name, executes it, and prints the number, name, elapsed seconds and exit
+status. A twelve-minute gate now says whether it is on step 3 or step 20, and
+which step spent the twelve minutes.
+
+**A step's label and its command are one string.** Each step line is
+`step='<command>' && run`, and `run` executes `eval "$step"`. The obvious
+alternative — `run bun run lint`, with the command as arguments — leaves two
+copies of every command in the recipe, a label and an argv, which can disagree.
+DBCLI-030 needed a contract test comparing the two halves precisely because they
+were two halves; with one string there is nothing to compare and nothing that
+can misattribute a line. A log or an attestation that names the wrong step is
+worse than one that names none: it sends its reader to a step that ran fine.
+
+The argv form also does not survive contact with the roster. One step sets two
+environment variables inline, which as arguments is not a command at all and
+would need an `env` prefix — a step spelled differently from every other step,
+for the convenience of a mechanism that was already the weaker option.
+
+**`eval` here is not the usual `eval`.** Its input is not user input, a
+variable from the environment, or a value read at runtime: it is a single-quoted
+literal on the line above, pinned character-for-character by a contract test that
+also refuses a `;` anywhere in a step. A reader who arrives at this line and
+reaches for the usual rule should read that test first.
+
+**Whole seconds.** `date +%s` is POSIX and answers the question being asked.
+Millisecond timing here would be precision this log has no use for, and the
+steps that matter take minutes.
+
+## Consequences
+
+The verify log gains two lines per step. That is the cost, and it is small
+against twenty-four steps of tool output.
+
+Nothing else moves: the roster is unchanged in content and order, every step
+still blocks, the recipe re-exits with the run's own status, `failed_step` still
+names the step that stopped it, and the two attestation phases still exchange
+state through the recipe's own shell rather than a file.
+
+Per-step timings are not recorded in the attestation. The document states one
+run's verdict and where it stopped; a per-step table is a different artifact,
+and adding it would move the schema for something the log already says.
+
+**Falsified if:** a step ever needs to be spelled differently from the way it is
+run — a step whose command cannot be a single-quoted literal, or one that must
+be built at runtime. Then `step='<command>' && run` in the `Makefile` is no
+longer one string serving both purposes, and the label and the command separate
+again, with the comparison test that separation requires.

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1049,12 +1049,13 @@ workflow:
     - DBCLI-028
     - DBCLI-029
     - DBCLI-030
+    - DBCLI-031
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: d387498bb32e8e2e18ca5f0289db9a08cdc73bb1
+  commit: bbcdd4540028823a2098084dccf5d07544ea09a2
   dirty_worktree: false
   story_owned_paths:
     - specs/stories/DBCLI-028-delivery-is-not-authorization/story.md

--- a/specs/stories/DBCLI-031-a-verify-log-that-says-where-it-is/acceptance.md
+++ b/specs/stories/DBCLI-031-a-verify-log-that-says-where-it-is/acceptance.md
@@ -1,0 +1,62 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [ ] AC-001: A `make verify` run prints, for each step, a line naming it before
+      it runs and a line giving its duration and exit status after it.
+* [ ] AC-002: The lines carry a step number, so a reader knows how far in a
+      running gate is.
+
+## Business Rules
+
+* [ ] AC-003: A step's label and its command are the same string; there is no
+      second copy that could name a different command.
+* [ ] AC-004: Every step line is `step='<command>' && run`, and a line that is
+      not fails the contract test.
+* [ ] AC-005: The roster is unchanged in content and order, and every step still
+      blocks.
+* [ ] AC-006: The recipe stays POSIX and contains no `pipefail`.
+
+## Failure Cases
+
+* [ ] AC-007: A failing step prints its closing line with the non-zero status,
+      the chain stops there, and the recipe re-exits with that status.
+* [ ] AC-008: The attestation still records `failed_step` naming that step.
+
+## Regression Requirements
+
+* [ ] AC-009: `src/` is unchanged.
+* [ ] AC-010: `bun run forgeflow:check` and `bun run forgeflow:contract` pass,
+      with `PREDATING_FINDINGS` still empty.
+* [ ] AC-011: The complete repository verification gate passes.
+
+## Acceptance Evidence
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | command | `make verify` | `repository checkout` | `a paired ==> and <== line for each step` |
+| `AC-002` | command | `make verify` | `repository checkout` | `each line carries its step number` |
+| `AC-003` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe` | `the command is the marker` |
+| `AC-004` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe` | `every step line invokes run` |
+| `AC-005` | test | `tests/contract/forgepilot-boundary.test.ts` | `the pinned roster` | `same steps, same order, all blocking` |
+| `AC-006` | test | `tests/contract/forgepilot-boundary.test.ts` | `the verify recipe text` | `no pipefail` |
+| `AC-007` | command | `make verify` | `the test services stopped` | `services:check closes with exit 1 and the chain stops` |
+| `AC-008` | command | `cat .verification/attestation.json` | `the same failing run` | `failed_step is bun run services:check` |
+| `AC-009` | command | `git diff --stat bbcdd454 -- src` | `repository checkout` | `empty output` |
+| `AC-010` | command | `bun run forgeflow:check` | `this branch` | `reconciliation passed` |
+| `AC-011` | command | `make verify` | `repository checkout` | `exit 0` |
+
+## Verification Notes
+
+```sh
+bun test tests/contract/forgepilot-boundary.test.ts
+docker compose -f docker-compose.test.yml stop && make verify   # AC-007, AC-008
+docker compose -f docker-compose.test.yml up -d --wait
+make verify
+```
+
+What human review should weigh is `eval "$step"` in the recipe. The alternative
+is passing the command as arguments, which needs an `env` prefix for the one
+step that sets variables and, more importantly, leaves two copies of every
+command that a test then has to compare. One string used for both the label and
+the execution cannot misattribute a line. ADR-0034 records that trade.

--- a/specs/stories/DBCLI-031-a-verify-log-that-says-where-it-is/story.md
+++ b/specs/stories/DBCLI-031-a-verify-log-that-says-where-it-is/story.md
@@ -1,0 +1,128 @@
+# Story: DBCLI-031 A Verify Log That Says Where It Is
+
+## Goal
+
+`make verify` says which step it is running and how long each one took, so a
+run that is failing, hanging or merely slow can be read while it happens rather
+than reconstructed afterwards.
+
+## Context
+
+The Makefile has carried this as a named, unpaid cost since DBCLI-017. Each step
+used to be its own recipe line, so `make` echoed it and a log showed which check
+was running and which one stopped. Joining the steps into one `@`-prefixed line
+— which is what makes a FAIL recordable, because `make` stops at a failing
+*line* — took that away.
+
+DBCLI-030 paid half of it: a FAIL attestation now names the step it stopped at.
+That is the half you read afterwards. The half you read *during* is still
+missing, and it is the half that matters while a twelve-minute gate is running:
+nothing says whether it is on step 3 or step 20, and nothing says that
+`bun run test` took eleven of those minutes.
+
+Both halves were recorded in the Makefile rather than quietly accepted, so this
+Story is collecting a debt the repository wrote down itself.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: yes
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: yes
+* deploy: no
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0034`
+* Boundary: `VerificationAttestation`
+* Contract: `every step announces itself and its duration, and a step's label and its command are one string`
+* Owner: `VerificationAttestation = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `verification-harness`
+
+The recipe decides every verdict this repository issues. The failure mode to
+guard is not a wrong record but a gate that stops running, or one whose steps
+stop blocking.
+
+## Scope
+
+### In Scope
+
+* `Makefile`: a `run` shell function that prints the step, runs it, and prints
+  its duration and exit status, with each step line becoming
+  `step='<command>' && run`.
+* `tests/contract/forgepilot-boundary.test.ts`: the roster stays literal, every
+  step line is `step='<command>' && run`, and the prologue pins the function.
+* ADR-0034.
+
+### Out of Scope
+
+* Any change to which steps run, their order, or their blocking behaviour.
+* Sub-second timing. `date +%s` is POSIX and whole seconds answer the question
+  being asked; a millisecond clock here would be precision this log cannot use.
+* Machine-readable per-step output in the attestation. The document records one
+  run's verdict and the step it stopped at; a per-step table is a different
+  artifact and would move the schema again for something a log already says.
+* Any change to `src/`, and any release.
+
+## Inputs
+
+* `Makefile`, `tests/contract/forgepilot-boundary.test.ts`.
+* ADR-0033 — the attestation half of the same debt.
+
+## Outputs
+
+* A verify log that names each step, numbers it, and times it.
+* A contract test that fails if a step stops announcing itself.
+
+## Rules
+
+* R1: Each step prints its number and name before it runs, and its number,
+  name, duration and exit status after it.
+* R2: A step's label and its command are one string. Two copies that can
+  disagree would put a step's name on another step's output, and a log that
+  misattributes is worse than one that says nothing.
+* R3: Every step still blocks: the chain stops at the first failure and the
+  recipe re-exits with that status.
+* R4: The step roster is unchanged in content and order.
+* R5: The recipe stays POSIX — `dash` runs it on the Ubuntu runner — and free
+  of `pipefail`.
+* R6: `failed_step` in the attestation is unchanged and still names the step the
+  run stopped at.
+* R7: No change to `src/`.
+
+## Expected Errors
+
+* A failing step prints its own line with a non-zero exit status before the
+  chain stops.
+* A step line that does not announce itself fails the contract test.
+
+## Dependencies
+
+* ADR-0034 — the decision and its falsification condition.
+* ADR-0033 — the attestation names the failing step; this is the live half.
+
+## Constraints
+
+* Nothing may swallow a step's own output or alter its exit status.
+* The two attestation phases still exchange state through the recipe's shell,
+  never a file.
+
+## Superseded Behavior
+
+* `tests/contract/forgepilot-boundary.test.ts` — the recipe parser compares each
+  step's marker against the command spelled beside it. There is no second copy
+  to compare once the command is the marker, so that assertion is replaced by
+  one that every step line invokes `run`.

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -67,11 +67,18 @@ const REQUIRED_STEPS = [
  * `verify:` target further down that make would run instead. Each of them
  * changes one of these lines, so each of them now fails.
  */
-const PROLOGUE = ["@run=$$(bun run scripts/write-attestation.ts begin) || run='';"] as const
+const PROLOGUE = [
+  "@started=$$(bun run scripts/write-attestation.ts begin) || started='';",
+  'run() { count=$$((count+1)); at=$$(date +%s);',
+  'printf \'==> [%s] %s\\n\' "$$count" "$$step";',
+  'eval "$$step"; code=$$?;',
+  'printf \'<== [%s] %s %ss exit %s\\n\' "$$count" "$$step" "$$(($$(date +%s)-at))" "$$code";',
+  'return $$code; };',
+] as const
 
 const EPILOGUE = [
   'status=$$?;',
-  'bun run scripts/write-attestation.ts finish $$status $$run "$$step" || true;',
+  'bun run scripts/write-attestation.ts finish $$status $$started "$$step" || true;',
   'exit $$status',
 ] as const
 
@@ -120,10 +127,10 @@ const parseVerifyRecipe = (makefile: string): Recipe => {
   expect(opening).toBeGreaterThanOrEqual(0)
   expect(closing).toBeGreaterThan(opening)
 
-  // Each step line is `step='<name>' && <command>`, and the two halves are
-  // compared. A step whose marker names a different command would put the wrong
-  // step in a FAIL attestation, which is worse than the field not existing: it
-  // sends the reader to a step that ran fine.
+  // Each step line is `step='<command>' && run`. There is nothing to compare:
+  // DBCLI-031 made the label and the command one string, because two copies can
+  // disagree and a log or an attestation that names the wrong step sends its
+  // reader to a step that ran fine.
   //
   // Every line but the last ends in `&&`, which is what keeps it blocking; the
   // last ends the chain with `;` so that `status=$?` runs whatever happened.
@@ -139,10 +146,9 @@ const parseVerifyRecipe = (makefile: string): Recipe => {
     const body = line.replace(last ? /;$/ : /\s*&&$/, '').trim()
     expect(body).not.toContain(';')
 
-    const marked = body.match(/^step='([^']*)' && (.+)$/)
-    expect(marked, `step line is not marked: ${JSON.stringify(line)}`).not.toBeNull()
-    expect(marked![1]).toBe(marked![2] as string)
-    return marked![2] as string
+    const marked = body.match(/^step='([^']*)' && run$/)
+    expect(marked, `step line does not announce itself: ${JSON.stringify(line)}`).not.toBeNull()
+    return marked![1] as string
   })
 
   return { prologue: recipe.slice(0, opening), steps, epilogue: recipe.slice(closing) }


### PR DESCRIPTION
## 為什麼

Makefile 從 DBCLI-017 起就把這筆成本寫在自己身上：步驟本來各自一行，`make` 會回顯，log 看得出在跑哪一步、停在哪一步；併成一行加 `@` 之後就沒了——而併成一行正是 FAIL 能被記錄的原因（`make` 停在失敗的**那一行**）。

DBCLI-030 付了事後那一半：attestation 指名停在哪一步。這次付跑的當下那一半。十二分鐘的 gate 現在說得出它在第 3 步還是第 20 步，以及那十二分鐘是誰花掉的。

## 長什麼樣

```
==> [10] SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test
<== [10] SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test 266s exit 0
```

這一輪 `make verify` 的實際分佈（總長 ~11 分鐘）：`bun run test` 266s、`build:determinism` 116s、`build` 59s、`typecheck:tests` 36s、`lint` 24s、`format:check` 24s，其餘 24 步都在 15s 以下。這份數字以前要拿碼表才有。

## 設計：步驟的標籤與指令是同一個字串

每一行是 `step='<command>' && run`，`run` 執行 `eval "$step"`。

另一種寫法 `run bun run lint` 會在 recipe 裡留下每個指令的兩份拷貝（一個標籤、一組 argv），而兩份會不一致——DBCLI-030 需要一支比對兩半的 contract test，正是因為它們是兩半。一份字串沒有東西可比，也沒有東西會把某一步的名字掛到另一步的輸出上。**指名錯步驟的 log 比不指名更糟**：它把讀的人送去一個跑得好好的步驟。

argv 寫法也撐不過現有 roster：有一步在行內設兩個環境變數，當成 argv 根本不是指令，得加 `env` 前綴——為了一個本來就比較弱的機制，讓某一步跟其他步驟拼法不同。

**這裡的 `eval` 不是一般意義的 `eval`**：輸入不是使用者輸入、不是環境變數、不是執行期讀進來的值，是上一行的單引號字面值，被 `tests/contract/forgepilot-boundary.test.ts` 逐字釘住，而那支測試同時拒絕步驟裡出現任何 `;`。走到這一行想套用平常那條規則的讀者，請先讀那支測試。ADR-0034 記下這個取捨與失效條件。

## 沒有動的東西

roster 內容與順序不變、每一步照樣 blocking、recipe 照樣以該輪自己的 status 離開、`failed_step` 照樣指名停在哪一步、兩個 attestation 階段照樣走 recipe 的 shell 而不是檔案。per-step 時間**不**進 attestation：那份文件記的是一輪的判決與它停在哪，per-step 表格是另一種 artifact，為了 log 已經講出來的事再動一次 schema 不划算。

## 驗證

| 檢查 | 結果 |
| --- | --- |
| `make verify` | PASS at `1a11e7d93bb7a29f1996b98714eb400b0791c80a`（sha256:`73ef9d5d…`） |
| FAIL 路徑（停掉容器） | 印出 `<== [2] bun run services:check 0s exit 1`，attestation 寫出 `failed_step` |
| `bun test tests/contract/forgepilot-boundary.test.ts` | 12 pass / 0 fail |
| `bun run forgeflow:check` | 通過，39 completed Stories |
| `bun run forgeflow:contract` | 通過（`cb4bc976`），39 Stories、0 admitted findings |

`PREDATING_FINDINGS` 仍為空集合，`src/` 零變更，不需新 tag。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn