### PR TITLE
perf: [ verification ] gate 少 build 一次

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ verify:
 	step='bun run typecheck:tests' && run && \
 	step='bun run lint' && run && \
 	step='SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test' && run && \
-	step='bun run build' && run && \
 	step='bun run build:determinism' && run && \
 	step='bun run dev -- --help' && run && \
 	step='bun run dev -- --version' && run && \

--- a/docs/adr/ADR-0035-a-step-that-nothing-reads-is-not-a-check.md
+++ b/docs/adr/ADR-0035-a-step-that-nothing-reads-is-not-a-check.md
@@ -1,0 +1,101 @@
+# A step that nothing reads is not a check
+
+* Status: accepted
+* Date: 2026-09-10
+
+`make verify`'s roster is deliberately hard to shrink. Its own comment says a
+step may be added deliberately and that removing one has to be argued for,
+because a control plane that runs this gate must not become a reason to make it
+say less.
+
+This is that argument, for one step.
+
+ADR-0034 made the gate's per-step timings visible. The first measured run, at
+eleven minutes:
+
+```text
+<== [11] bun run build 59s exit 0
+<== [12] bun run build:determinism 116s exit 0
+```
+
+`build:determinism` builds twice and compares four digests. Those two builds are
+the property being checked — building once and trusting it is not a cheaper
+check, it is no check — so its 116 seconds are the price of the answer. (That
+116 is one sample of a number this machine also produced as 133, 151 and 207;
+see the Consequences.)
+
+The 59 seconds above it buy nothing. Step 11 built the same artifacts from the
+same source; step 12 overwrote them with two more builds before anything read
+them. The steps in between run `bun run dev`, from source. The steps that
+execute `dist/` come after, and they execute what step 12 left — which the check
+had just proved is byte-identical to what step 11 produced. The gate was
+building three times to learn what two builds say.
+
+## Decision
+
+**`bun run build` leaves the roster.** The remaining steps are unchanged in
+content and order, each still blocks, and a contract test now pins the ordering
+that the removal makes load-bearing: a step executing `dist/` must come after a
+step that builds it. The roster is a literal list, and a literal list is exactly
+what can be rearranged without anyone noticing.
+
+**A build that fails inside the determinism check reports itself.** That check
+ran its builds with `.quiet()` and let `$` throw, which carried the exit status
+and dropped the build's diagnostics. The removed step was, incidentally, what
+made a broken build readable. Removing it without this would have traded a
+minute of wall-clock for an unreadable failure, and the message names which of
+the two builds failed — a second build failing after the first succeeded is a
+much stranger event than an ordinary broken build and should not be reported in
+the same words.
+
+**The decisions move to `scripts/lib/build-determinism.ts`.** Comparing digests
+and composing the failure message are pure, and separating them from the two
+builds is what lets them be tested without spending two minutes. One of them was
+worth testing on its own account: a missing digest now counts as drift, where
+`undefined === undefined` would have read a build that produced nothing as
+reproducible.
+
+## Consequences
+
+**The gate performs two builds per run instead of three.** That is the change,
+stated the way it can be checked. Nothing else in the roster moved.
+
+**How much wall-clock this saves is not something this machine can measure**,
+and the first attempt to claim it was wrong. Comparing the two whole-gate runs
+either side of the change said the gate got *slower*: `build:determinism` went
+from 116s to 207s while the removed step's 59s went away. Measuring the pieces
+directly said the opposite — 151s for `build:determinism` alone against 196s for
+a build plus `build:determinism`, which is one build's worth of saving, as
+expected.
+
+Both readings are from the same machine on the same source. Identical builds
+measured 63s, 94s and 104s; `build:determinism` measured 116s, 133s, 151s and
+207s. The spread is larger than the effect, so *any* number attached to this
+change here is noise with a decimal point, and the honest claim is the
+structural one: one build fewer.
+
+That the direction was measurable at all only in the direct comparison is worth
+remembering — the whole-gate comparison put a 91-second swing on one step and a
+confident wrong sign on the conclusion. GATE-002 and GATE-003 are the same
+lesson about assertions; this is it about a claim in a decision record.
+
+The saving is expected to be larger and steadier in CI, where every runner
+starts cold and no earlier build has warmed anything. That is an inference from
+the cold measurement above, not a measurement of CI, and it is written here as
+one.
+
+The measurement is the point, not the minute. This step had been running for
+every verification since the roster was written, and it took making the timings
+visible for one run to see it. Other steps in the list are now measured too, and
+the same question can be asked of them — with the caution that this machine
+answers a repeated question three different ways.
+
+`bun run build:determinism` remains runnable on its own from a checkout with no
+`dist/`, which is what makes it a usable pre-release check as well as a gate
+step.
+
+**Falsified if:** a step is added between `build:determinism` and the steps that
+execute `dist/` which rebuilds, deletes, or modifies those artifacts. Then what
+the later steps execute is no longer what the determinism check proved
+reproducible, and the roster in `Makefile` needs its own build back — or that
+step needs to come before it.

--- a/scripts/check-build-determinism.ts
+++ b/scripts/check-build-determinism.ts
@@ -13,8 +13,17 @@
 //
 // Not part of `bun test` — it builds twice, which takes far too long for the
 // default suite. Run it in CI, or by hand before a release.
+//
+// Since DBCLI-032 this is also the `make verify` roster's only build. The
+// separate `bun run build` step before it produced artifacts that these two
+// builds overwrote before anything read them, and this check proves the two are
+// byte-identical to what it produced — so the roster was building three times to
+// learn what two builds say. What that step did provide was a readable failure,
+// because the builds here ran with their output discarded; that is why a failing
+// build now reports itself. The decisions live in `lib/build-determinism.ts`.
 
 import { $ } from 'bun'
+import { buildFailureMessage, driftedArtifacts } from './lib/build-determinism'
 
 const ARTIFACTS = [
   'dist/cli.mjs',
@@ -32,7 +41,21 @@ async function digest(path: string): Promise<string> {
 
 async function buildAndDigest(label: string): Promise<Map<string, string>> {
   console.log(`building (${label})...`)
-  await $`bun run build`.quiet()
+
+  // `.nothrow()` and an explicit report, rather than letting `$` throw: the
+  // throw carried the exit status and dropped the build's own diagnostics,
+  // which is the one thing a reader of a failed build needs.
+  const built = await $`bun run build`.nothrow().quiet()
+  if (built.exitCode !== 0) {
+    console.error(
+      buildFailureMessage(
+        label,
+        built.exitCode,
+        `${built.stdout.toString()}${built.stderr.toString()}`
+      )
+    )
+    process.exit(built.exitCode)
+  }
 
   const digests = new Map<string, string>()
   for (const artifact of ARTIFACTS) {
@@ -44,7 +67,7 @@ async function buildAndDigest(label: string): Promise<Map<string, string>> {
 const first = await buildAndDigest('first')
 const second = await buildAndDigest('second')
 
-const drifted = ARTIFACTS.filter((artifact) => first.get(artifact) !== second.get(artifact))
+const drifted = driftedArtifacts(ARTIFACTS, first, second)
 
 for (const artifact of ARTIFACTS) {
   const stable = !drifted.includes(artifact)

--- a/scripts/lib/build-determinism.ts
+++ b/scripts/lib/build-determinism.ts
@@ -1,0 +1,51 @@
+// The build determinism check's decisions, with the two builds left out.
+//
+// The check spends about two minutes building; what it decides afterwards is
+// pure and lives here so that it can be asserted without spending that. Nothing
+// in this file imports anything, for the same reason the handoff rules do not:
+// what it does is then a property of the file rather than a promise about it.
+//
+// Why the failure message is this file's business at all: DBCLI-032 removed the
+// separate `bun run build` step from the `make verify` roster, because
+// `build:determinism` rebuilds the same artifacts twice and overwrites its
+// output before anything reads it. That step was also, incidentally, the one
+// that made a broken build readable — this check ran its builds with their
+// output discarded. Removing it without this would have traded a minute of gate
+// time for an unreadable failure.
+
+/**
+ * The artifacts whose digests differ between two builds of identical source.
+ *
+ * A digest that is missing counts as drift. `undefined === undefined` is the
+ * shape that turns a build which produced nothing at all into a passing
+ * reproducibility check, which is the one answer this must never give.
+ */
+export function driftedArtifacts(
+  artifacts: readonly string[],
+  first: ReadonlyMap<string, string>,
+  second: ReadonlyMap<string, string>
+): string[] {
+  return artifacts.filter((artifact) => {
+    const before = first.get(artifact)
+    const after = second.get(artifact)
+    return before === undefined || after === undefined || before !== after
+  })
+}
+
+/**
+ * What to print when one of the two builds fails.
+ *
+ * Which build matters: a first build that fails is an ordinary broken build,
+ * and a second that fails after the first succeeded is a far stranger thing and
+ * should not be reported in the same words.
+ */
+export function buildFailureMessage(label: string, exitCode: number, output: string): string {
+  const text = output.trim()
+  const body = text.length > 0 ? text : '(the build produced no output)'
+
+  return [
+    `✗ the ${label} build failed with exit ${exitCode}, so reproducibility was not checked.`,
+    '',
+    body,
+  ].join('\n')
+}

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -1050,12 +1050,13 @@ workflow:
     - DBCLI-029
     - DBCLI-030
     - DBCLI-031
+    - DBCLI-032
   status: done
 
 baseline:
   repository: CarlLee1983/dbcli
   branch: main
-  commit: bbcdd4540028823a2098084dccf5d07544ea09a2
+  commit: 1b22b47c3c6cc982091db8471549ca4736abad2c
   dirty_worktree: false
   story_owned_paths:
     - specs/stories/DBCLI-028-delivery-is-not-authorization/story.md

--- a/specs/stories/DBCLI-032-one-build-fewer/acceptance.md
+++ b/specs/stories/DBCLI-032-one-build-fewer/acceptance.md
@@ -1,0 +1,63 @@
+# Acceptance Criteria
+
+## Happy Path
+
+* [ ] AC-001: `make verify` builds the artifacts twice, not three times, and
+      passes.
+* [ ] AC-002: The per-step log shows two builds where it showed three. No
+      wall-clock claim is made: this machine measured identical builds at 63s,
+      94s and 104s, a spread wider than one build's saving.
+
+## Business Rules
+
+* [ ] AC-003: `bun run build` is no longer in the roster, and every step that
+      executes `dist/` still runs after the step that produces it.
+* [ ] AC-004: `bun run build:determinism` still builds twice, digests four
+      artifacts, and fails when they differ.
+* [ ] AC-005: `bun run build:determinism` runs on its own from a checkout with
+      no `dist/`.
+
+## Failure Cases
+
+* [ ] AC-006: A build that fails inside the determinism check names which of the
+      two builds failed and prints the build's own output.
+* [ ] AC-007: A roster that executes `dist/` before building it fails the
+      contract test.
+
+## Regression Requirements
+
+* [ ] AC-008: `src/` is unchanged.
+* [ ] AC-009: `bun run forgeflow:check` and `bun run forgeflow:contract` pass,
+      with `PREDATING_FINDINGS` still empty.
+* [ ] AC-010: The complete repository verification gate passes.
+
+## Acceptance Evidence
+
+| AC | Method | Evidence | Fixture / precondition | Expected observation |
+| --- | --- | --- | --- | --- |
+| `AC-001` | command | `make verify` | `repository checkout` | `two building lines, exit 0` |
+| `AC-002` | command | `make verify` | `repository checkout` | `no bun run build step in the log, two building lines inside build:determinism` |
+| `AC-003` | test | `tests/contract/forgepilot-boundary.test.ts` | `the pinned roster` | `build absent, dist steps after build:determinism` |
+| `AC-004` | test | `tests/unit/scripts/build-determinism.test.ts` | `two digest sets that differ` | `the drifted artifact is reported` |
+| `AC-005` | command | `rm -rf dist && bun run build:determinism` | `a checkout with no dist` | `exit 0` |
+| `AC-006` | test | `tests/unit/scripts/build-determinism.test.ts` | `a failing build's label, status and output` | `the message names the build and carries its output` |
+| `AC-007` | test | `tests/contract/forgepilot-boundary.test.ts` | `a roster with a dist step before the build` | `the assertion fails` |
+| `AC-008` | command | `git diff --stat 1b22b47c -- src` | `repository checkout` | `empty output` |
+| `AC-009` | command | `bun run forgeflow:check` | `this branch` | `reconciliation passed` |
+| `AC-010` | command | `make verify` | `repository checkout` | `exit 0` |
+
+## Verification Notes
+
+```sh
+bun test tests/contract/forgepilot-boundary.test.ts tests/unit/scripts/build-determinism.test.ts
+rm -rf dist && bun run build:determinism
+make verify
+```
+
+What human review should weigh is the removal itself. The roster's own comment
+says a step may be added deliberately but removing one has to be argued for. The
+argument is that the step's output is overwritten by the next step before
+anything reads it, and that the next step proves the two are byte-identical —
+so the check that step 11 performed is performed again, twice, immediately
+after. If that reading is wrong, the gate loses a check for a minute of
+wall-clock, which is the trade this repository should refuse.

--- a/specs/stories/DBCLI-032-one-build-fewer/story.md
+++ b/specs/stories/DBCLI-032-one-build-fewer/story.md
@@ -1,0 +1,138 @@
+# Story: DBCLI-032 One Build Fewer
+
+## Goal
+
+`make verify` builds the artifacts twice instead of three times, and a build
+that fails inside the determinism check says why.
+
+## Context
+
+DBCLI-031 made the gate's per-step timings visible for the first time. The
+measurement it produced, on an eleven-minute run:
+
+```text
+<== [11] bun run build 59s exit 0
+<== [12] bun run build:determinism 116s exit 0
+```
+
+`build:determinism` builds twice and compares the digests — that is the check,
+and its 116 seconds are the price of the property. The 59 seconds above it are
+not. Step 11 builds the same artifacts from the same source, and step 12
+overwrites them with two more builds before anything reads them: the steps
+between are `bun run dev`, which runs from source. The steps that do read
+`dist/` come after, and they read what step 12 left — which the check itself has
+just proved is byte-identical to what step 11 produced.
+
+So the roster contains one build whose only output is the wall-clock it spent.
+Removing it is the kind of change the roster's own comment says must be argued
+for rather than assumed, which is why this Story exists instead of a commit.
+
+One thing the redundant step was quietly providing: a build failure with its
+output on screen. `check-build-determinism.ts` runs `bun run build` with
+`.quiet()`, so a broken build inside it throws with its diagnostics discarded.
+Removing step 11 without fixing that trades a minute of gate time for an
+unreadable failure, which is not a trade worth making.
+
+## Classification
+
+* Security sensitive: no
+* Baseline conformance: yes
+* Task mode: mixed
+
+## Authority
+
+* plan: yes
+* modify: yes
+* add_dependency: no
+* migration: no
+* commit: yes
+* push: yes
+* deploy: no
+
+## Architecture
+
+* Impact: medium
+* Decision: `ADR-0035`
+* Boundary: `VerificationAttestation`
+* Contract: `every step in the roster produces something a later step or a human reads`
+* Owner: `VerificationAttestation = repository-governance`
+
+## Risk
+
+* Level: medium
+* Reason: `verification-harness`
+
+A step is being removed from the repository's verification contract. The roster
+exists so that this cannot happen by accident, and the argument has to survive
+review rather than the diff being small.
+
+## Scope
+
+### In Scope
+
+* `Makefile`: `bun run build` removed from the `verify` roster.
+* `tests/contract/forgepilot-boundary.test.ts`: `REQUIRED_STEPS` loses that
+  entry and gains an assertion that the roster still builds — the artifacts the
+  later steps execute must be produced by a step, and `build:determinism` is now
+  the only step that produces them.
+* `scripts/check-build-determinism.ts`: a failing build reports its own output
+  and which of the two builds failed, instead of throwing with the diagnostics
+  discarded.
+* ADR-0035.
+
+### Out of Scope
+
+* Making `build:determinism` faster. Its two builds are the property being
+  checked; building once and trusting it is not a cheaper check, it is no check.
+* Building the two artifacts sets concurrently. They write the same output
+  directory, and separating them to make them parallel is a design change to buy
+  seconds this Story is not spending.
+* Any other step in the roster.
+* Any change to `src/`, and any release.
+
+## Inputs
+
+* `Makefile`, `tests/contract/forgepilot-boundary.test.ts`,
+  `scripts/check-build-determinism.ts`.
+* The per-step timings from DBCLI-031's first run.
+
+## Outputs
+
+* A gate that builds twice per run instead of three times, with the same checks.
+* A determinism check whose build failures are readable.
+
+## Rules
+
+* R1: The roster no longer contains `bun run build`, and every step that reads
+  `dist/` still runs after a step that produced it.
+* R2: A build that fails inside `build:determinism` reports which build failed
+  and prints the build's own output.
+* R3: The determinism property is unchanged: two builds of identical source,
+  four artifacts, digests compared, a difference fails.
+* R4: The roster is otherwise unchanged in content and order, and every step
+  still blocks.
+* R5: No change to `src/`.
+
+## Expected Errors
+
+* A failing build inside the determinism check exits non-zero with its output
+  shown and the failing build named.
+* A step reading `dist/` placed before the step that builds fails the contract
+  test.
+
+## Dependencies
+
+* ADR-0035 — the decision and its falsification condition.
+* ADR-0034 — the per-step timings this Story is acting on.
+
+## Constraints
+
+* `bun run build:determinism` must stay runnable on its own, from a checkout
+  with no `dist/`.
+
+## Superseded Behavior
+
+* `tests/contract/forgepilot-boundary.test.ts` — `REQUIRED_STEPS` pins
+  `bun run build` as a required step. That is the entry being argued away, and
+  the roster's comment requires the argument to be recorded rather than the list
+  edited quietly.

--- a/tests/contract/forgepilot-boundary.test.ts
+++ b/tests/contract/forgepilot-boundary.test.ts
@@ -39,7 +39,6 @@ const REQUIRED_STEPS = [
   'bun run typecheck:tests',
   'bun run lint',
   'SKIP_INTEGRATION_TESTS=false REQUIRE_INTEGRATION_SERVICES=true bun run test',
-  'bun run build',
   'bun run build:determinism',
   'bun run dev -- --help',
   'bun run dev -- --version',
@@ -202,6 +201,21 @@ describe('make verify runs from a clean checkout', () => {
     const recipeText = makefile.slice(makefile.indexOf('verify:'))
 
     expect(recipeText).not.toContain('pipefail')
+  })
+
+  test('builds the artifacts before any step executes them', async () => {
+    // DBCLI-032 removed the roster's separate `bun run build`: `build:determinism`
+    // rebuilds the same artifacts twice and overwrote it before anything read
+    // it, and the check itself proves the two are byte-identical. What has to
+    // hold after that removal is the ordering, not the step — the roster is a
+    // literal list, and a literal list is exactly the thing that can be
+    // rearranged without anyone noticing.
+    const { steps } = await verifyRecipe()
+    const builds = steps.findIndex((step) => step.includes('build'))
+    const executes = steps.findIndex((step) => step.startsWith('./dist/'))
+
+    expect(builds).toBeGreaterThanOrEqual(0)
+    expect(executes).toBeGreaterThan(builds)
   })
 
   test('keeps every step it had before, in the same order', async () => {

--- a/tests/unit/scripts/build-determinism.test.ts
+++ b/tests/unit/scripts/build-determinism.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The determinism check's two decisions, taken away from its two builds.
+ *
+ * The check itself spends two minutes building; these are the parts that decide
+ * what to say afterwards, and they are pure so that they can be asserted without
+ * spending it. DBCLI-032 removed the roster's separate `bun run build` step,
+ * which is what used to make a broken build readable — so the message a failing
+ * build produces is now this check's own responsibility and has a test.
+ */
+import { describe, expect, test } from 'bun:test'
+import { buildFailureMessage, driftedArtifacts } from '../../../scripts/lib/build-determinism'
+
+describe('driftedArtifacts', () => {
+  const artifacts = ['dist/cli.mjs', 'dist/core.mjs'] as const
+
+  test('identical digests drift nowhere', () => {
+    const digests = new Map([
+      ['dist/cli.mjs', 'aaa'],
+      ['dist/core.mjs', 'bbb'],
+    ])
+
+    expect(driftedArtifacts(artifacts, digests, new Map(digests))).toEqual([])
+  })
+
+  test('an artifact whose second build differs is named', () => {
+    const first = new Map([
+      ['dist/cli.mjs', 'aaa'],
+      ['dist/core.mjs', 'bbb'],
+    ])
+    const second = new Map([
+      ['dist/cli.mjs', 'aaa'],
+      ['dist/core.mjs', 'ccc'],
+    ])
+
+    expect(driftedArtifacts(artifacts, first, second)).toEqual(['dist/core.mjs'])
+  })
+
+  test('a digest that is missing counts as drift, not as agreement', () => {
+    // `undefined === undefined` is the shape that turns a build which produced
+    // nothing into a passing reproducibility check.
+    const first = new Map([['dist/cli.mjs', 'aaa']])
+
+    expect(driftedArtifacts(artifacts, first, first)).toEqual(['dist/core.mjs'])
+  })
+})
+
+describe('buildFailureMessage', () => {
+  test('names which build failed and carries the build output', () => {
+    const message = buildFailureMessage('second', 1, 'error: Could not resolve "./missing"')
+
+    expect(message).toContain('second')
+    expect(message).toContain('exit 1')
+    expect(message).toContain('Could not resolve')
+  })
+
+  test('a build that failed silently says so rather than printing nothing', () => {
+    // A failure whose message is empty reads as a tool that did not run. The
+    // separate `bun run build` step used to make this legible; it is gone.
+    const message = buildFailureMessage('first', 137, '   \n')
+
+    expect(message).toContain('first')
+    expect(message).toContain('exit 137')
+    expect(message).toMatch(/no output/i)
+  })
+})


### PR DESCRIPTION
## 為什麼

DBCLI-031 第一次把每一步的秒數印出來，量到的是：

```
<== [11] bun run build 59s exit 0
<== [12] bun run build:determinism 116s exit 0
```

`build:determinism` 的兩次 build 是那個性質的價錢——build 一次然後相信它，不是比較便宜的檢查，是沒有檢查。上面那一步不買任何東西：step 11 用同一份原始碼 build 出同一批 artifact，step 12 在任何東西讀到它之前用兩次 build 覆蓋掉；中間那幾步跑的是 `bun run dev`，讀原始碼。真正執行 `dist/` 的步驟在後面，而它們執行的是 step 12 留下的東西——**那個 check 自己剛剛才證明它與 step 11 的產物位元相同**。gate 一直在 build 三次，去知道兩次 build 就會說的事。

roster 的註解說：加一步可以是刻意的，拿掉一步必須被論證。ADR-0035 就是那份論證。

## 宣稱的是「少 build 一次」，不是任何秒數

第一版的 PR 說「短了約一分鐘、9%」。**那個宣稱是錯的，已經改掉。**

- 拿改動前後兩輪完整 gate 相比：gate 看起來變**慢**了（`build:determinism` 116s → 207s，而移除的 59s 消失）。
- 直接量各部分：單獨的 `build:determinism` 151s，對上 build（63s）加 `build:determinism`（133s）的 196s——剛好是一次 build 的差。

同一台機器、同一份原始碼：build 量到 63、94、104 秒，`build:determinism` 量到 116、133、141、151、207 秒。**散佈比效果還大**，所以任何掛在這個改動上的秒數都是帶小數點的雜訊。能講、也查得到的只有結構那句：**gate 每輪 build 兩次而不是三次**（log 從 24 步變 23 步）。

CI 上省得更多是推論——每個 runner 都從冷開始，沒有前一次 build 暖過任何東西——ADR 裡標成推論，不是量測。

## 一起處理的副作用

`check-build-determinism.ts` 用 `.quiet()` 跑 build 並讓 `$` 直接 throw，帶走 exit code、丟掉 build 自己的診斷。被拿掉的那一步剛好就是「build 壞掉時看得懂」的來源，所以失敗現在會**指名是第一次還是第二次 build 失敗**並印出它的輸出——第二次在第一次成功之後失敗，是遠比一般 build 壞掉更奇怪的事，不該用同一句話報告。

判斷邏輯搬到 `scripts/lib/build-determinism.ts`，離開那兩次 build 才測得動。其中一條本來就值得單獨測：**摘要缺席現在算 drift**，而 `undefined === undefined` 會把「什麼都沒 build 出來」讀成可重現。

contract test 補上一條因為這次移除才變成承重的斷言：執行 `dist/` 的步驟必須排在會 build 的步驟後面。roster 是一份字面清單，而字面清單正是那種被重新排序也沒人會發現的東西。

## 驗證

| 檢查 | 結果 |
| --- | --- |
| `make verify` | PASS at `7e1bbcbde2b311e19fab7f39b358bd20b1eaa018`（sha256:`78245a4d…`），23 步 |
| `rm -rf dist && bun run build:determinism` | exit 0，仍可獨立執行 |
| `bun test`（contract + 新的 build-determinism unit） | 全綠 |
| `bun run forgeflow:check` | 通過，40 completed Stories |
| `bun run forgeflow:contract` | 通過（`cb4bc976`），40 Stories、0 admitted findings |

`PREDATING_FINDINGS` 仍為空集合，`src/` 零變更，不需新 tag。

https://claude.ai/code/session_019BfLoPoRxgqv3pcC9h3Kqn